### PR TITLE
feat: require one of check or overwrite options in format command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* `format` now requires one of the `--check` or `--overwrite` arguments ([#51](https://github.com/stjude-rust-labs/sprocket/pull/51)).
+
 ## 0.9.0 - 10-22-2024
 
 ### Changed

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -43,9 +43,10 @@ const DEFAULT_SPACE_IDENT_SIZE: usize = 4;
     author,
     version,
     about,
-    after_help = "Use the `--overwrite` option to replace a WDL document, or a directory \
-                  containing WDL documents, with the formatted source. Use the `--check` option \
-                  to print the diff or none if the source is already formatted."
+    after_help = "Use the `--overwrite` option to replace a WDL document or a directory \
+                  containing WDL documents with the formatted source.\nUse the `--check` option \
+                  to verify that a document or a directory containing WDL documents is already formatted \
+                  and print the diff if not."
 )]
 pub struct FormatArgs {
     /// The path to the WDL document to format (`-` for STDIN); the path may be
@@ -107,8 +108,8 @@ fn read_source(path: &Path) -> Result<String> {
 
 /// Formats a document.
 ///
-/// Checks if the document is formatted correctly and prints the diff if not
-/// if check_only is true.
+/// If `check_only` is true, checks if the document is formatted correctly and prints the diff if not
+/// then exits. Else will format and overwrite the document.
 ///
 /// If the document failed to parse, this emits the diagnostics and returns
 /// `Ok(count)` of the diagnostics to the caller.

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -45,8 +45,8 @@ const DEFAULT_SPACE_IDENT_SIZE: usize = 4;
     about,
     after_help = "Use the `--overwrite` option to replace a WDL document or a directory \
                   containing WDL documents with the formatted source.\nUse the `--check` option \
-                  to verify that a document or a directory containing WDL documents is already formatted \
-                  and print the diff if not."
+                  to verify that a document or a directory containing WDL documents is already \
+                  formatted and print the diff if not."
 )]
 pub struct FormatArgs {
     /// The path to the WDL document to format (`-` for STDIN); the path may be
@@ -108,8 +108,9 @@ fn read_source(path: &Path) -> Result<String> {
 
 /// Formats a document.
 ///
-/// If `check_only` is true, checks if the document is formatted correctly and prints the diff if not
-/// then exits. Else will format and overwrite the document.
+/// If `check_only` is true, checks if the document is formatted correctly and
+/// prints the diff if not then exits. Else will format and overwrite the
+/// document.
 ///
 /// If the document failed to parse, this emits the diagnostics and returns
 /// `Ok(count)` of the diagnostics to the caller.
@@ -197,7 +198,6 @@ pub fn format(args: FormatArgs) -> Result<()> {
 
     let mut diagnostics = 0;
     if args.path.to_str() != Some("-") && args.path.is_dir() {
-
         for entry in WalkDir::new(&args.path) {
             let entry = entry.with_context(|| {
                 format!(

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -43,9 +43,9 @@ const DEFAULT_SPACE_IDENT_SIZE: usize = 4;
     author,
     version,
     about,
-    after_help = "By default, the `format` command will print a single formatted WDL \
-                  document.\n\nUse the `--overwrite` option to replace a WDL document, or a \
-                  directory containing WDL documents, with the formatted source."
+    after_help = "Use the `--overwrite` option to replace a WDL document, or a directory \
+                  containing WDL documents, with the formatted source. Use the `--check` option \
+                  to print the diff or none if the source is already formatted."
 )]
 pub struct FormatArgs {
     /// The path to the WDL document to format (`-` for STDIN); the path may be
@@ -70,12 +70,21 @@ pub struct FormatArgs {
     #[arg(long, value_name = "SIZE")]
     pub indentation_size: Option<usize>,
 
+    /// Argument group defining the mode of behavior
+    #[command(flatten)]
+    mode: ModeGroup,
+}
+
+/// Argument group defining the mode of behavior
+#[derive(Parser, Debug)]
+#[group(required = true, multiple = false)]
+pub struct ModeGroup {
     /// Overwrite the WDL documents with the formatted versions
     #[arg(long, conflicts_with = "check")]
     pub overwrite: bool,
 
     /// Check if files are formatted correctly and print diff if not
-    #[arg(long, conflicts_with = "overwrite")]
+    #[arg(long)]
     pub check: bool,
 }
 
@@ -98,6 +107,9 @@ fn read_source(path: &Path) -> Result<String> {
 
 /// Formats a document.
 ///
+/// Checks if the document is formatted correctly and prints the diff if not
+/// if check_only is true.
+///
 /// If the document failed to parse, this emits the diagnostics and returns
 /// `Ok(count)` of the diagnostics to the caller.
 ///
@@ -105,13 +117,12 @@ fn read_source(path: &Path) -> Result<String> {
 fn format_document(
     config: Config,
     path: &Path,
-    overwrite: bool,
     report_mode: Mode,
     no_color: bool,
-    check: bool,
+    check_only: bool,
 ) -> Result<usize> {
     if path.to_str() != Some("-") {
-        let action = if check { "checking" } else { "formatting" };
+        let action = if check_only { "checking" } else { "formatting" };
         println!(
             "{action_colored} `{path}`",
             action_colored = if no_color {
@@ -147,7 +158,7 @@ fn format_document(
     let formatter = Formatter::new(config);
     let formatted = formatter.format(&document)?;
 
-    if check {
+    if check_only {
         if formatted != source {
             print!("{}", StrComparison::new(&source, &formatted));
             return Ok(1);
@@ -156,12 +167,9 @@ fn format_document(
         return Ok(0);
     }
 
-    if overwrite {
-        fs::write(path, formatted)
-            .with_context(|| format!("failed to write `{path}`", path = path.display()))?;
-    } else {
-        print!("{formatted}");
-    }
+    // write file because check is not true
+    fs::write(path, formatted)
+        .with_context(|| format!("failed to write `{path}`", path = path.display()))?;
 
     Ok(0)
 }
@@ -188,7 +196,7 @@ pub fn format(args: FormatArgs) -> Result<()> {
 
     let mut diagnostics = 0;
     if args.path.to_str() != Some("-") && args.path.is_dir() {
-        if !args.overwrite && !args.check {
+        if !args.mode.overwrite && !args.mode.check {
             bail!("formatting a directory requires the `--overwrite` or `--check` option");
         }
 
@@ -207,20 +215,18 @@ pub fn format(args: FormatArgs) -> Result<()> {
             diagnostics += format_document(
                 config,
                 path,
-                args.overwrite,
                 args.report_mode,
                 args.no_color,
-                args.check,
+                args.mode.check,
             )?;
         }
     } else {
         diagnostics += format_document(
             config,
             &args.path,
-            args.overwrite,
             args.report_mode,
             args.no_color,
-            args.check,
+            args.mode.check,
         )?;
     }
 

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -197,9 +197,6 @@ pub fn format(args: FormatArgs) -> Result<()> {
 
     let mut diagnostics = 0;
     if args.path.to_str() != Some("-") && args.path.is_dir() {
-        if !args.mode.overwrite && !args.mode.check {
-            bail!("formatting a directory requires the `--overwrite` or `--check` option");
-        }
 
         for entry in WalkDir::new(&args.path) {
             let entry = entry.with_context(|| {


### PR DESCRIPTION
Requires that one of `--overwrite` or `--check` be provided and removes the default behavior of just printing the formatted files to stdout.

The `--overwrite` flag is now just a safety check so the caller knows that what they are doing is destructive, as writing the file is now "default" behavior, with `--check` being the modifier.

Test:
```
❯ cargo run --release format --check --overwrite ~/wdl/wdl-format/tests/format/optional_structs/
    Finished `release` profile [optimized] target(s) in 0.07s
     Running `target/release/sprocket format --check --overwrite /home/scott/wdl/wdl-format/tests/format/optional_structs/`
error: the argument '--check' cannot be used with '--overwrite'

Usage: sprocket format <--overwrite|--check> <PATH>

For more information, try '--help'.
```

```
❯ cargo run --release format ~/wdl/wdl-format/tests/format/optional_structs/ 
    Finished `release` profile [optimized] target(s) in 0.07s
     Running `target/release/sprocket format /home/scott/wdl/wdl-format/tests/format/optional_structs/`
error: the following required arguments were not provided:
  <--overwrite|--check>

Usage: sprocket format <--overwrite|--check> <PATH>

For more information, try '--help'.
```