### PR TITLE
chore: correct `cross` metadata key in `Cargo.toml`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ indicatif = "0.17.8"
 clap-verbosity-flag = "2.2.1"
 
 # Install openssl for the linux arm64 build
-[workspace.metadata.cross.target.aarch64-unknown-linux-gnu]
+[package.metadata.cross.target.aarch64-unknown-linux-gnu]
 pre-build = [
     "dpkg --add-architecture $CROSS_DEB_ARCH",
     "apt-get update && apt-get --assume-yes install libssl-dev:$CROSS_DEB_ARCH"


### PR DESCRIPTION
As `sprocket` is not in a workspace, it should be using the package metadata key.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
