### PR TITLE
feat: add the `sprocket format` command.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Publish to crates.io
       run: cargo publish
       env:
-        CRATES_IO_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
     - name: Create a GH release
       uses: softprops/action-gh-release@v2
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added the `format` subcommand to sprocket ([#24](https://github.com/stjude-rust-labs/sprocket/pull/24)).
+* Added the analysis rules to `sprocket explain` ([#24](https://github.com/stjude-rust-labs/sprocket/pull/24)).
+
 ## 0.7.0 - 09-16-2024
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,7 +80,7 @@ checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -97,7 +97,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -201,7 +201,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.1",
 ]
 
 [[package]]
@@ -213,7 +213,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -316,6 +316,41 @@ name = "crossbeam-utils"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.10.0",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "dashmap"
@@ -474,7 +509,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -542,7 +577,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
  "time",
 ]
 
@@ -703,6 +738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -756,6 +797,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -837,7 +887,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -860,6 +910,18 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "macropol"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a037b9563fd07a0cf51e56bc79151a4c29a9a2f08e7006afcb79cf3e8653709"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -984,7 +1046,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1033,6 +1095,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path-clean"
@@ -1086,7 +1154,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1308,6 +1376,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,7 +1451,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1400,7 +1474,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1494,15 +1568,54 @@ dependencies = [
 
 [[package]]
 name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.77",
+]
 
 [[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1590,7 +1703,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1675,7 +1788,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1764,7 +1877,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1792,7 +1905,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1973,7 +2086,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
@@ -2007,7 +2120,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2020,13 +2133,13 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wdl"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32e631974edc83bf2011419bc65328571de3c32672d78a9ac5beb242661f52d"
+version = "0.9.0"
+source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
 dependencies = [
  "codespan-reporting",
  "wdl-analysis",
  "wdl-ast",
+ "wdl-format",
  "wdl-grammar",
  "wdl-lint",
  "wdl-lsp",
@@ -2034,11 +2147,11 @@ dependencies = [
 
 [[package]]
 name = "wdl-analysis"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af53090203ea16dabdb3130f65c34a4008be1f9717cbfb402430aea5897c1cff"
+version = "0.4.0"
+source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
 dependencies = [
  "anyhow",
+ "convert_case",
  "futures",
  "id-arena",
  "indexmap",
@@ -2059,10 +2172,11 @@ dependencies = [
 
 [[package]]
 name = "wdl-ast"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba65907547bc784a0fdddf4d46c9d899ef875060accbc34cf6e8de958d6547b"
+version = "0.8.0"
+source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
 dependencies = [
+ "macropol",
+ "paste",
  "rowan",
  "url",
  "urlencoding",
@@ -2070,21 +2184,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "wdl-format"
+version = "0.2.0"
+source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
+dependencies = [
+ "nonempty",
+ "wdl-ast",
+]
+
+[[package]]
 name = "wdl-grammar"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aded7e39c201e4128115aa4121ea7b25b7b4606ab918c94235fb8a87026e4f6"
+version = "0.9.0"
+source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
 dependencies = [
  "codespan-reporting",
+ "itertools",
  "logos",
  "rowan",
+ "strum",
 ]
 
 [[package]]
 name = "wdl-lint"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063fd5979661d3698abf7e745ee2651da298ef23aa0c2767bd44eee23ae02dfa"
+version = "0.7.0"
+source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
 dependencies = [
  "convert_case",
  "indexmap",
@@ -2094,9 +2217,8 @@ dependencies = [
 
 [[package]]
 name = "wdl-lsp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20378cdbea9f27f3c9036adde2370153580d39a1c69d4f1b87042b3e35c4f5e0"
+version = "0.4.0"
+source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
 dependencies = [
  "anyhow",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -74,13 +74,13 @@ checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -97,14 +97,14 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
@@ -153,15 +153,15 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cc"
-version = "1.1.19"
+version = "1.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d74707dde2ba56f86ae90effb3b43ddd369504387e718014de010cec7959800"
+checksum = "b16803a61b81d9eabb7eae2588776c4c1e584b738ede45fdbb4c972cec1e9945"
 dependencies = [
  "shlex",
 ]
@@ -174,9 +174,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -184,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "clap-verbosity-flag"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d19864d6b68464c59f7162c9914a0b569ddc2926b4a2d71afe62a9738eff53"
+checksum = "e099138e1807662ff75e2cebe4ae2287add879245574489f9b1588eb5e5564ed"
 dependencies = [
  "clap",
  "log",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -206,14 +206,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -359,7 +359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -480,15 +480,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -497,38 +497,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git-testament"
@@ -577,7 +577,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "time",
 ]
 
@@ -605,6 +605,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -654,15 +660,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "hyper"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -713,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -726,7 +732,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
@@ -755,12 +760,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -788,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -815,9 +820,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
+checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -830,9 +835,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "line-index"
@@ -868,18 +873,18 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "logos"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1ceb190eb9bdeecdd8f1ad6a71d6d632a50905948771718741b5461fb01e13"
+checksum = "1c6b6e02facda28ca5fb8dbe4b152496ba3b1bd5a4b40bb2b1b2d8ad74e0f39b"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
 name = "logos-codegen"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90be66cb7bd40cb5cc2e9cfaf2d1133b04a3d93b72344267715010a466e0915a"
+checksum = "b32eb6b5f26efacd015b000bfc562186472cd9b34bdba3f6b264e2a052676d10"
 dependencies = [
  "beef",
  "fnv",
@@ -887,14 +892,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "logos-derive"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45154231e8e96586b39494029e58f12f8ffcb5ecf80333a603a13aa205ea8cbd"
+checksum = "3e5d0c5463c911ef55624739fc353238b4e310f0144be1f875dc42fec6bfd5ec"
 dependencies = [
  "logos-codegen",
 ]
@@ -1010,24 +1015,24 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl"
-version = "0.10.66"
+version = "0.10.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
+checksum = "7b8cefcf97f41316955f9294cd61f639bdcfa9f2f230faac6cb896aa8ab64704"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
@@ -1046,7 +1051,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1057,9 +1062,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.103"
+version = "0.9.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
 dependencies = [
  "cc",
  "libc",
@@ -1116,9 +1121,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
  "serde",
@@ -1139,22 +1144,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
+checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
+checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1171,15 +1176,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "portable-atomic"
-version = "1.7.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "powerfmt"
@@ -1189,9 +1194,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "7c3a7fc5db1e57d5a779a352c8cdb57b29aa4c40cc69c3a68a7fedc815fbf2f9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1227,24 +1232,24 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64",
  "bytes",
@@ -1305,7 +1310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a542b0253fa46e632d27a1dc5cf7b930de4df8659dc6e720b647fc72147ae3d"
 dependencies = [
  "countme",
- "hashbrown",
+ "hashbrown 0.14.5",
  "rustc-hash",
  "text-size",
 ]
@@ -1337,9 +1342,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1350,19 +1355,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
 
 [[package]]
 name = "rustls-webpki"
@@ -1398,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -1426,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1451,7 +1455,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1474,7 +1478,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1597,7 +1601,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1619,9 +1623,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1660,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1688,22 +1692,22 @@ checksum = "f18aa187839b2bdb1ad2fa35ead8c4c2976b64e4363c386d45ac0f7ee85c9233"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1788,7 +1792,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1835,7 +1839,6 @@ dependencies = [
  "futures-util",
  "pin-project",
  "pin-project-lite",
- "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -1877,7 +1880,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1905,7 +1908,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1951,15 +1954,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -1969,9 +1972,9 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -1984,9 +1987,9 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "untrusted"
@@ -2020,9 +2023,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom",
 ]
@@ -2066,9 +2069,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
+checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2077,24 +2080,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
+checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.43"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
+checksum = "cc7ec4f8827a71586374db3e87abdb5a2bb3a15afed140221307c3ec06b1f63b"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2104,9 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
+checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2114,27 +2117,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
+checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.93"
+version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
+checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wdl"
 version = "0.9.0"
-source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e4d4df257cb316e033ddc160594fa1b5e98f57713ae1a3413c6b10dcf9bba5"
 dependencies = [
  "codespan-reporting",
  "wdl-analysis",
@@ -2148,7 +2152,8 @@ dependencies = [
 [[package]]
 name = "wdl-analysis"
 version = "0.4.0"
-source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52631340ceaa901f12c97842257e737016c8ed239d70578ff4f1de2f663a586c"
 dependencies = [
  "anyhow",
  "convert_case",
@@ -2173,7 +2178,8 @@ dependencies = [
 [[package]]
 name = "wdl-ast"
 version = "0.8.0"
-source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ed5e5948559f28affe07ad69a7db918af14bae7c6793682dd3cdc7714b32788"
 dependencies = [
  "macropol",
  "paste",
@@ -2186,7 +2192,8 @@ dependencies = [
 [[package]]
 name = "wdl-format"
 version = "0.2.0"
-source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3d1106993b586b6a3fdf47e51df05fce8c565d329f16f2d01054e8b9b0dfb5"
 dependencies = [
  "nonempty",
  "wdl-ast",
@@ -2195,7 +2202,8 @@ dependencies = [
 [[package]]
 name = "wdl-grammar"
 version = "0.9.0"
-source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da55dd7021225a41e16427328b0e5774a0f0952d0eccce0d55638f9f1eee27c0"
 dependencies = [
  "codespan-reporting",
  "itertools",
@@ -2207,7 +2215,8 @@ dependencies = [
 [[package]]
 name = "wdl-lint"
 version = "0.7.0"
-source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd67edb609c8e77a37369f621baa720f9d6557ed33b84a9609ac2e4afadc0d56"
 dependencies = [
  "convert_case",
  "indexmap",
@@ -2218,7 +2227,8 @@ dependencies = [
 [[package]]
 name = "wdl-lsp"
 version = "0.4.0"
-source = "git+https://github.com/stjude-rust-labs/wdl#b5caa3ad3e77c5cb396aaf90eaf9691f3a9e9736"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e423da7c74ea0f96cb122e3758c9d09bb3c013c423fdf54632f4c2e3c77bf7d"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -2237,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.70"
+version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,9 +2136,9 @@ checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
 
 [[package]]
 name = "wdl"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e4d4df257cb316e033ddc160594fa1b5e98f57713ae1a3413c6b10dcf9bba5"
+checksum = "a4ff8741c88ebf236603d3ade29bb52a43254826eb1a1ebaee36ebd550061c8a"
 dependencies = [
  "codespan-reporting",
  "wdl-analysis",
@@ -2191,9 +2191,9 @@ dependencies = [
 
 [[package]]
 name = "wdl-format"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3d1106993b586b6a3fdf47e51df05fce8c565d329f16f2d01054e8b9b0dfb5"
+checksum = "5899bf15bdd9320271205da22d66035eab34d2eaec8081054ea28ca7edd36aec"
 dependencies = [
  "nonempty",
  "wdl-ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ nonempty = "0.10.0"
 pest = { version = "2.7.11", features = ["pretty-print"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
-wdl = { version = "0.8.0", features = ["codespan", "lsp", "analysis"] }
+wdl = { version = "0.9.0", features = ["codespan", "lsp", "analysis", "format"], git = "https://github.com/stjude-rust-labs/wdl" }
 walkdir = "2.5.0"
 colored = "2.1.0"
 tokio = { version = "1.39.1", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ nonempty = "0.10.0"
 pest = { version = "2.7.11", features = ["pretty-print"] }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
-wdl = { version = "0.9.0", features = ["codespan", "lsp", "analysis", "format"], git = "https://github.com/stjude-rust-labs/wdl" }
+wdl = { version = "0.9.0", features = ["codespan", "lsp", "analysis", "format"] }
 walkdir = "2.5.0"
 colored = "2.1.0"
 tokio = { version = "1.39.1", features = ["full"] }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -12,7 +12,7 @@ pub mod explain;
 pub mod format;
 
 /// The diagnostic mode to use for reporting diagnostics.
-#[derive(Clone, Debug, Default, ValueEnum)]
+#[derive(Clone, Copy, Debug, Default, ValueEnum, PartialEq, Eq)]
 pub enum Mode {
     /// Prints diagnostics as multiple lines.
     #[default]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,5 +1,55 @@
 //! Implementation of sprocket CLI commands.
 
+use clap::ValueEnum;
+use codespan_reporting::term::Config;
+use codespan_reporting::term::DisplayStyle;
+use codespan_reporting::term::termcolor::ColorChoice;
+use codespan_reporting::term::termcolor::StandardStream;
+
 pub mod analyzer;
 pub mod check;
 pub mod explain;
+pub mod format;
+
+/// The diagnostic mode to use for reporting diagnostics.
+#[derive(Clone, Debug, Default, ValueEnum)]
+pub enum Mode {
+    /// Prints diagnostics as multiple lines.
+    #[default]
+    Full,
+
+    /// Prints diagnostics as one line.
+    OneLine,
+}
+
+impl std::fmt::Display for Mode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Mode::Full => write!(f, "full"),
+            Mode::OneLine => write!(f, "one-line"),
+        }
+    }
+}
+
+/// Gets the display config to use for reporting diagnostics.
+fn get_display_config(report_mode: Mode, no_color: bool) -> (Config, StandardStream) {
+    let display_style = match report_mode {
+        Mode::Full => DisplayStyle::Rich,
+        Mode::OneLine => DisplayStyle::Short,
+    };
+
+    let config = Config {
+        display_style,
+        ..Default::default()
+    };
+
+    let color_choice = if no_color {
+        ColorChoice::Never
+    } else {
+        ColorChoice::Always
+    };
+
+    let writer = StandardStream::stderr(color_choice);
+
+    (config, writer)
+}

--- a/src/commands/analyzer.rs
+++ b/src/commands/analyzer.rs
@@ -10,11 +10,11 @@ use wdl::lsp::ServerOptions;
 pub struct AnalyzerArgs {
     /// Use stdin and stdout for the RPC transport.
     #[clap(long, required = true)]
-    stdio: bool,
+    pub stdio: bool,
 
     /// Whether or not to enable all lint rules.
     #[clap(long)]
-    lint: bool,
+    pub lint: bool,
 }
 
 /// Runs the `analyzer` command.

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -1,7 +1,9 @@
 //! Implementation of the explain command.
 
+use anyhow::bail;
 use clap::Parser;
 use colored::Colorize;
+use wdl::analysis;
 use wdl::lint;
 
 /// Arguments for the `explain` subcommand.
@@ -16,22 +18,48 @@ pub struct Args {
 /// Lists all rules as a string for displaying after CLI help.
 pub fn list_all_rules() -> String {
     let mut result = "Available rules:".to_owned();
-    for rule in lint::rules() {
-        result.push_str(&format!("\n  - {}", rule.id()));
+    let analysis_rules = analysis::rules();
+    let lint_rules = lint::rules();
+
+    let mut indexes = (0..(analysis_rules.len() + lint_rules.len())).collect::<Vec<_>>();
+
+    let id = |index: usize| {
+        if index >= analysis_rules.len() {
+            lint_rules[index - analysis_rules.len()].id()
+        } else {
+            analysis_rules[index].id()
+        }
+    };
+
+    indexes.sort_by(|a, b| id(*a).cmp(id(*b)));
+
+    for index in indexes {
+        result.push_str(&format!("\n  - {}", id(index)));
     }
+
     result
 }
 
-/// Pretty prints a rule to a string.
-pub fn pretty_print_rule(rule: &dyn lint::Rule) -> String {
-    let mut result = format!("{}", rule.id().bold().underline());
-    result = format!("{}\n{}", result, rule.description());
-    result = format!("{}\n{}", result, format!("{}", rule.tags()).yellow());
-    result = format!("{}\n\n{}", result, rule.explanation());
-    match rule.url() {
-        Some(url) => format!("{}\n{}", result, url.underline().blue()),
-        None => result,
+/// Pretty prints a lint rule to a string.
+pub fn pretty_print_lint_rule(rule: &dyn lint::Rule) {
+    println!(
+        "{id} {tags}",
+        id = rule.id().bold().underline(),
+        tags = format!("{}", rule.tags()).yellow()
+    );
+    println!("{desc}", desc = rule.description());
+    println!("\n{explanation}", explanation = rule.explanation());
+
+    if let Some(url) = rule.url() {
+        println!("\n{url}", url = url.underline().blue());
     }
+}
+
+/// Pretty prints an analysis rule to a string.
+pub fn pretty_print_analysis_rule(rule: &dyn analysis::Rule) {
+    println!("{id}", id = rule.id().bold().underline());
+    println!("{desc}", desc = rule.description());
+    println!("\n{explanation}", explanation = rule.explanation());
 }
 
 /// Explains a lint rule.
@@ -39,17 +67,26 @@ pub fn explain(args: Args) -> anyhow::Result<()> {
     let name = args.rule_name;
     let lowercase_name = name.to_lowercase();
 
-    let rule = lint::rules()
+    match analysis::rules()
         .into_iter()
-        .find(|rule| rule.id().to_lowercase() == lowercase_name);
-
-    match rule {
+        .find(|rule| rule.id().to_lowercase() == lowercase_name)
+    {
         Some(rule) => {
-            println!("{}", pretty_print_rule(&*rule));
+            pretty_print_analysis_rule(rule.as_ref());
         }
         None => {
-            println!("{}", list_all_rules());
-            anyhow::bail!("No rule found with the name '{}'", name);
+            match lint::rules()
+                .into_iter()
+                .find(|rule| rule.id().to_lowercase() == lowercase_name)
+            {
+                Some(rule) => {
+                    pretty_print_lint_rule(rule.as_ref());
+                }
+                None => {
+                    println!("{rules}\n", rules = list_all_rules());
+                    bail!("No rule found with the name `{name}`");
+                }
+            }
         }
     }
 

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -1,5 +1,4 @@
 //! Implementation of the format command.
-//! Implementation of the analyzer command.
 
 use std::fs;
 use std::io::Read;

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -36,7 +36,7 @@ const DEFAULT_TAB_INDENT_SIZE: usize = 1;
 /// The default number of spaces to use for indentation.
 const DEFAULT_SPACE_IDENT_SIZE: usize = 4;
 
-/// Arguments for the `analyzer` subcommand.
+/// Arguments for the `format` subcommand.
 #[derive(Parser, Debug)]
 #[command(
     author,

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -1,0 +1,106 @@
+//! Implementation of the format command.
+//! Implementation of the analyzer command.
+
+use std::fs;
+use std::io::Read;
+use std::num::NonZeroUsize;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use clap::Parser;
+use codespan_reporting::files::SimpleFile;
+use codespan_reporting::term::emit;
+use wdl::ast::Document;
+use wdl::ast::Node;
+use wdl::format::Formatter;
+use wdl::format::config::Builder;
+use wdl::format::config::Indent;
+use wdl::format::element::node::AstNodeFormatExt;
+
+use super::Mode;
+use crate::commands::get_display_config;
+
+/// Reads source from the given path.
+///
+/// If the path is simply `-`, the source is read from STDIN.
+fn read_source(path: &Path) -> Result<String> {
+    if path.as_os_str() == "-" {
+        let mut source = String::new();
+        std::io::stdin()
+            .read_to_string(&mut source)
+            .context("failed to read source from STDIN")?;
+        Ok(source)
+    } else {
+        Ok(fs::read_to_string(path).with_context(|| {
+            format!("failed to read source file `{path}`", path = path.display())
+        })?)
+    }
+}
+
+/// Arguments for the `analyzer` subcommand.
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+pub struct FormatArgs {
+    /// The path to the source WDL file (`-` for STDIN).
+    #[arg(value_name = "PATH")]
+    pub path: PathBuf,
+
+    /// Disables color output.
+    #[arg(long)]
+    pub no_color: bool,
+
+    /// The report mode.
+    #[arg(short = 'm', long, default_value_t, value_name = "MODE")]
+    pub report_mode: Mode,
+
+    /// Use tabs instead of spaces for indentation.
+    pub with_tabs: bool,
+
+    /// The number of spaces that represents an indentation level.
+    #[arg(value_name = "SIZE", default_value = "4", conflicts_with = "with_tabs")]
+    pub indentation_size: usize,
+}
+
+/// Runs the `format` command.
+pub fn format(args: FormatArgs) -> Result<()> {
+    let source = read_source(&args.path)?;
+
+    let (document, diagnostics) = Document::parse(&source);
+    if !diagnostics.is_empty() {
+        let (config, mut stream) = get_display_config(args.report_mode, args.no_color);
+        let file = SimpleFile::new(args.path.to_string_lossy(), source);
+        for diagnostic in diagnostics.iter() {
+            emit(&mut stream, &config, &file, &diagnostic.to_codespan())
+                .context("failed to emit diagnostic")?;
+        }
+
+        bail!(
+            "aborting due to previous {count} diagnostic{s}",
+            count = diagnostics.len(),
+            s = if diagnostics.len() == 1 { "" } else { "s" }
+        );
+    }
+
+    let document = Node::Ast(document.ast().into_v1().unwrap()).into_format_element();
+    let config = Builder::default()
+        .indent(if args.with_tabs {
+            Indent::Tabs(NonZeroUsize::new(1).unwrap())
+        } else {
+            Indent::Spaces(
+                NonZeroUsize::new(args.indentation_size)
+                    .ok_or_else(|| anyhow!("indentation size must be non-zero"))?,
+            )
+        })
+        .try_build()?;
+
+    let formatter = Formatter::new(config);
+    let formatted = formatter.format(&document)?;
+
+    print!("{formatted}");
+
+    Ok(())
+}

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -85,7 +85,13 @@ pub fn format(args: FormatArgs) -> Result<()> {
         );
     }
 
-    let document = Node::Ast(document.ast().into_v1().unwrap()).into_format_element();
+    let document = Node::Ast(
+        document
+            .ast()
+            .into_v1()
+            .ok_or_else(|| anyhow!("only WDL 1.x documents are currently supported"))?,
+    )
+    .into_format_element();
     let config = Builder::default()
         .indent(if args.with_tabs {
             Indent::Tabs(NonZeroUsize::new(1).unwrap())

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -58,10 +58,16 @@ pub struct FormatArgs {
     pub report_mode: Mode,
 
     /// Use tabs instead of spaces for indentation.
+    #[arg(long)]
     pub with_tabs: bool,
 
     /// The number of spaces that represents an indentation level.
-    #[arg(value_name = "SIZE", default_value = "4", conflicts_with = "with_tabs")]
+    #[arg(
+        long,
+        value_name = "SIZE",
+        default_value = "4",
+        conflicts_with = "with_tabs"
+    )]
     pub indentation_size: usize,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,8 +17,8 @@ git_testament!(TESTAMENT);
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
-    /// Checks a WDL document (or a directory containing WDL documents) and reports
-    /// diagnostics.
+    /// Checks a WDL document (or a directory containing WDL documents) and
+    /// reports diagnostics.
     Check(commands::check::CheckArgs),
 
     /// Lints Workflow Description Language files.

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ git_testament!(TESTAMENT);
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
-    /// Checks a WDL file (or a directory containing WDL files) and reports
+    /// Checks a WDL document (or a directory containing WDL files) and reports
     /// diagnostics.
     Check(commands::check::CheckArgs),
 
@@ -29,6 +29,10 @@ enum Commands {
 
     /// Runs the analyzer LSP server.
     Analyzer(commands::analyzer::AnalyzerArgs),
+
+    /// Formats a WDL document.
+    #[clap(alias = "fmt")]
+    Format(commands::format::FormatArgs),
 }
 
 #[derive(Parser)]
@@ -58,6 +62,7 @@ pub async fn inner() -> anyhow::Result<()> {
         Commands::Lint(args) => commands::check::lint(args).await,
         Commands::Explain(args) => commands::explain::explain(args),
         Commands::Analyzer(args) => commands::analyzer::analyzer(args).await,
+        Commands::Format(args) => commands::format::format(args),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ git_testament!(TESTAMENT);
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
-    /// Checks a WDL document (or a directory containing WDL files) and reports
+    /// Checks a WDL document (or a directory containing WDL documents) and reports
     /// diagnostics.
     Check(commands::check::CheckArgs),
 


### PR DESCRIPTION
This commit adds the `format` command to `sprocket`.

The command will format a single WDL document.

Also updated the existing commands to the latest WDL API and corrected the environment variable name for publishing crates.

Included the analysis rules in `sprocket explain`; the list of rules is now sorted by id.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
