### PR TITLE
feat: extend explain command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * YAML support for `validate-inputs` command ([#79](https://github.com/stjude-rust-labs/sprocket/pull/79)).
+* Added `--tag [TAG]` flag to `explain` command to list all the rules with that `TAG` ([#80](https://github.com/stjude-rust-labs/sprocket/pull/80)).
+* Show related rules in the `explain` command ([#80](https://github.com/stjude-rust-labs/sprocket/pull/80)).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * YAML support for `validate-inputs` command ([#79](https://github.com/stjude-rust-labs/sprocket/pull/79)).
-* Added `--tag [TAG]` flag to `explain` command to list all the rules with that `TAG` ([#80](https://github.com/stjude-rust-labs/sprocket/pull/80)).
-* Show related rules in the `explain` command ([#80](https://github.com/stjude-rust-labs/sprocket/pull/80)).
+* Extend `explain` to display related rules, list tags using `--t`, show WDL definitions using `--definitions` ([#80](https://github.com/stjude-rust-labs/sprocket/pull/80)).
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,7 +1292,7 @@ dependencies = [
 [[package]]
 name = "http-cache-stream"
 version = "0.1.0"
-source = "git+https://github.com/stjude-rust-labs/http-cache-stream#c8332277cd101b1696cd6c00aa31edccc1bc0bc9"
+source = "git+https://github.com/stjude-rust-labs/http-cache-stream#39a7948ed06a50ae18efbdae6bc780d04f44d5a1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1320,7 +1320,7 @@ dependencies = [
 [[package]]
 name = "http-cache-stream-reqwest"
 version = "0.1.0"
-source = "git+https://github.com/stjude-rust-labs/http-cache-stream#c8332277cd101b1696cd6c00aa31edccc1bc0bc9"
+source = "git+https://github.com/stjude-rust-labs/http-cache-stream#39a7948ed06a50ae18efbdae6bc780d04f44d5a1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4204,7 +4204,7 @@ dependencies = [
 [[package]]
 name = "wdl"
 version = "0.11.0"
-source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#e441e1ef5dd577161966335d835a025bb5b7eb61"
+source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#c33aa448207357a59527a7530c9dd701192876b3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4238,7 +4238,7 @@ dependencies = [
 [[package]]
 name = "wdl-analysis"
 version = "0.6.0"
-source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#e441e1ef5dd577161966335d835a025bb5b7eb61"
+source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#c33aa448207357a59527a7530c9dd701192876b3"
 dependencies = [
  "anyhow",
  "convert_case 0.8.0",
@@ -4263,7 +4263,7 @@ dependencies = [
 [[package]]
 name = "wdl-ast"
 version = "0.10.0"
-source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#e441e1ef5dd577161966335d835a025bb5b7eb61"
+source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#c33aa448207357a59527a7530c9dd701192876b3"
 dependencies = [
  "macropol",
  "paste",
@@ -4276,7 +4276,7 @@ dependencies = [
 [[package]]
 name = "wdl-doc"
 version = "0.1.0"
-source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#e441e1ef5dd577161966335d835a025bb5b7eb61"
+source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#c33aa448207357a59527a7530c9dd701192876b3"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -4292,7 +4292,7 @@ dependencies = [
 [[package]]
 name = "wdl-engine"
 version = "0.1.0"
-source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#e441e1ef5dd577161966335d835a025bb5b7eb61"
+source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#c33aa448207357a59527a7530c9dd701192876b3"
 dependencies = [
  "anyhow",
  "crankshaft",
@@ -4328,7 +4328,7 @@ dependencies = [
 [[package]]
 name = "wdl-format"
 version = "0.4.0"
-source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#e441e1ef5dd577161966335d835a025bb5b7eb61"
+source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#c33aa448207357a59527a7530c9dd701192876b3"
 dependencies = [
  "nonempty 0.11.0",
  "wdl-ast",
@@ -4337,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "wdl-grammar"
 version = "0.11.0"
-source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#e441e1ef5dd577161966335d835a025bb5b7eb61"
+source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#c33aa448207357a59527a7530c9dd701192876b3"
 dependencies = [
  "codespan-reporting",
  "itertools",
@@ -4349,7 +4349,7 @@ dependencies = [
 [[package]]
 name = "wdl-lint"
 version = "0.9.0"
-source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#e441e1ef5dd577161966335d835a025bb5b7eb61"
+source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#c33aa448207357a59527a7530c9dd701192876b3"
 dependencies = [
  "anyhow",
  "convert_case 0.8.0",
@@ -4367,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "wdl-lsp"
 version = "0.6.0"
-source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#e441e1ef5dd577161966335d835a025bb5b7eb61"
+source = "git+https://github.com/stjude-rust-labs/wdl?branch=main#c33aa448207357a59527a7530c9dd701192876b3"
 dependencies = [
  "anyhow",
  "indexmap 2.8.0",

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -33,6 +33,7 @@ pub struct Args {
     pub definitions: bool,
 }
 
+/// Display all rules and tags.
 fn generate_after_help() -> String {
     format!("{}\n\n{}", list_all_rules(), list_all_tags())
 }
@@ -62,7 +63,7 @@ pub fn list_all_rules() -> String {
     result
 }
 
-/// Lists all tags as a string for displaying after CLI help.
+/// Lists all tags as a string for displaying.
 pub fn list_all_tags() -> String {
     let mut result = "Available tags:".to_owned();
     let lint_rules = lint::rules();

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -1,18 +1,31 @@
 //! Implementation of the explain command.
 
+use std::collections::HashSet;
+
+use anyhow::Ok;
+use anyhow::anyhow;
 use anyhow::bail;
 use clap::Parser;
 use colored::Colorize;
 use wdl::analysis;
 use wdl::lint;
+use wdl::lint::Tag;
 
 /// Arguments for the `explain` subcommand.
 #[derive(Parser, Debug)]
-#[command(author, version, about, after_help = list_all_rules())]
+#[command(author, version, about, after_help = generate_after_help())]
 pub struct Args {
     /// The name of the rule to explain.
-    #[arg(required = true)]
-    pub rule_name: String,
+    #[arg(required_unless_present = "tag", value_name = "RULE_NAME")]
+    pub rule_name: Option<String>,
+
+    /// List all rules with the given tag.
+    #[arg(short, long, value_name = "TAG", conflicts_with = "rule_name")]
+    pub tag: Option<String>,
+}
+
+fn generate_after_help() -> String {
+    format!("{}\n\n{}", list_all_rules(), list_all_tags())
 }
 
 /// Lists all rules as a string for displaying after CLI help.
@@ -40,6 +53,28 @@ pub fn list_all_rules() -> String {
     result
 }
 
+/// Lists all tags as a string for displaying after CLI help.
+pub fn list_all_tags() -> String {
+    let mut result = "Available tags:".to_owned();
+    let lint_rules = lint::rules();
+
+    let mut tags: HashSet<Tag> = HashSet::new();
+    for rule in lint_rules {
+        for tag in rule.tags().iter() {
+            tags.insert(tag);
+        }
+    }
+
+    let mut tags: Vec<Tag> = tags.into_iter().collect();
+    tags.sort_unstable_by(|a, b| a.to_string().cmp(&b.to_string()));
+
+    for tag in tags {
+        result.push_str(&format!("\n  - {}", tag));
+    }
+
+    result
+}
+
 /// Pretty prints a lint rule to a string.
 pub fn pretty_print_lint_rule(rule: &dyn lint::Rule) {
     println!(
@@ -53,6 +88,16 @@ pub fn pretty_print_lint_rule(rule: &dyn lint::Rule) {
     if let Some(url) = rule.url() {
         println!("\n{url}", url = url.underline().blue());
     }
+
+    let related = rule.related_rules();
+    if !related.is_empty() {
+        println!("\n{}", "Related Rules:".bold());
+        let mut sorted_related = related.iter().collect::<Vec<_>>();
+        sorted_related.sort_unstable_by(|a, b| a.cmp(b));
+        sorted_related.iter().for_each(|rule| {
+            println!("  - {}", rule.cyan());
+        });
+    };
 }
 
 /// Pretty prints an analysis rule to a string.
@@ -64,31 +109,59 @@ pub fn pretty_print_analysis_rule(rule: &dyn analysis::Rule) {
 
 /// Explains a lint rule.
 pub fn explain(args: Args) -> anyhow::Result<()> {
-    let name = args.rule_name;
-    let lowercase_name = name.to_lowercase();
+    if let Some(tag) = args.tag {
+        let target: Tag = tag.as_str().try_into().map_err(|_| {
+            println!("{}\n", list_all_tags());
+            anyhow!("Invalid tag '{}'", tag)
+        })?;
 
-    match analysis::rules()
-        .into_iter()
-        .find(|rule| rule.id().to_lowercase() == lowercase_name)
-    {
-        Some(rule) => {
-            pretty_print_analysis_rule(rule.as_ref());
+        let rules = lint::rules()
+            .into_iter()
+            .filter(|rule| rule.tags().contains(target))
+            .collect::<Vec<_>>();
+
+        if rules.is_empty() {
+            println!("{}\n", list_all_tags());
+            bail!("No rules found with the tag `{}`", tag);
+        } else {
+            println!("Rules with the tag `{}`:", tag);
+            let mut rule_ids = rules.iter().map(|rule| rule.id()).collect::<Vec<_>>();
+            rule_ids.sort_unstable_by(|a, b| a.cmp(b));
+            for id in rule_ids {
+                println!("  - {}", id);
+            }
         }
-        None => {
-            match lint::rules()
-                .into_iter()
-                .find(|rule| rule.id().to_lowercase() == lowercase_name)
-            {
-                Some(rule) => {
-                    pretty_print_lint_rule(rule.as_ref());
-                }
-                None => {
-                    println!("{rules}\n", rules = list_all_rules());
-                    bail!("No rule found with the name `{name}`");
+        return Ok(());
+    }
+
+    if let Some(rule_name) = args.rule_name {
+        let lowercase_name = rule_name.to_lowercase();
+
+        match analysis::rules()
+            .into_iter()
+            .find(|rule| rule.id().to_lowercase() == lowercase_name)
+        {
+            Some(rule) => {
+                pretty_print_analysis_rule(rule.as_ref());
+            }
+            None => {
+                match lint::rules()
+                    .into_iter()
+                    .find(|rule| rule.id().to_lowercase() == lowercase_name)
+                {
+                    Some(rule) => {
+                        pretty_print_lint_rule(rule.as_ref());
+                    }
+                    None => {
+                        println!("{rules}\n", rules = list_all_rules());
+                        bail!("No rule found with the name `{rule_name}`");
+                    }
                 }
             }
         }
-    }
 
-    Ok(())
+        Ok(())
+    } else {
+        bail!("Invalid arguments: either a rule_name or a tag must be provided");
+    }
 }

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -119,7 +119,7 @@ pub fn explain(args: Args) -> anyhow::Result<()> {
     };
 
     if let Some(tag) = args.tag {
-        let target: Tag = tag.as_str().try_into().map_err(|_| {
+        let target = tag.parse::<Tag>().map_err(|_| {
             println!("{}\n", list_all_tags());
             anyhow!("Invalid tag '{}'", tag)
         })?;

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -32,7 +32,7 @@ fn generate_after_help() -> String {
     format!("{}\n\n{}", list_all_rules(), list_all_tags())
 }
 
-/// Lists all rules as a string for displaying after CLI help.
+/// Lists all rules as a string for displaying.
 pub fn list_all_rules() -> String {
     let mut result = "Available rules:".to_owned();
     let analysis_rules = analysis::rules();
@@ -171,6 +171,6 @@ pub fn explain(args: Args) -> anyhow::Result<()> {
 
         Ok(())
     } else {
-        bail!("Invalid arguments: either a rule_name or a tag must be provided");
+        bail!("Invalid arguments: either a rule_name, a --tag, or --definitions must be provided");
     }
 }

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -16,12 +16,16 @@ use wdl::lint::Tag;
 #[command(author, version, about, after_help = generate_after_help())]
 pub struct Args {
     /// The name of the rule to explain.
-    #[arg(required_unless_present = "tag", value_name = "RULE_NAME")]
+    #[arg(required_unless_present_any = ["tag", "definitions"], value_name = "RULE_NAME")]
     pub rule_name: Option<String>,
 
     /// List all rules with the given tag.
-    #[arg(short, long, value_name = "TAG", conflicts_with = "rule_name")]
+    #[arg(short, long, value_name = "TAG", conflicts_with_all = ["rule_name", "definitions"])]
     pub tag: Option<String>,
+
+    /// Display general WDL definitions.
+    #[arg(long, conflicts_with_all = ["rule_name", "tag"])]
+    pub definitions: bool,
 }
 
 fn generate_after_help() -> String {
@@ -109,6 +113,11 @@ pub fn pretty_print_analysis_rule(rule: &dyn analysis::Rule) {
 
 /// Explains a lint rule.
 pub fn explain(args: Args) -> anyhow::Result<()> {
+    if args.definitions {
+        println!("{}", lint::DEFINITIONS_TEXT);
+        return Ok(());
+    };
+
     if let Some(tag) = args.tag {
         let target: Tag = tag.as_str().try_into().map_err(|_| {
             println!("{}\n", list_all_tags());

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -12,7 +12,7 @@ use wdl::lint;
 use wdl::lint::Tag;
 
 /// Usage string for the `explain` subcommand.
-const USAGE: &str = "sprocket explain [RULE_NAME]
+const USAGE: &str = "sprocket explain [RULE]
     sprocket explain --tag <TAG>
     sprocket explain --definitions";
 
@@ -21,7 +21,7 @@ const USAGE: &str = "sprocket explain [RULE_NAME]
 #[command(author, version, about, after_help = generate_after_help(), override_usage = USAGE)]
 pub struct Args {
     /// The name of the rule to explain.
-    #[arg(required_unless_present_any = ["tag", "definitions"], value_name = "RULE_NAME")]
+    #[arg(required_unless_present_any = ["tag", "definitions"], value_name = "RULE")]
     pub rule_name: Option<String>,
 
     /// List all rules with the given tag.

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -11,6 +11,7 @@ use wdl::analysis;
 use wdl::lint;
 use wdl::lint::Tag;
 
+/// Usage string for the `explain` subcommand.
 const USAGE: &str = "sprocket explain [RULE_NAME]
     sprocket explain --tag <TAG>
     sprocket explain --definitions";
@@ -74,7 +75,7 @@ pub fn list_all_tags() -> String {
     }
 
     let mut tags: Vec<Tag> = tags.into_iter().collect();
-    tags.sort_unstable_by(|a, b| a.to_string().cmp(&b.to_string()));
+    tags.sort_by_key(|tag| tag.to_string());
 
     for tag in tags {
         result.push_str(&format!("\n  - {}", tag));
@@ -101,7 +102,7 @@ pub fn pretty_print_lint_rule(rule: &dyn lint::Rule) {
     if !related.is_empty() {
         println!("\n{}", "Related Rules:".bold());
         let mut sorted_related = related.iter().collect::<Vec<_>>();
-        sorted_related.sort_unstable_by(|a, b| a.cmp(b));
+        sorted_related.sort();
         sorted_related.iter().for_each(|rule| {
             println!("  - {}", rule.cyan());
         });
@@ -139,7 +140,7 @@ pub fn explain(args: Args) -> anyhow::Result<()> {
         } else {
             println!("Rules with the tag `{}`:", tag);
             let mut rule_ids = rules.iter().map(|rule| rule.id()).collect::<Vec<_>>();
-            rule_ids.sort_unstable_by(|a, b| a.cmp(b));
+            rule_ids.sort();
             for id in rule_ids {
                 println!("  - {}", id);
             }

--- a/src/commands/explain.rs
+++ b/src/commands/explain.rs
@@ -11,9 +11,13 @@ use wdl::analysis;
 use wdl::lint;
 use wdl::lint::Tag;
 
+const USAGE: &str = "sprocket explain [RULE_NAME]
+    sprocket explain --tag <TAG>
+    sprocket explain --definitions";
+
 /// Arguments for the `explain` subcommand.
 #[derive(Parser, Debug)]
-#[command(author, version, about, after_help = generate_after_help())]
+#[command(author, version, about, after_help = generate_after_help(), override_usage = USAGE)]
 pub struct Args {
     /// The name of the rule to explain.
     #[arg(required_unless_present_any = ["tag", "definitions"], value_name = "RULE_NAME")]


### PR DESCRIPTION
- `explain --help` now lists available tags along with available rules. (rules >>> tag)
- add `-t TAG` flag to list all rules which uses that `TAG` in alphabetical order
- add `--definitions` to show WDL definitions in markdown format
- `explain [RULE]` now shows related lint rules

Closes: #80 

Maybe tags should be listed above rules ?

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
