### PR TITLE
Add `validate-inputs` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
 - **`sprocket format`** Formats WDL documents.
 - **`sprocket lint`** Performs static analysis on WDL documents with additional
   linting rules enabled.
+- **`sprocket validate-inputs`** Validates an input JSON against a task or workflow input schema.
 
 ## Guiding Principles
 


### PR DESCRIPTION
The `validate-inputs` subcommand is missing from the README.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).