### PR TITLE
docs: update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,41 +1,3 @@
-<!-- 
-When creating a pull request, you should uncomment the section below that describes
-the type of pull request you are submitting.
--->
-
-<!-- START SECTION: "adding a new linting/validation rule"
-
-**
-This pull request adds a new rule to Sprocket.
-
-This pull request adds a new rule.
-
-- **Rule Name**: `a_rule_name`
-- **Concern Kind**: Lint warning/Validation error
-- **Concern Code**: `v1::W001`
-- **Implemented In**: `wdl-ast`/`wdl-grammar`
-
-_Describe the rules you have implemented and link to any relevant issues._
-
-Before submitting this PR, please make sure:
-
-- [ ] You have added a few sentences describing the PR here.
-- [ ] You have added yourself or the appropriate individual as the assignee.
-- [ ] You have added at least one relevant code reviewer to the PR.
-- [ ] Your code builds clean without any errors or warnings.
-- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
-
-Rule specific checks:
-
-- [ ] You have updated `CONCERNS.md` in the root of this project to account for 
-      this rule. 
-- [ ] You have added a test that covers every possible setting for the rule 
-      within the file where the rule is implemented.
-
-END SECTION -->
-
-<!-- START SECTION: "any other pull request"
-
 _Describe the problem or feature in addition to a link to the issues._
 
 Before submitting this PR, please make sure:
@@ -45,6 +7,5 @@ Before submitting this PR, please make sure:
 - [ ] You have added at least one relevant code reviewer to the PR.
 - [ ] Your code builds clean without any errors or warnings.
 - [ ] You have added tests (when appropriate).
+- [ ] You have added an entry in the CHANGELOG (when appropriate).
 - [ ] You have updated the README or other documentation to account for these changes (when appropriate).
-
-END SECTION -->


### PR DESCRIPTION
The first "option" for the PR template (added a new Rule to Sprocket) doesn't make sense as rules aren't implemented in this repo. So that option has been deleted.

That leaves one other option for the template which is no longer commented out by default.

Also added a checkbox for updating the CHANGELOG (which I am guilty of forgetting to update).