### PR TITLE
Fix run output missing workflow/task name prefix

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -401,7 +401,7 @@ pub async fn run(args: Args) -> Result<()> {
         },
         res = &mut evaluate => match res {
             Ok(outputs) => {
-                println!("{outputs}", outputs = serde_json::to_string_pretty(&outputs)?);
+                println!("{outputs}", outputs = serde_json::to_string_pretty(&outputs.with_name(&name))?);
                 Ok(())
             }
             Err(EvaluationError::Source(e)) => {


### PR DESCRIPTION
Fixes #130 by adding the workflow/task prefix to run outputs.

- [x] You have read the `wdl` crates' [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
