### PR TITLE
fix: do not flatten engine configuration as optional.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed run configuration to not use a default configuration when there is an
+  error in the flattened engine configuration fields ([#124](https://github.com/stjude-rust-labs/sprocket/pull/124)).
 * The `sprocket run`, `sprocket validate`, and `sprocket inputs` commands will
   no longer require the `--name` option if passed a WDL document containing a
   single task and no workflow ([#121](github.com/stjude-rust-labs/sprocket/pull/121)).

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -90,7 +90,7 @@ pub struct Args {
 impl Args {
     /// Applies the configuration to the arguments.
     pub fn apply(mut self, config: crate::config::Config) -> Self {
-        self.engine = config.run.engine;
+        self.engine = Some(config.run.engine);
         self.no_color = self.no_color || !config.common.color;
         self.report_mode = match self.report_mode {
             Some(mode) => Some(mode),

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,7 +95,7 @@ pub struct CheckConfig {
 pub struct RunConfig {
     /// The engine configuration.
     #[serde(flatten)]
-    pub engine: Option<engine::config::Config>,
+    pub engine: engine::config::Config,
 }
 
 impl Config {


### PR DESCRIPTION
Currently we flatten the engine configuration into the `run` configuration as `Option`. This has the unintended consequence of turning errors in deserializing a field within the engine configuration into a `None` for the entire engine configuration.

The result is implicitly using a default engine configuration when an engine configuration field fails to deserialize due to a call to `unwrap_or_default`.

The fix is to not make `engine` in the run configuration `Option`.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the `wdl` crates' [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
