### PR TITLE
feat: explain command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 wdl = { version = "0.3.0", features = ["ast", "core", "grammar"] }
 walkdir = "2.4.0"
+colored = "2.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ nonempty = "0.9.0"
 pest = { version = "2.7.5", features = ["pretty-print"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
-wdl = { version = "0.2.0", features = ["ast", "core", "grammar"] }
+wdl = { version = "0.3.0", features = ["ast", "core", "grammar"] }
 walkdir = "2.4.0"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@
 
 ## 🎨 Features
 
-* **`sprocket lint`.** Lint Workflow Description Language files.
+* **`sprocket lint`** Lint Workflow Description Language files.
+* **`sprocket explain`** Explain lint warnings.
 
 ## Guiding Principles
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 ## 🎨 Features
 
 * **`sprocket lint`** Lint Workflow Description Language files.
-* **`sprocket explain`** Explain lint warnings.
+* **`sprocket explain`** Explain lint rules.
 
 ## Guiding Principles
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,1 +1,2 @@
+pub mod explain;
 pub mod lint;

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -8,9 +8,9 @@ use wdl::grammar::v1::lint as grammar_lint;
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 pub struct Args {
-    /// The rule name or code to explain.
+    /// The name or code of the rule to explain.
     #[arg(required = true)]
-    pub rule_name_or_code: String,
+    pub rule_identifier: String,
 }
 
 /// TODO IDK how to get this fn signature to work with both ast_lint and
@@ -23,7 +23,7 @@ pub fn pretty_print_rule<E>(rule: &dyn Rule<E>) {
 }
 
 pub fn explain(args: Args) -> anyhow::Result<()> {
-    let ident = args.rule_name_or_code;
+    let ident = args.rule_identifier;
 
     let rule = grammar_lint::rules()
         .into_iter()

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -1,0 +1,45 @@
+use clap::Parser;
+use wdl::ast::v1::lint as ast_lint;
+use wdl::grammar::v1::lint as grammar_lint;
+
+/// Arguments for the `explain` subcommand.
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+pub struct Args {
+    /// The rule name to explain.
+    #[arg(required = true)]
+    pub rule_name: String,
+}
+
+pub fn explain(args: Args) -> anyhow::Result<()> {
+    let name = args.rule_name;
+
+    let rules = grammar_lint::rules()
+        .iter()
+        .map(|rule| rule.name())
+        .chain(ast_lint::rules().iter().map(|rule| rule.name()))
+        .collect::<Vec<String>>();
+
+    if !rules.contains(&name) {
+        return Err(anyhow::anyhow!("Unknown rule: {}", name));
+    }
+
+    let rule = grammar_lint::rules()
+        .into_iter()
+        .find(|rule| rule.name() == name);
+
+    match rule {
+        Some(rule) => {
+            println!("{}", rule.body());
+        }
+        None => {
+            let rule = ast_lint::rules()
+                .into_iter()
+                .find(|rule| rule.name() == name)
+                .unwrap();
+            println!("{}", rule.body());
+        }
+    }
+
+    Ok(())
+}

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -13,8 +13,6 @@ pub struct Args {
     pub rule_identifier: String,
 }
 
-/// TODO IDK how to get this fn signature to work with both ast_lint and
-/// grammar_lint
 pub fn pretty_print_rule<E>(rule: &dyn Rule<E>) {
     println!("{}", rule.name().bold().underline());
     println!("{}", format!("{}::{}", rule.code(), rule.tags(),).yellow());
@@ -31,11 +29,7 @@ pub fn explain(args: Args) -> anyhow::Result<()> {
 
     match rule {
         Some(rule) => {
-            // pretty_print_rule(&rule);
-            println!("{}", rule.name().bold().underline());
-            println!("{}", format!("{}::{}", rule.code(), rule.tags(),).yellow());
-            println!();
-            println!("{}", rule.body());
+            pretty_print_rule(&*rule);
         }
         None => {
             let rule = ast_lint::rules()
@@ -44,11 +38,7 @@ pub fn explain(args: Args) -> anyhow::Result<()> {
 
             match rule {
                 Some(rule) => {
-                    // pretty_print_rule(&rule);
-                    println!("{}", rule.name().bold().underline());
-                    println!("{}", format!("{}::{}", rule.code(), rule.tags(),).yellow());
-                    println!();
-                    println!("{}", rule.body());
+                    pretty_print_rule(&*rule);
                 }
                 None => {
                     anyhow::bail!("No rule found with the identifier '{}'", ident);

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use colored::Colorize;
 use wdl::ast::v1::lint as ast_lint;
 use wdl::core::concern::lint::Rule;
 use wdl::grammar::v1::lint as grammar_lint;
@@ -7,55 +8,50 @@ use wdl::grammar::v1::lint as grammar_lint;
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
 pub struct Args {
-    /// The rule name to explain.
+    /// The rule name or code to explain.
     #[arg(required = true)]
-    pub rule_name: String,
+    pub rule_name_or_code: String,
 }
 
 /// TODO IDK how to get this fn signature to work with both ast_lint and
 /// grammar_lint
 pub fn pretty_print_rule<E>(rule: &dyn Rule<E>) {
-    println!("{}", rule.name());
-    println!(
-        "{}::{}",
-        rule.code(),
-        rule.tags(),
-        // rule.level(), // TODO: Add level() to Rule trait
-    );
+    println!("{}", rule.name().bold().underline());
+    println!("{}", format!("{}::{}", rule.code(), rule.tags(),).yellow());
     println!();
     println!("{}", rule.body());
 }
 
 pub fn explain(args: Args) -> anyhow::Result<()> {
-    let name = args.rule_name;
+    let ident = args.rule_name_or_code;
 
     let rule = grammar_lint::rules()
         .into_iter()
-        .find(|rule| rule.name() == name);
+        .find(|rule| rule.name() == ident || rule.code().to_string() == ident);
 
     match rule {
         Some(rule) => {
             // pretty_print_rule(&rule);
-            println!("{}", rule.name());
-            println!("{}::{}", rule.code(), rule.tags(),);
+            println!("{}", rule.name().bold().underline());
+            println!("{}", format!("{}::{}", rule.code(), rule.tags(),).yellow());
             println!();
             println!("{}", rule.body());
         }
         None => {
             let rule = ast_lint::rules()
                 .into_iter()
-                .find(|rule| rule.name() == name);
+                .find(|rule| rule.name() == ident || rule.code().to_string() == ident);
 
             match rule {
                 Some(rule) => {
                     // pretty_print_rule(&rule);
-                    println!("{}", rule.name());
-                    println!("{}::{}", rule.code(), rule.tags(),);
+                    println!("{}", rule.name().bold().underline());
+                    println!("{}", format!("{}::{}", rule.code(), rule.tags(),).yellow());
                     println!();
                     println!("{}", rule.body());
                 }
                 None => {
-                    anyhow::bail!("No rule found with the name '{}'", name);
+                    anyhow::bail!("No rule found with the identifier '{}'", ident);
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,9 @@ git_testament!(TESTAMENT);
 enum Commands {
     /// Lints Workflow Description Language files.
     Lint(commands::lint::Args),
+
+    /// Explains a lint warning.
+    Explain(commands::explain::Args),
 }
 
 #[derive(Parser)]
@@ -51,6 +54,7 @@ pub fn inner() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Lint(args) => commands::lint::lint(args),
+        Commands::Explain(args) => commands::explain::explain(args),
     }
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -42,9 +42,9 @@ impl<'a> Reporter<'a> {
             Concern::LintWarning(warning) => {
                 let mut diagnostic = Diagnostic::warning()
                     .with_code(format!(
-                        "{}::{}/{:?}",
+                        "{}::{}::{:?}",
                         warning.code(),
-                        warning.group(),
+                        warning.tags(),
                         warning.level()
                     ))
                     .with_message(warning.subject());
@@ -56,7 +56,7 @@ impl<'a> Reporter<'a> {
                     let byte_range = location.byte_range().unwrap();
 
                     diagnostic = diagnostic.with_labels(vec![
-                        Label::primary(handle, byte_range).with_message(warning.body()),
+                        Label::primary(handle, byte_range).with_message(warning.subject()),
                     ]);
                 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -60,9 +60,16 @@ impl<'a> Reporter<'a> {
                     ]);
                 }
 
-                if let Some(fix) = warning.fix() {
-                    diagnostic = diagnostic.with_notes(vec![format!("fix: {}", fix)]);
-                }
+                let mut notes = match warning.fix() {
+                    Some(fix) => vec![format!("fix: {}", fix)],
+                    None => vec![],
+                };
+                notes.extend(vec![format!(
+                    "see `sprocket explain {}` for more information",
+                    warning.code()
+                )]);
+
+                diagnostic = diagnostic.with_notes(notes);
 
                 diagnostic
             }


### PR DESCRIPTION
All the functionality changes here are quite straightforward. I added a new dependency, `colored`, in order to get some "prettier" explain output. Maybe there's more we can do in that direction?