### PR TITLE
fix: print diagnostics for `sprocket run`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Fix `sprocket run` not printing analysis diagnostics ([#110](https://github.com/stjude-rust-labs/sprocket/pull/110)).
+
 ## 0.12.1 - 05-05-2025
 
 ### Fixed

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -40,7 +40,7 @@ pub struct Common {
     #[clap(long)]
     pub deny_notes: bool,
 
-    /// Supress diagnostics from documents that were not explicitly provided in
+    /// Suppress diagnostics from documents that were not explicitly provided in
     /// the sources list (i.e., were imported from a provided source).
     ///
     /// If the sources list contains a directory, an error will be raised.


### PR DESCRIPTION
This commit fixes a failure to print diagnostics after the analysis performed by `sprocket run`.

If the diagnostics contain any errors, the command aborts before evaluation is attempted.

Fixes #108.
Fixes #109.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the `wdl` crates' [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
