### PR TITLE
revise: adds a default source for the `check`, `format`, and `lint` subcommands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Removed the `--config` option of `sprocket run`; the run command's
   configuration is now merged into `sprocket.toml` under the `run` section ([#121](github.com/stjude-rust-labs/sprocket/pull/121))
+* Added the current working directory as the default source for the `check`,
+  `format` and `lint` subcommands
+  ([#127](github.com/stjude-rust-labs/sprocket/pull/127)).
 
 ### Fixed
 

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -17,6 +17,7 @@ use wdl::lint::find_nearest_rule;
 
 use super::explain::ALL_RULE_IDS;
 use crate::Mode;
+use crate::cwd_source;
 use crate::emit_diagnostics;
 use crate::get_display_config;
 
@@ -25,7 +26,7 @@ use crate::get_display_config;
 #[command(author, version, about)]
 pub struct Common {
     /// A set of source documents as files, directories, or URLs.
-    #[clap(value_name = "PATH or URL")]
+    #[clap(value_name = "PATH or URL", default_values_t = cwd_source())]
     pub sources: Vec<Source>,
 
     /// Excepts (ignores) an analysis or lint rule.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,8 +143,10 @@ fn emit_diagnostics<'a>(
     Ok(())
 }
 
-/// Returns a vectory containing a single source for the current working
+/// Returns a vector containing a single source for the current working
 /// directory.
 fn cwd_source() -> Vec<Source> {
-    vec![Source::Directory(PathBuf::from("."))]
+    vec![Source::Directory(PathBuf::from(
+        std::path::Component::CurDir.as_os_str(),
+    ))]
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use std::borrow::Cow;
 use std::collections::HashMap;
 use std::io::IsTerminal as _;
 use std::io::Write as _;
+use std::path::PathBuf;
 use std::sync::LazyLock;
 
 use anyhow::Context as _;
@@ -28,6 +29,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use wdl::ast::AstNode as _;
 use wdl::ast::Diagnostic;
+use wdl::cli::analysis::Source;
 use wdl::engine::CallLocation;
 
 pub mod commands;
@@ -139,4 +141,10 @@ fn emit_diagnostics<'a>(
     }
 
     Ok(())
+}
+
+/// Returns a vectory containing a single source for the current working
+/// directory.
+fn cwd_source() -> Vec<Source> {
+    vec![Source::Directory(PathBuf::from("."))]
 }


### PR DESCRIPTION
This PR adds default sources for the `check`, `format`, and `lint` subcommands. All of these default to the current directory.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the `wdl` crates' [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [ ] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
