### PR TITLE
feat: introduces incremental command line parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Introduced the `run` subcommand ([#102](https://github.com/stjude-rust-labs/sprocket/pull/102)).
+
 ### Changed
 
 * Unknown `--except` rules will now emit a warning instead of being silently ignored ([#94](https://github.com/stjude-rust-labs/sprocket/pull/94))
+* Changed the `validate-inputs` subcommand to the more concise `validate` subcommand ([#102](https://github.com/stjude-rust-labs/sprocket/pull/102)).
+* Changed all existing subcommands to use the facilities provided in `wdl-cli` when possible ([#102](https://github.com/stjude-rust-labs/sprocket/pull/102)).
+* Updates the underlying `wdl` dependency to v0.13.1 ([#102](https://github.com/stjude-rust-labs/sprocket/pull/102)).
+
 
 ## 0.11.0 - 04-01-2025
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,14 +27,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "ammonia"
-version = "4.0.0"
+name = "allocator-api2"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab99eae5ee58501ab236beb6f20f6ca39be615267b014899c89b2f0bc18a459"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "ammonia"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ada2ee439075a3e70b6992fce18ac4e407cd05aea9ca3f75d2c0b0c20bbb364"
 dependencies = [
+ "cssparser",
  "html5ever",
  "maplit",
- "once_cell",
  "tendril",
  "url",
 ]
@@ -106,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arraydeque"
@@ -136,7 +142,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -147,13 +153,13 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auto_impl"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -232,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34a796731680be7931955498a16a10b2270c7762963d5d570fdbfe02dcbf314f"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -299,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.5.1"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65268237be94042665b92034f979c42d431d2fd998b49809543afe3e66abad1c"
+checksum = "ced38439e7a86a4761f7f7d5ded5ff009135939ecb464a24452eaa4c1696af7d"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -309,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.5.1"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803c95b2ecf650eb10b5f87dda6b9f6a1b758cee53245e2b7b825c9b3803a443"
+checksum = "0ce61d2d3844c6b8d31b2353d9f66cf5e632b3e9549583fe3cac2f4f6136725e"
 dependencies = [
  "darling 0.20.11",
  "ident_case",
@@ -319,18 +325,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "bstr"
-version = "1.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
-dependencies = [
- "memchr",
- "regex-automata 0.4.9",
- "serde",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -347,9 +342,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "shlex",
 ]
@@ -368,9 +363,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -383,22 +378,12 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
-]
-
-[[package]]
-name = "clap-verbosity-flag"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c77f67047557f62582784fd7482884697731b2932c7d37ced54bce2312e1e2"
-dependencies = [
- "clap",
- "log",
 ]
 
 [[package]]
@@ -409,13 +394,14 @@ checksum = "2678fade3b77aa3a8ff3aae87e9c008d3fb00473a41c71fbf74e91c8c7b37e84"
 dependencies = [
  "clap",
  "log",
+ "tracing-core",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -432,7 +418,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -443,12 +429,13 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "codespan-reporting"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
 dependencies = [
+ "serde",
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -456,16 +443,6 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
-
-[[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "colored"
@@ -523,7 +500,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -585,9 +562,9 @@ dependencies = [
 
 [[package]]
 name = "crankshaft"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd386851d2dafe17c034ff80d5bc0c1e10301b48a32ffecbb0d7fa552081d037"
+checksum = "c4b3b078dc5c110d3e2dc3396909b2f4b516a013ea548467e889f224efd95fa5"
 dependencies = [
  "crankshaft-config",
  "crankshaft-engine",
@@ -595,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "crankshaft-config"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e262fe5ce939c3d6b7a8aa45ca3f2040a0dbc66ae88a2131def75ed7c6b3d22"
+checksum = "fc556efa065005f792a179b37ca38b64b4cde134650d564ba09b92f4b40a0a17"
 dependencies = [
  "bon",
  "config",
@@ -610,14 +587,14 @@ dependencies = [
 
 [[package]]
 name = "crankshaft-docker"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2212deafca625573bb9f7ef868d2f14524bd2d98490e3fe0f54226ee93fd8e"
+checksum = "72e6f6da2da70bf81bd3ff2d6f093995d9169f04783edacb4664e2c7c6193acf"
 dependencies = [
  "bollard",
  "bon",
  "futures",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "tar",
  "thiserror 2.0.12",
@@ -628,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "crankshaft-engine"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139a4d5c09fe918a89c9f9c133a9ef49196cc81d252115217ce0013ac7cb1840"
+checksum = "a18269fdab1246ad7b334bdafd9d06d392436ae698df11d03ceea8512efea076"
 dependencies = [
  "async-trait",
  "bollard",
@@ -640,9 +617,9 @@ dependencies = [
  "eyre",
  "futures",
  "growable-bloom-filter",
- "indexmap 2.8.0",
- "nonempty 0.11.0",
- "rand 0.9.0",
+ "indexmap 2.9.0",
+ "nonempty",
+ "rand 0.9.1",
  "regex",
  "shlex",
  "ssh2",
@@ -701,6 +678,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "darling"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,7 +745,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -767,7 +767,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -784,21 +784,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dbus"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bb21987b9fb1613058ba3843121dd18b163b254d8a6e797e144cbac14d96d1b"
-dependencies = [
- "libc",
- "libdbus-sys",
- "winapi",
-]
-
-[[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -849,7 +838,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -859,6 +848,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "dtoa"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6add3b8cff394282be81f3fc1a0605db594ed69890078ca6e2cab1c408bcf04"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
 ]
 
 [[package]]
@@ -890,9 +894,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -969,15 +973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ftree"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,7 +1044,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1103,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1152,7 +1147,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "time",
 ]
 
@@ -1176,9 +1171,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1186,7 +1181,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1207,10 +1202,12 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -1220,7 +1217,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -1237,16 +1234,14 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "html5ever"
-version = "0.27.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+checksum = "953cbbe631aae7fc0a112702ad5d3aaf09da38beaf45ea84610d6e1c358f569c"
 dependencies = [
  "log",
  "mac",
  "markup5ever",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "match_token",
 ]
 
 [[package]]
@@ -1605,7 +1600,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1654,12 +1649,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -1675,26 +1670,6 @@ dependencies = [
  "unicode-width 0.2.0",
  "vt100",
  "web-time",
-]
-
-[[package]]
-name = "inotify"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
-dependencies = [
- "bitflags 2.9.0",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -1758,26 +1733,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kqueue"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1785,19 +1740,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
-
-[[package]]
-name = "libdbus-sys"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06085512b750d640299b79be4bad3d2fa90a9c00b1fd9e1b46364f66f0485c72"
-dependencies = [
- "cc",
- "pkg-config",
-]
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libredox"
@@ -1807,7 +1752,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.10",
+ "redox_syscall 0.5.11",
 ]
 
 [[package]]
@@ -1848,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -1896,7 +1841,7 @@ dependencies = [
  "quote",
  "regex-syntax 0.8.5",
  "rustc_version",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1947,16 +1892,24 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup5ever"
-version = "0.12.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+checksum = "d0a8096766c229e8c88a3900c9b44b7e06aa7f7343cc229158c3e58ef8f9973a"
 dependencies = [
  "log",
- "phf",
- "phf_codegen",
- "string_cache",
- "string_cache_codegen",
  "tendril",
+ "web_atoms",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1987,7 +1940,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1998,25 +1951,24 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "miette"
-version = "7.5.0"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
  "cfg-if",
  "miette-derive",
- "thiserror 1.0.69",
  "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "miette-derive"
-version = "7.5.0"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf45bf44ab49be92fd1227a3be6fc6f617f1a337c06af54981048574d8783147"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2027,9 +1979,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -2041,7 +1993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -2077,49 +2028,9 @@ checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nonempty"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "303e8749c804ccd6ca3b428de7fe0d86cb86bc7606bc15291f100fd487960bb8"
-
-[[package]]
-name = "nonempty"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
-
-[[package]]
-name = "normpath"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8911957c4b1549ac0dc74e30db9c8b0e66ddcd6d7acc33098f4c63a64a6d7ed"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "notify"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
-dependencies = [
- "bitflags 2.9.0",
- "filetime",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio",
- "notify-types",
- "walkdir",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "notify-types"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "ntapi"
@@ -2162,6 +2073,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,22 +2097,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "opener"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0812e5e4df08da354c851a3376fead46db31c2214f849d3de356d774d057681"
-dependencies = [
- "bstr",
- "dbus",
- "normpath",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags 2.9.0",
  "cfg-if",
@@ -2211,7 +2119,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2222,9 +2130,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
@@ -2306,7 +2214,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.10",
+ "redox_syscall 0.5.11",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2368,7 +2276,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2384,12 +2292,14 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "7a98c6720655620a521dcc722d0ad66cd8afd5d86e34a89ef691c50b7b24de06"
 dependencies = [
  "fixedbitset",
- "indexmap 2.8.0",
+ "hashbrown 0.15.3",
+ "indexmap 2.9.0",
+ "serde",
 ]
 
 [[package]]
@@ -2398,6 +2308,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros",
  "phf_shared",
 ]
 
@@ -2419,6 +2330,19 @@ checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2447,7 +2371,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2507,19 +2431,19 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -2532,7 +2456,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "version_check",
 ]
 
@@ -2577,13 +2501,13 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
+checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -2597,9 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2637,13 +2561,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy",
 ]
 
 [[package]]
@@ -2672,7 +2595,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2715,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -2728,7 +2651,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.12",
 ]
@@ -2830,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e8975513bd9a7a43aad01030e79b3498e05db14e9d945df6483e8cf9b8c4c4"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2852,7 +2775,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "futures",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "http",
  "hyper",
  "parking_lot 0.11.2",
@@ -2875,6 +2798,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rev_buf_reader"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0f2e47e00e29920959826e2e1784728a3780d1a784247be5257258cc75f910"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2882,7 +2814,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2952,9 +2884,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -2965,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "once_cell",
  "ring",
@@ -3097,7 +3029,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3120,7 +3052,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3154,7 +3086,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3163,11 +3095,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml_ng"
-version = "0.9.36"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd24347956e682cf958c95e82deb9914cad4010d3efc035d579f81f4c426038c"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "ryu",
  "serde",
@@ -3176,9 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3195,6 +3127,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3202,9 +3143,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -3226,9 +3167,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
@@ -3247,18 +3188,22 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "clap-verbosity-flag 2.2.3",
+ "clap-verbosity-flag",
  "codespan-reporting",
- "colored 2.2.0",
+ "colored",
+ "futures",
  "git-testament",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "indicatif",
- "nonempty 0.10.0",
+ "nonempty",
  "pest",
  "pretty_assertions",
+ "serde_json",
  "tokio",
+ "tokio-util",
+ "toml",
  "tracing",
- "tracing-log",
+ "tracing-indicatif",
  "tracing-subscriber",
  "url",
  "walkdir",
@@ -3339,7 +3284,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3361,9 +3306,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3381,26 +3326,25 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
+ "objc2-core-foundation",
  "windows",
 ]
 
@@ -3521,7 +3465,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3532,7 +3476,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3612,9 +3556,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3637,14 +3581,14 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "tokio-metrics"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb2bb07a8451c4c6fa8b3497ad198510d8b8dffa5df5cfb97a64102a58b113c8"
+checksum = "7817b32d36c9b94744d7aa3f8fc13526aa0f5112009d7045f3c659413a6e44ac"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -3685,9 +3629,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3698,9 +3642,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3710,25 +3654,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tower"
@@ -3796,7 +3747,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3824,7 +3775,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3999,7 +3950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.2",
- "rand 0.9.0",
+ "rand 0.9.1",
  "uuid-macro-internal",
 ]
 
@@ -4011,7 +3962,7 @@ checksum = "72dcd78c4f979627a754f5522cea6e6a25e55139056535fe6e69c506cd64a862"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4133,7 +4084,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -4168,7 +4119,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4212,31 +4163,14 @@ dependencies = [
 
 [[package]]
 name = "wdl"
-version = "0.12.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda06c3856787386e41654a64b34c6706c3135eaaf99a36f7bad65d21619948f"
+checksum = "1a2e1bcef479acfcb2c46e512cda0328c0e82f6a8dedbd03965e515c1e0b5bad"
 dependencies = [
- "anyhow",
- "clap",
- "clap-verbosity-flag 3.0.2",
  "codespan-reporting",
- "colored 3.0.0",
- "futures",
- "indexmap 2.8.0",
- "indicatif",
- "notify",
- "opener",
- "serde_json",
- "tokio",
- "tokio-util",
- "toml",
- "tracing",
- "tracing-indicatif",
- "tracing-log",
- "tracing-subscriber",
- "url",
  "wdl-analysis",
  "wdl-ast",
+ "wdl-cli",
  "wdl-doc",
  "wdl-engine",
  "wdl-format",
@@ -4247,19 +4181,20 @@ dependencies = [
 
 [[package]]
 name = "wdl-analysis"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7df0e5c7600e39780ae813047bf938c398f7e7c25d7916235c56174ea8601f4"
+checksum = "334e317ba3d5657114237c8e48c73dca92ae5bea8d1572994745bb60fa5a9256"
 dependencies = [
  "anyhow",
  "convert_case 0.8.0",
  "futures",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "line-index",
  "parking_lot 0.12.3",
  "path-clean",
  "petgraph",
  "rayon",
+ "regex",
  "reqwest",
  "rowan",
  "tokio",
@@ -4273,9 +4208,9 @@ dependencies = [
 
 [[package]]
 name = "wdl-ast"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a312aefb813e8b97151869633147762748066c40b508bf6dc64f295aad5cfcc"
+checksum = "bb0a2184bc886a87725b8916cf86fe77d6c10290f26823a7da357c99de513edb"
 dependencies = [
  "macropol",
  "paste",
@@ -4286,14 +4221,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "wdl-doc"
-version = "0.2.0"
+name = "wdl-cli"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7ed174ea3b6e5c6f8cd216de1f738af1ca5f26e3c7ad7256b16babb45e4b36"
+checksum = "7a27b66db1ff9813d0710ae5a846206aca42581ff5d2d718698e1b5bb035634f"
+dependencies = [
+ "anyhow",
+ "codespan-reporting",
+ "futures",
+ "indexmap 2.9.0",
+ "nonempty",
+ "path-clean",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "shellexpand",
+ "thiserror 2.0.12",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wdl-analysis",
+ "wdl-ast",
+ "wdl-engine",
+ "wdl-lint",
+]
+
+[[package]]
+name = "wdl-doc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f8087e2f6d2e9796d7b1d864bedb7dbc29824d9877a2a4e42aa16d67035eb61"
 dependencies = [
  "ammonia",
  "anyhow",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "maud",
  "pathdiff",
  "pulldown-cmark",
@@ -4304,9 +4266,9 @@ dependencies = [
 
 [[package]]
 name = "wdl-engine"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5569a91807ecf8c265d20825da01c56f6069a37be0cc03639ecd6e1f9a354d"
+checksum = "3df7deed96b0b930154052a9a369fdfc36e4fb99ed5170c5c4768a2f56e1d344"
 dependencies = [
  "anyhow",
  "crankshaft",
@@ -4314,20 +4276,23 @@ dependencies = [
  "futures",
  "glob",
  "http-cache-stream-reqwest",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itertools",
- "nonempty 0.11.0",
+ "libc",
+ "nonempty",
  "ordered-float",
  "path-clean",
  "petgraph",
- "rand 0.9.0",
+ "rand 0.9.1",
  "regex",
  "reqwest",
  "reqwest-middleware",
+ "rev_buf_reader",
  "rowan",
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "shellexpand",
  "sysinfo",
  "tempfile",
  "tokio",
@@ -4341,19 +4306,19 @@ dependencies = [
 
 [[package]]
 name = "wdl-format"
-version = "0.5.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a342212cd27fd1712a8b01826a29f046fbc0ad4e70d1c62565d99ae38c4bd8"
+checksum = "afa125737770e6af91c315d9241659371901254e71fceb83388b2f63949d6cec"
 dependencies = [
- "nonempty 0.11.0",
+ "nonempty",
  "wdl-ast",
 ]
 
 [[package]]
 name = "wdl-grammar"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad842a9648f204d2cde62163f2f29f26d6d4a9d61bec0f3976cebd6483968f3c"
+checksum = "9f783d89bd7baa370a0be62ff1ed6b546f39ca10f8e4bd9b1be14e39b9cf71cd"
 dependencies = [
  "codespan-reporting",
  "itertools",
@@ -4364,31 +4329,33 @@ dependencies = [
 
 [[package]]
 name = "wdl-lint"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4780e6e85dcaf653bed5ff6cc48a05c3757c1fe94cf98a4d8471e9730507a499"
+checksum = "b4c0f5f74fc93e76c77574e5421583d36b0cc22915da7316c0d24011f7e2469f"
 dependencies = [
  "anyhow",
  "convert_case 0.8.0",
  "ftree",
- "indexmap 2.8.0",
- "rand 0.9.0",
+ "indexmap 2.9.0",
+ "rand 0.9.1",
  "rowan",
  "serde",
  "serde_json",
  "strsim 0.11.1",
  "tracing",
+ "url",
+ "wdl-analysis",
  "wdl-ast",
 ]
 
 [[package]]
 name = "wdl-lsp"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "141db95b605daee44d77a66413dead20a0d65fbbfec1403ec732f39e6f87a964"
+checksum = "dffb35be3d8c184ab62dc0214913e31902e9d991c8fc01b00762f50cdcf904be"
 dependencies = [
  "anyhow",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "line-index",
  "parking_lot 0.12.3",
  "serde_json",
@@ -4424,10 +4391,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.8"
+name = "web_atoms"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "08bcbdcad8fb2e316072ba6bbe09419afdb550285668ac2534f4230a6f2da0ee"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4438,7 +4417,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
- "redox_syscall 0.5.10",
+ "redox_syscall 0.5.11",
  "wasite",
  "web-sys",
 ]
@@ -4517,7 +4496,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4528,7 +4507,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4539,7 +4518,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4550,7 +4529,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4754,9 +4733,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
 dependencies = [
  "memchr",
 ]
@@ -4835,28 +4814,28 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4876,7 +4855,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -4905,5 +4884,5 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,21 +12,30 @@ readme = "README.md"
 
 [dependencies]
 anyhow = "1.0.91"
-clap = { version = "4.5.20", features = ["derive", "string"] }
-codespan-reporting = "0.11.1"
+chrono = "0.4.41"
+clap = { version = "4.5.37", features = ["derive", "string"] }
+clap-verbosity-flag = { version = "3.0.2", features = ["tracing"] }
+codespan-reporting = "0.12.0"
+colored = "3.0.0"
+futures = "0.3.31"
 git-testament = "0.2.5"
-indexmap = "2.6.0"
-nonempty = "0.10.0"
-pest = { version = "2.7.14", features = ["pretty-print"] }
-tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
-wdl = { version = "0.12.0", features = ["cli", "lsp"] }
-walkdir = "2.5.0"
-colored = "2.1.0"
-tokio = { version = "1.41.0", features = ["full"] }
-tracing-log = "0.2.0"
+indexmap = "2.9.0"
 indicatif = "0.17.8"
-clap-verbosity-flag = "2.2.2"
+nonempty = "0.11.0"
+pest = { version = "2.7.14", features = ["pretty-print"] }
 pretty_assertions = "1.4.1"
+serde_json = "1.0.140"
+tokio = { version = "1.41.0", features = ["full"] }
+tokio-util = "0.7.15"
+toml = "0.8.22"
+tracing = "0.1.40"
+tracing-indicatif = "0.3.9"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = "2.5.4"
-chrono = "0.4.39"
+walkdir = "2.5.0"
+wdl = { version = "0.13.1", features = [
+    "cli",
+    "codespan",
+    "engine",
+    "lsp",
+] }

--- a/README.md
+++ b/README.md
@@ -30,15 +30,17 @@
 
 ## 🎨 Features
 
-- **`sprocket analyzer`** Run Sprocket as a LSP server for IDE integration.
-- **`sprocket check`** Performs static analysis on WDL documents.
-- **`sprocket explain`** Explain lint rules.
-- **`sprocket format`** Formats WDL documents.
-- **`sprocket lint`** Performs static analysis on WDL documents with additional
-  linting rules enabled.
-- **`sprocket validate-inputs`** Validates an input JSON or YAML against a task or workflow input schema.
+- **`sprocket analyzer`** runs Sprocket as a LSP server, which is useful for IDE integration.
+- **`sprocket check`** performs static analysis on a document or directory of documents.
+- **`sprocket explain`** explains validation and lint rules supported by Sprocket.
+- **`sprocket format`** formats a document.
+- **`sprocket lint`** performs static analysis on a document or directory of documents with additional linting rules enabled (effectively a shortcut for `check --lint`).
+- **`sprocket run`** runs a task or workflow.
+- **`sprocket validate`** validates a set of inputs read from files or on the command line against a task or workflow.
 
 ## Guiding Principles
+
+The following are high-level guiding principles of the Sprocket project.
 
 - Provide a **high-performance** workflow execution engine capable of
   orchestrating massive bioinformatics workloads (the stated target is 20,000+

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -4,4 +4,5 @@ pub mod analyzer;
 pub mod check;
 pub mod explain;
 pub mod format;
+pub mod run;
 pub mod validate;

--- a/src/commands/analyzer.rs
+++ b/src/commands/analyzer.rs
@@ -1,4 +1,4 @@
-//! Implementation of the analyzer command.
+//! Implementation of the language server protocol (LSP) subcommand.
 
 use clap::Parser;
 use wdl::lsp::Server;
@@ -7,7 +7,7 @@ use wdl::lsp::ServerOptions;
 /// Arguments for the `analyzer` subcommand.
 #[derive(Parser, Debug)]
 #[command(author, version, about)]
-pub struct AnalyzerArgs {
+pub struct Args {
     /// Use stdin and stdout for the RPC transport.
     #[clap(long, required = true)]
     pub stdio: bool,
@@ -18,7 +18,7 @@ pub struct AnalyzerArgs {
 }
 
 /// Runs the `analyzer` command.
-pub async fn analyzer(args: AnalyzerArgs) -> anyhow::Result<()> {
+pub async fn analyzer(args: Args) -> anyhow::Result<()> {
     Server::run(ServerOptions {
         name: Some("Sprocket".into()),
         version: Some(env!("CARGO_PKG_VERSION").into()),

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,0 +1,353 @@
+//! Implementation of the `run` subcommand.
+
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use clap::Parser;
+use colored::Colorize as _;
+use futures::FutureExt as _;
+use indexmap::IndexSet;
+use indicatif::ProgressStyle;
+use tokio::select;
+use tokio_util::sync::CancellationToken;
+use tracing::Level;
+use tracing::error;
+use tracing_indicatif::span_ext::IndicatifSpanExt as _;
+use wdl::ast::AstNode as _;
+use wdl::cli::Analysis;
+use wdl::cli::Evaluator;
+use wdl::cli::Inputs;
+use wdl::cli::analysis::Source;
+use wdl::cli::inputs::OriginPaths;
+use wdl::engine::EvaluationError;
+use wdl::engine::Inputs as EngineInputs;
+use wdl::engine::v1::ProgressKind;
+
+use crate::Mode;
+use crate::emit_diagnostics;
+
+/// The delay in showing the progress bar.
+///
+/// This is to prevent the progress bar from flashing on the screen for
+/// very short analyses.
+const PROGRESS_BAR_DELAY_BEFORE_RENDER: Duration = Duration::from_secs(2);
+
+/// Arguments to the `run` subcommand.
+#[derive(Parser, Debug)]
+#[clap(disable_version_flag = true)]
+pub struct Args {
+    /// A source WDL file or URL.
+    #[clap(value_name = "PATH or URL")]
+    pub source: Source,
+
+    /// The inputs for the task or workflow.
+    ///
+    /// These inputs can be either paths to files containing inputs or key-value
+    /// pairs passed in on the command line.
+    pub inputs: Vec<String>,
+
+    /// The name of the task or workflow to run.
+    ///
+    /// If inputs are provided, this will be attempted to be inferred from the
+    /// prefixed names of the inputs (e.g, `<name>.<input-name>`).
+    ///
+    /// If no inputs are provided and this argument is not provided, it will be
+    /// assumed you're trying to run the workflow present in the specified WDL
+    /// document.
+    #[clap(short, long, value_name = "NAME")]
+    pub name: Option<String>,
+
+    /// The execution output directory; defaults to the task name if provided,
+    /// otherwise, `output`.
+    #[clap(short, long, value_name = "OUTPUT_DIR")]
+    pub output: Option<PathBuf>,
+
+    /// The path to the engine TOML configuration file.
+    #[clap(short, long, value_name = "CONFIG")]
+    pub config: Option<PathBuf>,
+
+    /// Overwrites the execution output directory if it exists.
+    #[clap(long)]
+    pub overwrite: bool,
+
+    /// Disables color output.
+    #[arg(long)]
+    pub no_color: bool,
+
+    /// The report mode.
+    #[arg(short = 'm', long, default_value_t, value_name = "MODE")]
+    pub report_mode: Mode,
+}
+
+/// Helper for displaying task ids.
+struct Ids<'a>(&'a IndexSet<String>);
+
+impl std::fmt::Display for Ids<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        /// The maximum number of executing task names to display at a time
+        const MAX_TASKS: usize = 10;
+
+        let mut first = true;
+        for (i, id) in self.0.iter().enumerate() {
+            if i == MAX_TASKS {
+                write!(f, "...")?;
+                break;
+            }
+
+            if first {
+                first = false;
+            } else {
+                write!(f, ", ")?;
+            }
+
+            write!(f, "{id}", id = id.magenta().bold())?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Represents state for reporting evaluation progress.
+#[derive(Default)]
+struct State {
+    /// The set of currently executing task identifiers.
+    ids: IndexSet<String>,
+    /// The number of completed tasks.
+    completed: usize,
+    /// The number of tasks awaiting execution.
+    ready: usize,
+    /// The number of currently executing tasks.
+    executing: usize,
+}
+
+/// A callback for updating state based on engine events.
+fn progress(kind: ProgressKind<'_>, pb: &tracing::Span, state: &Mutex<State>) {
+    pb.pb_start();
+
+    let message = {
+        let mut state = state.lock().expect("failed to lock progress mutex");
+        match kind {
+            ProgressKind::TaskStarted { .. } | ProgressKind::TaskRetried { .. } => {
+                state.ready += 1;
+            }
+            ProgressKind::TaskExecutionStarted { id } => {
+                state.ready -= 1;
+                state.executing += 1;
+                state.ids.insert(id.to_string());
+            }
+            ProgressKind::TaskExecutionCompleted { id, .. } => {
+                state.executing -= 1;
+                state.ids.swap_remove(id);
+            }
+            ProgressKind::TaskCompleted { .. } => {
+                state.completed += 1;
+            }
+            _ => {}
+        }
+
+        format!(
+            " - {c} {completed} task{s1}, {r} {ready} task{s2}, {e} {executing} task{s3}: {ids}",
+            c = state.completed,
+            completed = "completed".cyan(),
+            s1 = if state.completed == 1 { "" } else { "s" },
+            r = state.ready,
+            ready = "ready".cyan(),
+            s2 = if state.ready == 1 { "" } else { "s" },
+            e = state.executing,
+            executing = "executing".cyan(),
+            s3 = if state.executing == 1 { "" } else { "s" },
+            ids = Ids(&state.ids)
+        )
+    };
+
+    pb.pb_set_message(&message);
+}
+
+/// The main function for the `run` subcommand.
+pub async fn run(args: Args) -> Result<()> {
+    let style = ProgressStyle::with_template(
+        "[{elapsed_precise:.cyan/blue}] {bar:40.cyan/blue} {msg} {pos}/{len}",
+    )
+    .unwrap();
+
+    let span = tracing::span!(Level::WARN, "progress");
+    let start = std::time::Instant::now();
+
+    let results = match Analysis::default()
+        .add_source(args.source.clone())
+        .init({
+            let span = span.clone();
+            Box::new(move || {
+                span.pb_set_style(&style);
+            })
+        })
+        .progress({
+            let span = span.clone();
+            move |kind, completed, total| {
+                let span = span.clone();
+                async move {
+                    if start.elapsed() < PROGRESS_BAR_DELAY_BEFORE_RENDER {
+                        return;
+                    }
+
+                    if completed == 0 {
+                        span.pb_start();
+                        span.pb_set_length(total.try_into().unwrap());
+                        span.pb_set_message(&format!("{kind}"));
+                    }
+
+                    span.pb_set_position(completed.try_into().unwrap());
+                }
+                .boxed()
+            }
+        })
+        .run()
+        .await
+    {
+        Ok(results) => results,
+        Err(errors) => {
+            // SAFETY: this is a non-empty, so it must always have a first
+            // element.
+            bail!(errors.into_iter().next().unwrap())
+        }
+    };
+
+    // SAFETY: this must exist, as we added it as the only source to be analyzed
+    // above.
+    let document = results.filter(&[&args.source]).next().unwrap().document();
+
+    let output_dir = args
+        .output
+        .as_deref()
+        .unwrap_or_else(|| {
+            args.name
+                .as_ref()
+                .map(Path::new)
+                .unwrap_or_else(|| Path::new("output"))
+        })
+        .to_owned();
+
+    // Check to see if the output directory already exists and if it should be
+    // removed.
+    if output_dir.exists() {
+        if !args.overwrite {
+            bail!(
+                "output directory `{dir}` exists; use the `--overwrite` option to overwrite its \
+                 contents",
+                dir = output_dir.display()
+            );
+        }
+
+        std::fs::remove_dir_all(&output_dir).with_context(|| {
+            format!(
+                "failed to remove output directory `{dir}`",
+                dir = output_dir.display()
+            )
+        })?;
+    }
+
+    let config = args
+        .config
+        .map(|p| {
+            let contents = std::fs::read_to_string(&p).with_context(|| {
+                format!(
+                    "failed to read configuration file `{path}`",
+                    path = p.display(),
+                )
+            })?;
+
+            toml::from_str(&contents)
+                .with_context(|| format!("invalid configuration file `{path}`", path = p.display()))
+        })
+        .transpose()?
+        .unwrap_or_default();
+
+    let inferred = Inputs::coalesce(args.inputs)?.into_engine_inputs(document)?;
+
+    let (name, inputs, origins) = if let Some(inputs) = inferred {
+        inputs
+    } else {
+        let origins =
+            OriginPaths::from(std::env::current_dir().context("failed to get current directory")?);
+
+        if let Some(name) = args.name {
+            match (document.task_by_name(&name), document.workflow()) {
+                (Some(_), _) => (name, EngineInputs::Task(Default::default()), origins),
+                (None, Some(workflow)) => {
+                    if workflow.name() == name {
+                        (name, EngineInputs::Workflow(Default::default()), origins)
+                    } else {
+                        bail!("no task or workflow with name `{name}` was found")
+                    }
+                }
+                (None, None) => bail!("no task or workflow with name `{name}` was found"),
+            }
+        } else if let Some(workflow) = document.workflow() {
+            (
+                workflow.name().to_owned(),
+                EngineInputs::Workflow(Default::default()),
+                origins,
+            )
+        } else {
+            bail!(
+                "no workflow was found in `{path}`; either specify a document with a workflow or \
+                 use the `-n` option to refer to a specific task or workflow by name",
+                path = args.source
+            )
+        }
+    };
+
+    let run_kind = match &inputs {
+        EngineInputs::Task(_) => "task",
+        EngineInputs::Workflow(_) => "workflow",
+    };
+
+    span.pb_set_style(
+        &ProgressStyle::with_template(&format!(
+            "[{{elapsed_precise:.cyan/blue}}] {{spinner:.cyan/blue}} {running} {run_kind} \
+             {name}{{msg}}",
+            running = "running".cyan(),
+            name = name.magenta().bold()
+        ))
+        .unwrap(),
+    );
+
+    let state = Mutex::<State>::default();
+    let evaluator = Evaluator::new(document, &name, inputs, origins, config, &output_dir);
+    let token = CancellationToken::new();
+
+    let mut evaluate = evaluator
+        .run(token.clone(), move |kind: ProgressKind<'_>| {
+            progress(kind, &span, &state);
+            async {}
+        })
+        .boxed();
+
+    select! {
+        // Always prefer the CTRL-C signal to the evaluation returning.
+        biased;
+
+        _ = tokio::signal::ctrl_c() => {
+            error!("execution was interrupted: waiting for evaluation to abort");
+            token.cancel();
+            evaluate.await.ok();
+            bail!("execution was aborted");
+        },
+        res = &mut evaluate => match res {
+            Ok(outputs) => {
+                println!("{outputs}", outputs = serde_json::to_string_pretty(&outputs)?);
+                Ok(())
+            }
+            Err(EvaluationError::Source(e)) => {
+                emit_diagnostics(&e.document.path(), e.document.root().text().to_string(), &[e.diagnostic], &e.backtrace, args.report_mode, args.no_color)?;
+                bail!("aborting due to evaluation error");
+            }
+            Err(EvaluationError::Other(e)) => Err(e)
+        },
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,18 +7,31 @@
 #![warn(clippy::missing_docs_in_private_items)]
 #![warn(rustdoc::broken_intra_doc_links)]
 
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::io::IsTerminal as _;
+use std::io::Write as _;
 use std::sync::LazyLock;
 
+use anyhow::Context as _;
+use anyhow::Result;
 use clap::ValueEnum;
-use codespan_reporting::files::SimpleFile;
+use codespan_reporting::diagnostic::Label;
+use codespan_reporting::diagnostic::LabelStyle;
+use codespan_reporting::files::SimpleFiles;
 use codespan_reporting::term::Config;
 use codespan_reporting::term::DisplayStyle;
 use codespan_reporting::term::emit;
 use codespan_reporting::term::termcolor::ColorChoice;
 use codespan_reporting::term::termcolor::StandardStream;
+use wdl::ast::AstNode as _;
 use wdl::ast::Diagnostic;
+use wdl::engine::CallLocation;
 
 pub mod commands;
+
+/// The maximum number of call locations to print for evaluation errors.
+const MAX_CALL_LOCATIONS: usize = 10;
 
 /// Configuration for full display style.
 static FULL_CONFIG: LazyLock<Config> = LazyLock::new(|| Config {
@@ -52,7 +65,7 @@ impl std::fmt::Display for Mode {
     }
 }
 
-/// Gets the display config to use for reporting diagnostics.
+/// Gets the display configuration based on the user's preferences.
 fn get_display_config(report_mode: Mode, no_color: bool) -> (&'static Config, StandardStream) {
     let config = match report_mode {
         Mode::Full => &FULL_CONFIG,
@@ -61,28 +74,66 @@ fn get_display_config(report_mode: Mode, no_color: bool) -> (&'static Config, St
 
     let color_choice = if no_color {
         ColorChoice::Never
-    } else {
+    } else if std::io::stderr().is_terminal() {
         ColorChoice::Always
+    } else {
+        ColorChoice::Never
     };
 
-    let writer = StandardStream::stderr(color_choice);
+    let stream = StandardStream::stderr(color_choice);
 
-    (config, writer)
+    (config, stream)
 }
 
 /// Emits the given diagnostics to the terminal.
 fn emit_diagnostics<'a>(
+    path: &str,
+    source: String,
     diagnostics: impl IntoIterator<Item = &'a Diagnostic>,
-    file_name: &str,
-    source: &str,
+    backtrace: &[CallLocation],
     report_mode: Mode,
     no_color: bool,
-) {
-    let file = SimpleFile::new(file_name, source);
+) -> Result<()> {
+    let mut map = HashMap::new();
+    let mut files = SimpleFiles::new();
 
-    let (config, writer) = get_display_config(report_mode, no_color);
-    let mut writer = writer.lock();
+    let file_id = files.add(Cow::Borrowed(path), source);
+
+    let (config, mut stream) = get_display_config(report_mode, no_color);
+
     for diagnostic in diagnostics {
-        emit(&mut writer, config, &file, &diagnostic.to_codespan()).unwrap();
+        let diagnostic = diagnostic.to_codespan(file_id).with_labels_iter(
+            backtrace.iter().take(MAX_CALL_LOCATIONS).map(|l| {
+                let id = l.document.id();
+                let file_id = *map.entry(id).or_insert_with(|| {
+                    files.add(l.document.path(), l.document.root().text().to_string())
+                });
+
+                Label {
+                    style: LabelStyle::Secondary,
+                    file_id,
+                    range: l.span.start()..l.span.end(),
+                    message: "called from this location".into(),
+                }
+            }),
+        );
+
+        emit(&mut stream, config, &files, &diagnostic).context("failed to emit diagnostic")?;
+
+        if backtrace.len() > MAX_CALL_LOCATIONS {
+            writeln!(
+                &mut stream,
+                "  and {count} more call{s}...",
+                count = backtrace.len() - MAX_CALL_LOCATIONS,
+                s = if backtrace.len() - MAX_CALL_LOCATIONS == 1 {
+                    ""
+                } else {
+                    "s"
+                }
+            )
+            .unwrap();
+        }
     }
+
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,44 +6,47 @@ use std::io::stderr;
 use clap::Parser;
 use clap::Subcommand;
 use clap_verbosity_flag::Verbosity;
+use clap_verbosity_flag::WarnLevel;
 use colored::Colorize;
 use git_testament::git_testament;
 use git_testament::render_testament;
 use sprocket::commands;
-use tracing_log::AsTrace;
+use tracing_subscriber::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt as _;
 
 git_testament!(TESTAMENT);
 
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
-    /// Checks a WDL document (or a directory containing WDL documents) and
-    /// reports diagnostics.
+    /// Runs the Language Server Protocol (LSP) server.
+    Analyzer(commands::analyzer::Args),
+
+    /// Checks a document or a directory containing documents.
     Check(commands::check::CheckArgs),
 
-    /// Lints Workflow Description Language files.
-    Lint(commands::check::LintArgs),
-
-    /// Explains a rule.
+    /// Explains linting and validation rules.
     Explain(commands::explain::Args),
 
-    /// Runs the analyzer LSP server.
-    Analyzer(commands::analyzer::AnalyzerArgs),
-
-    /// Formats a WDL document.
+    /// Formats a document.
     #[clap(alias = "fmt")]
-    Format(commands::format::FormatArgs),
+    Format(commands::format::Args),
 
-    /// Validates an input JSON or YAML file against a task or workflow input
-    /// schema.
+    /// Lints a document or a directory containing documents.
+    Lint(commands::check::LintArgs),
+
+    /// Runs a task or workflow.
+    Run(commands::run::Args),
+
+    /// Validate a set of inputs against a task or workflow.
     ///
     /// This ensures that every required input is supplied, every supplied input
     /// is correctly typed, that no extraneous inputs are provided, and that any
     /// provided `File` or `Directory` inputs exist.
     ///
-    /// It will not catch potential runtime errors that
-    /// may occur when running the task or workflow.
-    ValidateInputs(commands::validate::ValidateInputsArgs),
+    /// It will not catch potential runtime errors that may occur when running
+    /// the task or workflow.
+    Validate(commands::validate::Args),
 }
 
 #[derive(Parser)]
@@ -53,28 +56,47 @@ struct Cli {
     pub command: Commands,
 
     #[command(flatten)]
-    verbose: Verbosity,
+    verbosity: Verbosity<WarnLevel>,
 }
 
 pub async fn inner() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
-    tracing_log::LogTracer::init()?;
+    match std::env::var("RUST_LOG") {
+        Ok(_) => {
+            let indicatif_layer = tracing_indicatif::IndicatifLayer::new();
 
-    let subscriber = tracing_subscriber::fmt::Subscriber::builder()
-        .with_max_level(cli.verbose.log_level_filter().as_trace())
-        .with_writer(std::io::stderr)
-        .with_ansi(stderr().is_terminal())
-        .finish();
-    tracing::subscriber::set_global_default(subscriber)?;
+            let subscriber = tracing_subscriber::fmt::Subscriber::builder()
+                .with_env_filter(EnvFilter::from_default_env())
+                .with_writer(indicatif_layer.get_stderr_writer())
+                .with_ansi(stderr().is_terminal())
+                .finish()
+                .with(indicatif_layer);
+
+            tracing::subscriber::set_global_default(subscriber)?;
+        }
+        Err(_) => {
+            let indicatif_layer = tracing_indicatif::IndicatifLayer::new();
+
+            let subscriber = tracing_subscriber::fmt()
+                .with_max_level(cli.verbosity)
+                .with_writer(indicatif_layer.get_stderr_writer())
+                .with_ansi(stderr().is_terminal())
+                .finish()
+                .with(indicatif_layer);
+
+            tracing::subscriber::set_global_default(subscriber)?;
+        }
+    };
 
     match cli.command {
-        Commands::Check(args) => commands::check::check(args).await,
-        Commands::Lint(args) => commands::check::lint(args).await,
-        Commands::Explain(args) => commands::explain::explain(args),
         Commands::Analyzer(args) => commands::analyzer::analyzer(args).await,
+        Commands::Check(args) => commands::check::check(args).await,
+        Commands::Explain(args) => commands::explain::explain(args),
         Commands::Format(args) => commands::format::format(args),
-        Commands::ValidateInputs(args) => commands::validate::validate_inputs(args).await,
+        Commands::Lint(args) => commands::check::lint(args).await,
+        Commands::Run(args) => commands::run::run(args).await,
+        Commands::Validate(args) => commands::validate::validate(args).await,
     }
 }
 


### PR DESCRIPTION
This commit is the second half of the changes needed to land incremental command line parsing into `sprocket`. The first half is at https://github.com/stjude-rust-labs/wdl/pull/430.

As indicated in the changes there, this commit also has the side effect of removing the `wdl` command line tool and putting all of the subcommands in `sprocket` instead. As such, you'll see many commands be modified to use the code created in the new `wdl-cli` package _OR_ brand new subcommands (like `run`).

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the `wdl` crates' [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
