### PR TITLE
fix: delay showing the progress bar.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Implemented the `check` command as a full static analysis ([#17](https://github.com/stjude-rust-labs/sprocket/pull/17)).
 
+### Fixed
+
+* Fixed the progress bar from showing up for short analysis jobs; it now is
+  delayed by two seconds ([#19](https://github.com/stjude-rust-labs/sprocket/pull/19)).
+
 ## 0.6.0 - 08-22-2024
 
 ### Added


### PR DESCRIPTION
This commit delays showing the progress bar until two seconds of analysis have passed.

For small analysis jobs, like single files, this will prevent a progress bar from showing and then immediately completing.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
