### PR TITLE
chore: use `cargo install` and readonly mount for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM rust:1.85 AS builder
 
+# Install Sprocket by invoking `cargo install` on the sources in the current directory. The `mount`
+# directive provides the current directory to the `builder` container, so no unnecessary copying is
+# performed into `builder`.
 WORKDIR /tmp/sprocket
-
-COPY Cargo.lock Cargo.toml ./
-COPY src/ src/
-
-RUN cargo build --release
+RUN --mount=type=bind,source=.,target=/tmp/sprocket,readonly \
+    cargo install --target-dir /tmp/sprocket-target --root /tmp/sprocket-root --path .
 
 FROM debian:bookworm-slim
 
 RUN apt update && apt install -y openssl ca-certificates shellcheck && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /tmp/sprocket/target/release/sprocket /opt/sprocket/bin/sprocket
+COPY --from=builder /tmp/sprocket-root/bin/sprocket /opt/sprocket/bin/sprocket
 
 ENV PATH=/opt/sprocket/bin:$PATH
 


### PR DESCRIPTION
This approach will not be subject to breakage if/when the `sprocket` crate develops additional dependencies on files outside of what we manually specify in the Dockerfile, but uses a `mount` directive to avoid the potential for unnecessary copying into the builder image.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
