### PR TITLE
fix: ignore failure to `publish` to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Update lock file
       run: cargo update
     - name: Publish to crates.io
-      run: cargo publish
+      run: cargo publish || true # Ignore errors if the version is already published
       env:
         CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
     - name: Create a GH release


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

continue on publish error.

Using `|| true` feels a bit hacky here, but there aren't great alternatives in the GH workflow syntax. We could alternatively use `if: always()` or similar in subsequent steps, but this seems mildly preferable.

Also of note, there's no flag to `cargo publish` that can be used to achieve this, which seems like a missing feature if you ask me

GH refs:
- https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#status-check-functions
- https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
