### PR TITLE
fix: adds `openssl` package to the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ COPY src/ src/
 
 RUN cargo build --release
 
-FROM debian:bookworm
+FROM debian:bookworm-slim
 
+RUN apt update && apt install openssl -y && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /tmp/sprocket/target/release/sprocket /opt/sprocket/bin/sprocket
 
 ENV PATH=/opt/sprocket/bin:$PATH


### PR DESCRIPTION
This commit adds the `openssl` package to the released Docker container. It also switches out the larger `debian:bookworm` image for the `debian:bookworm-slim`, which reduces the image by roughly 75MB.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
