### PR TITLE
ci: add stale PR closure

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,40 @@
+name: Close stale issues
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  check_stale_issues:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Close PRs
+        run: |
+          awaiting_labels=$(gh label list --json name --jq '.[] | select(.name | test("^S-awaiting")) | .name')
+          date=$(date --date='10 days ago' --utc +%Y-%m-%dT%H:%M:%SZ)
+          prs=""
+
+          for label in $awaiting_labels; do
+            pr_numbers=$(
+              gh api /repos/${{ github.repository }}/pulls --jq '.[] | select ((.labels | any(.name == "'$label'")) and .head.repo.pushed_at < "'$date'") | .number')
+            prs="$prs $pr_numbers"
+          done
+
+          for number in $prs; do
+            # Check if the PR is still open
+            if [ $(gh api /repos/${{ github.repository }}/pulls/$number --jq '.state') != "open" ]; then
+              continue
+            fi
+            gh issue comment $number --body "This PR has been awaiting action for \
+            more than 10 days with no response. Because of this inactivity, the PR \
+            is being closed. If you continue working on the PR, please comment here \
+            when it is ready for re-review."
+            gh issue close $number
+          done

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 jobs:
-  check_stale_issues:
+  check_stale_prs:
     runs-on: ubuntu-latest
 
     steps:
@@ -32,9 +32,9 @@ jobs:
             if [ $(gh api /repos/${{ github.repository }}/pulls/$number --jq '.state') != "open" ]; then
               continue
             fi
-            gh issue comment $number --body "This PR has been awaiting action for \
+            gh pr comment $number --body "This PR has been awaiting action for \
             more than 10 days with no response. Because of this inactivity, the PR \
             is being closed. If you continue working on the PR, please comment here \
             when it is ready for re-review."
-            gh issue close $number
+            gh pr close $number
           done

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: Close stale issues
+name: Close stale PRs
 
 on:
   schedule:


### PR DESCRIPTION
There are a number of stale PRs. This copies the same logic we use in the `wdl` repo.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
