### PR TITLE
feat: add shellcheck to dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added tab completions for `sprocket` commands ([#105](https://github.com/stjude-rust-labs/sprocket/pull/105)).
+* Added `shellcheck` to Dockerfile ([#114](https://github.com/stjude-rust-labs/sprocket/pull/114)).
 
 ## 0.12.2 - 05-05-2025
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN cargo build --release
 
 FROM debian:bookworm-slim
 
-RUN apt update && apt install openssl ca-certificates -y && rm -rf /var/lib/apt/lists/*
+RUN apt update && apt install -y openssl ca-certificates shellcheck && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /tmp/sprocket/target/release/sprocket /opt/sprocket/bin/sprocket
 
 ENV PATH=/opt/sprocket/bin:$PATH


### PR DESCRIPTION
closes #112 

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the `wdl` crates' [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).

```sh
➜  sprocket git:(shellcheck) ✗ docker build -t sprocket .
[+] Building 435.2s (14/14) FINISHED                                                                                                           docker:default
 => [internal] load build definition from Dockerfile                                                                                                     0.1s
 => => transferring dockerfile: 447B                                                                                                                     0.0s
 => [internal] load metadata for docker.io/library/debian:bookworm-slim                                                                                  3.2s
 => [internal] load metadata for docker.io/library/rust:1.85                                                                                             4.5s
 => [internal] load .dockerignore                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                          0.0s
 => [builder 1/5] FROM docker.io/library/rust:1.85@sha256:e51d0265072d2d9d5d320f6a44dde6b9ef13653b035098febd68cce8fa7c0bc4                             170.6s
 => => resolve docker.io/library/rust:1.85@sha256:e51d0265072d2d9d5d320f6a44dde6b9ef13653b035098febd68cce8fa7c0bc4                                       0.1s
 => => sha256:e51d0265072d2d9d5d320f6a44dde6b9ef13653b035098febd68cce8fa7c0bc4 7.75kB / 7.75kB                                                           0.0s
 => => sha256:bf7d87666c4da6eace19e06d21bc4859c6e2a5c97a21ac273b0e082112753cf0 1.94kB / 1.94kB                                                           0.0s
 => => sha256:d206fa34784c1c49e05c636e682892881896cce563bda7ca0b4cd96e159c8806 4.36kB / 4.36kB                                                           0.0s
 => => sha256:7cd785773db44407e20a679ce5439222e505475eed5b99f1910eb2cda51729ab 48.47MB / 48.47MB                                                        37.2s
 => => sha256:255774e0027b72d2327719e78dbad5ad8c9cf446d055e45be7fc149418470bae 64.40MB / 64.40MB                                                        64.3s
 => => sha256:091eb8249475f42de217265c501e0186f0a3ea7490ef7f51458c30db91fb3cac 24.01MB / 24.01MB                                                        16.6s
 => => sha256:353e14e5cc47664fba714a7da288001d90427c705494847ac773f5cc08199451 211.35MB / 211.35MB                                                     153.0s
 => => sha256:50edd9a93fcd3168d25021d6d0863290a0ce5692f406e0614ce3c8cef848babd 193.71MB / 193.71MB                                                     157.3s
 => => extracting sha256:7cd785773db44407e20a679ce5439222e505475eed5b99f1910eb2cda51729ab                                                                3.1s
 => => extracting sha256:091eb8249475f42de217265c501e0186f0a3ea7490ef7f51458c30db91fb3cac                                                                0.9s
 => => extracting sha256:255774e0027b72d2327719e78dbad5ad8c9cf446d055e45be7fc149418470bae                                                                3.9s
 => => extracting sha256:353e14e5cc47664fba714a7da288001d90427c705494847ac773f5cc08199451                                                               11.7s
 => => extracting sha256:50edd9a93fcd3168d25021d6d0863290a0ce5692f406e0614ce3c8cef848babd                                                                5.3s
 => [stage-1 1/3] FROM docker.io/library/debian:bookworm-slim@sha256:4b50eb66f977b4062683ff434ef18ac191da862dbe966961bc11990cf5791a8d                   86.1s
 => => resolve docker.io/library/debian:bookworm-slim@sha256:4b50eb66f977b4062683ff434ef18ac191da862dbe966961bc11990cf5791a8d                            0.1s
 => => sha256:4b50eb66f977b4062683ff434ef18ac191da862dbe966961bc11990cf5791a8d 8.56kB / 8.56kB                                                           0.0s
 => => sha256:5accafaaf0f2c0a3ee5f2dcd9a5f2ef7ed3089fe4ac6a9fc9b1cf16396571322 1.02kB / 1.02kB                                                           0.0s
 => => sha256:59429810452a41b3c3c45ec3ad270e50f10db1100edc71b175728a04e1bb97ad 453B / 453B                                                               0.0s
 => => sha256:254e724d77862dc53abbd3bf0e27f9d2f64293909cdd3d0aad6a8fe5a6680659 28.23MB / 28.23MB                                                        83.0s
 => => extracting sha256:254e724d77862dc53abbd3bf0e27f9d2f64293909cdd3d0aad6a8fe5a6680659                                                                2.7s
 => [internal] load build context                                                                                                                        0.1s
 => => transferring context: 171.48kB                                                                                                                    0.0s
 => [stage-1 2/3] RUN apt update && apt install openssl ca-certificates -y shellcheck && rm -rf /var/lib/apt/lists/*                                    16.0s
 => [builder 2/5] WORKDIR /tmp/sprocket                                                                                                                  0.4s
 => [builder 3/5] COPY Cargo.lock Cargo.toml ./                                                                                                          0.3s
 => [builder 4/5] COPY src/ src/                                                                                                                         0.2s
 => [builder 5/5] RUN cargo build --release                                                                                                            258.3s
 => [stage-1 3/3] COPY --from=builder /tmp/sprocket/target/release/sprocket /opt/sprocket/bin/sprocket                                                   0.1s
 => exporting to image                                                                                                                                   0.3s
 => => exporting layers                                                                                                                                  0.3s
 => => writing image sha256:575aabc96e54455fc2c47e5f0b3c3c1210573179903d2847f14a5d599dabba0a                                                             0.0s
 => => naming to docker.io/library/sprocket                                                                                                              0.0s

What's Next?
  View a summary of image vulnerabilities and recommendations → docker scout quickview
```
