### PR TITLE
feat: new and improved output dir logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 **/Cargo.lock
 
 rustc-ice*
+
+runs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added new default output directory logic ([#149](https://github.com/stjude-rust-labs/sprocket/pull/149)).
+
 ### Changed
 
 * `--name` option renamed to `--entrypoint` for `validate` and `run` ([#147](https://github.com/stjude-rust-labs/sprocket/pull/147)).
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Output directory logic for the `run` command now always uses the workflow or task name by default ([#148](https://github.com/stjude-rust-labs/sprocket/pull/148)).
+    * this logic replaced in [#149](https://github.com/stjude-rust-labs/sprocket/pull/149).
 
 ## 0.14.1 - 07-10-2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * `--entrypoint` is now required if no inputs are provided.
     * `--entrypoint` will be prefixed to the key of any key-value pairs supplied on the command line.
 
-### Fixed
-
-* Output directory logic for the `run` command now always uses the workflow or task name by default ([#148](https://github.com/stjude-rust-labs/sprocket/pull/148)).
-    * this logic was replaced in [#149](https://github.com/stjude-rust-labs/sprocket/pull/149).
-
 ## 0.14.1 - 07-10-2025
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Output directory logic for the `run` command now always uses the workflow or task name by default ([#148](https://github.com/stjude-rust-labs/sprocket/pull/148)).
-    * this logic replaced in [#149](https://github.com/stjude-rust-labs/sprocket/pull/149).
+    * this logic was replaced in [#149](https://github.com/stjude-rust-labs/sprocket/pull/149).
 
 ## 0.14.1 - 07-10-2025
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4437,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "wdl"
 version = "0.15.1"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f#f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
 dependencies = [
  "codespan-reporting",
  "wdl-analysis",
@@ -4454,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "wdl-analysis"
 version = "0.10.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f#f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
 dependencies = [
  "anyhow",
  "convert_case 0.8.0",
@@ -4483,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "wdl-ast"
 version = "0.14.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f#f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
 dependencies = [
  "macropol",
  "paste",
@@ -4496,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "wdl-cli"
 version = "0.3.1"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f#f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4522,7 +4522,7 @@ dependencies = [
 [[package]]
 name = "wdl-doc"
 version = "0.5.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f#f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "wdl-engine"
 version = "0.5.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f#f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "wdl-format"
 version = "0.8.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f#f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
 dependencies = [
  "nonempty",
  "wdl-ast",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "wdl-grammar"
 version = "0.14.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f#f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
 dependencies = [
  "codespan-reporting",
  "logos",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "wdl-lint"
 version = "0.13.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f#f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
 dependencies = [
  "anyhow",
  "convert_case 0.8.0",
@@ -4623,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "wdl-lsp"
 version = "0.10.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f#f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml 0.9.2",
+ "toml 0.9.3",
  "winnow",
  "yaml-rust2",
 ]
@@ -3046,9 +3046,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "once_cell",
  "ring",
@@ -3873,9 +3873,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "e06723639aaded957e5a80be250c1f82f274b9d23ebb4d94163668470623461c"
 dependencies = [
  "serde",
  "serde_spanned 1.0.0",
@@ -4058,9 +4058,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-indicatif"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c714cc8fc46db04fcfddbd274c6ef59bebb1b435155984e7c6e89c3ce66f200"
+checksum = "e1983afead46ff13a3c93581e0cec31d20b29efdd22cbdaa8b9f850eccf2c352"
 dependencies = [
  "indicatif",
  "tracing",
@@ -4437,7 +4437,7 @@ dependencies = [
 [[package]]
 name = "wdl"
 version = "0.15.1"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4#3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4"
 dependencies = [
  "codespan-reporting",
  "wdl-analysis",
@@ -4454,7 +4454,7 @@ dependencies = [
 [[package]]
 name = "wdl-analysis"
 version = "0.10.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4#3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4"
 dependencies = [
  "anyhow",
  "convert_case 0.8.0",
@@ -4483,7 +4483,7 @@ dependencies = [
 [[package]]
 name = "wdl-ast"
 version = "0.14.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4#3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4"
 dependencies = [
  "macropol",
  "paste",
@@ -4496,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "wdl-cli"
 version = "0.3.1"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4#3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4522,7 +4522,7 @@ dependencies = [
 [[package]]
 name = "wdl-doc"
 version = "0.5.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4#3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -4541,7 +4541,7 @@ dependencies = [
 [[package]]
 name = "wdl-engine"
 version = "0.5.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4#3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4581,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "wdl-format"
 version = "0.8.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4#3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4"
 dependencies = [
  "nonempty",
  "wdl-ast",
@@ -4590,7 +4590,7 @@ dependencies = [
 [[package]]
 name = "wdl-grammar"
 version = "0.14.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4#3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4"
 dependencies = [
  "codespan-reporting",
  "logos",
@@ -4603,7 +4603,7 @@ dependencies = [
 [[package]]
 name = "wdl-lint"
 version = "0.13.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4#3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4"
 dependencies = [
  "anyhow",
  "convert_case 0.8.0",
@@ -4623,7 +4623,7 @@ dependencies = [
 [[package]]
 name = "wdl-lsp"
 version = "0.10.0"
-source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=11e43537697a4d9d2652f701bb3f2b1cc44bdd4e#11e43537697a4d9d2652f701bb3f2b1cc44bdd4e"
+source = "git+https://github.com/stjude-rust-labs/wdl.git?rev=3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4#3f8f214d66c54d2c6cd7817c0c6aba8f61ec72b4"
 dependencies = [
  "anyhow",
  "indexmap 2.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ tracing-indicatif = "0.3.9"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = "2.5.4"
 walkdir = "2.5.0"
-wdl = { version = "0.15.1", features = ["cli", "codespan", "engine", "lsp", "doc"], git = "https://github.com/stjude-rust-labs/wdl.git", rev = "f7ba4c0d16a6b16c7b3bf7d302658799a0eed77f" }
+wdl = { version = "0.15.1", features = ["cli", "codespan", "engine", "lsp", "doc"], git = "https://github.com/stjude-rust-labs/wdl.git", rev = "11e43537697a4d9d2652f701bb3f2b1cc44bdd4e" }
 [dev-dependencies]
 shlex = "1.3.0"
 walkdir = "2.5.0"

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -103,10 +103,9 @@ impl CheckArgs {
         self.common.deny_notes = self.common.deny_notes || config.check.deny_notes;
         self.common.hide_notes = self.common.hide_notes || config.check.hide_notes;
         self.common.no_color = self.common.no_color || !config.common.color;
-        self.common.report_mode = match self.common.report_mode {
-            Some(mode) => Some(mode),
-            None => Some(config.common.report_mode),
-        };
+        if self.common.report_mode.is_none() {
+            self.common.report_mode = Some(config.common.report_mode);
+        }
 
         self
     }

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -73,19 +73,16 @@ impl Args {
     /// Applies the configuration to the command arguments.
     pub fn apply(mut self, config: crate::config::Config) -> Self {
         self.no_color = self.no_color || !config.common.color;
-        self.report_mode = match self.report_mode {
-            Some(mode) => Some(mode),
-            None => Some(config.common.report_mode),
-        };
+        if self.report_mode.is_none() {
+            self.report_mode = Some(config.common.report_mode);
+        }
         self.with_tabs = self.with_tabs || config.format.with_tabs;
-        self.indentation_size = match self.indentation_size {
-            Some(size) => Some(size),
-            None => Some(config.format.indentation_size),
-        };
-        self.max_line_length = match self.max_line_length {
-            Some(length) => Some(length),
-            None => Some(config.format.max_line_length),
-        };
+        if self.indentation_size.is_none() {
+            self.indentation_size = Some(config.format.indentation_size);
+        }
+        if self.max_line_length.is_none() {
+            self.max_line_length = Some(config.format.max_line_length);
+        }
         self
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -111,13 +111,16 @@ pub struct Args {
 impl Args {
     /// Applies the configuration to the arguments.
     pub fn apply(mut self, config: crate::config::Config) -> Self {
-        self.engine = Some(config.run.engine);
-        self.runs_dir = Some(config.run.runs_dir);
+        if self.engine.is_none() {
+            self.engine = Some(config.run.engine);
+        }
+        if self.runs_dir.is_none() {
+            self.runs_dir = Some(config.run.runs_dir);
+        }
         self.no_color = self.no_color || !config.common.color;
-        self.report_mode = match self.report_mode {
-            Some(mode) => Some(mode),
-            None => Some(config.common.report_mode),
-        };
+        if self.report_mode.is_none() {
+            self.report_mode = Some(config.common.report_mode);
+        }
         self
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -209,7 +209,7 @@ fn progress(kind: ProgressKind<'_>, pb: &tracing::Span, state: &Mutex<State>) {
 /// Determines the timestamped execution directory and performs any necessary
 /// staging prior to execution.
 ///
-/// Notably, this function does not actually create the exection directory at
+/// Notably, this function does not actually create the execution directory at
 /// the returned path, as that is handled by execution itself.
 ///
 /// If running on a Unix system, a symlink to the returned path will be created

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -43,7 +43,7 @@ const PROGRESS_BAR_DELAY_BEFORE_RENDER: Duration = Duration::from_secs(2);
 /// The name of the default "runs" directory.
 pub(crate) const DEFAULT_RUNS_DIR: &str = "runs";
 /// The name for the "latest" symlink.
-const LATEST: &str = "_latest";
+const LATEST: &str = "latest";
 
 /// Arguments to the `run` subcommand.
 #[derive(Parser, Debug)]
@@ -79,7 +79,7 @@ pub struct Args {
     /// Individual invocations of `sprocket run` will nest their execution
     /// directories beneath this root directory at the path
     /// `<entrypoint name>/<timestamp>/`. On Unix systems, the latest `run`
-    /// invocation will be symlinked at `<entrypoint name>/_latest`.
+    /// invocation will be symlinked at `<entrypoint name>/latest`.
     #[clap(short, long, value_name = "ROOT_DIR")]
     pub runs_dir: Option<PathBuf>,
 
@@ -219,7 +219,7 @@ fn progress(kind: ProgressKind<'_>, pb: &tracing::Span, state: &Mutex<State>) {
 /// the returned path, as that is handled by execution itself.
 ///
 /// If running on a Unix system, a symlink to the returned path will be created
-/// at `<root>/<entrypoint>/_latest`.
+/// at `<root>/<entrypoint>/latest`.
 pub fn setup_run_dir(root: &Path, entrypoint: &str) -> Result<PathBuf> {
     let root = root.join(entrypoint);
     std::fs::create_dir_all(&root)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -221,15 +221,13 @@ pub fn setup_run_dir(root: &Path, entrypoint: &str) -> Result<PathBuf> {
 
     let timestamp = chrono::Utc::now();
 
-    let mut output = root.join(timestamp.format("%F_%H%M%S%f").to_string());
+    let output = root.join(timestamp.format("%F_%H%M%S%f").to_string());
 
-    while output.exists() {
-        tracing::warn!(
-            "`{dir}` was selected for execution but it already exists",
+    if output.exists() {
+        bail!(
+            "timestamped execution directory `{dir}` existed before execution began",
             dir = output.display()
         );
-        let timestamp = chrono::Utc::now();
-        output = root.join(timestamp.format("%F_%H%M%S%f").to_string());
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -206,14 +206,14 @@ fn progress(kind: ProgressKind<'_>, pb: &tracing::Span, state: &Mutex<State>) {
     pb.pb_set_message(&message);
 }
 
-/// Determines the timestamped execution directory and performs any necessary staging prior
-/// to execution.
+/// Determines the timestamped execution directory and performs any necessary
+/// staging prior to execution.
 ///
 /// Notably, this function does not actually create the exection directory at
 /// the returned path, as that is handled by execution itself.
 ///
-/// If running on a Unix system, a symlink to the returned path will be created at
-/// `<root>/<entrypoint>/_latest`.
+/// If running on a Unix system, a symlink to the returned path will be created
+/// at `<root>/<entrypoint>/_latest`.
 pub fn setup_run_dir(root: &Path, entrypoint: &str) -> Result<PathBuf> {
     let root = root.join(entrypoint);
     std::fs::create_dir_all(&root)
@@ -400,7 +400,10 @@ pub async fn run(args: Args) -> Result<()> {
         )?
     };
 
-    tracing::info!("`{dir}` will be used as the execution directory", dir = output_dir.display());
+    tracing::info!(
+        "`{dir}` will be used as the execution directory",
+        dir = output_dir.display()
+    );
 
     let run_kind = match &inputs {
         EngineInputs::Task(_) => "task",

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -43,7 +43,7 @@ const PROGRESS_BAR_DELAY_BEFORE_RENDER: Duration = Duration::from_secs(2);
 /// The name of the default "runs" directory.
 pub(crate) const DEFAULT_RUNS_DIR: &str = "runs";
 /// The name for the "latest" symlink.
-const LATEST: &str = "latest";
+const LATEST: &str = "_latest";
 
 /// Arguments to the `run` subcommand.
 #[derive(Parser, Debug)]
@@ -79,7 +79,7 @@ pub struct Args {
     /// Individual invocations of `sprocket run` will nest their execution
     /// directories beneath this root directory at the path
     /// `<entrypoint name>/<timestamp>/`. On Unix systems, the latest `run`
-    /// invocation will be symlinked at `<entrypoint name>/latest`.
+    /// invocation will be symlinked at `<entrypoint name>/_latest`.
     #[clap(short, long, value_name = "ROOT_DIR")]
     pub runs_dir: Option<PathBuf>,
 
@@ -219,7 +219,7 @@ fn progress(kind: ProgressKind<'_>, pb: &tracing::Span, state: &Mutex<State>) {
 /// the returned path, as that is handled by execution itself.
 ///
 /// If running on a Unix system, a symlink to the returned path will be created
-/// at `<root>/<entrypoint>/latest`.
+/// at `<root>/<entrypoint>/_latest`.
 pub fn setup_run_dir(root: &Path, entrypoint: &str) -> Result<PathBuf> {
     let root = root.join(entrypoint);
     std::fs::create_dir_all(&root)

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -104,16 +104,19 @@ pub struct Args {
     pub report_mode: Option<Mode>,
 
     /// The engine configuration to use.
+    ///
+    /// This is not exposed via [`clap`] and is unsettable by users.
+    /// It will always be overwritten by the engine config provided by the user
+    /// (which will be set with `Default::default()` if the user does not
+    /// explicitly set `run` config values).
     #[clap(skip)]
-    pub engine: Option<engine::config::Config>,
+    pub engine: engine::config::Config,
 }
 
 impl Args {
     /// Applies the configuration to the arguments.
     pub fn apply(mut self, config: crate::config::Config) -> Self {
-        if self.engine.is_none() {
-            self.engine = Some(config.run.engine);
-        }
+        self.engine = config.run.engine;
         if self.runs_dir.is_none() {
             self.runs_dir = Some(config.run.runs_dir);
         }
@@ -427,7 +430,7 @@ pub async fn run(args: Args) -> Result<()> {
         &entrypoint,
         inputs,
         origins,
-        args.engine.unwrap_or_default(),
+        args.engine,
         &output_dir,
     );
     let token = CancellationToken::new();

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -112,6 +112,7 @@ impl Args {
     /// Applies the configuration to the arguments.
     pub fn apply(mut self, config: crate::config::Config) -> Self {
         self.engine = Some(config.run.engine);
+        self.runs_dir = Some(config.run.runs_dir);
         self.no_color = self.no_color || !config.common.color;
         self.report_mode = match self.report_mode {
             Some(mode) => Some(mode),

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -41,7 +41,7 @@ use crate::emit_diagnostics;
 const PROGRESS_BAR_DELAY_BEFORE_RENDER: Duration = Duration::from_secs(2);
 
 /// The name of the default "runs" directory.
-const DEFAULT_RUNS_DIR: &str = "runs";
+pub(crate) const DEFAULT_RUNS_DIR: &str = "runs";
 /// The name for the "latest" symlink.
 const LATEST: &str = "_latest";
 

--- a/src/commands/validate.rs
+++ b/src/commands/validate.rs
@@ -55,10 +55,9 @@ impl Args {
     /// Applies the configuration to the arguments.
     pub fn apply(mut self, config: crate::config::Config) -> Self {
         self.no_color = self.no_color || !config.common.color;
-        self.report_mode = match self.report_mode {
-            Some(mode) => Some(mode),
-            None => Some(config.common.report_mode),
-        };
+        if self.report_mode.is_none() {
+            self.report_mode = Some(config.common.report_mode);
+        }
         self
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,6 +2,7 @@
 
 use std::env;
 use std::path::Path;
+use std::path::PathBuf;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -90,12 +91,24 @@ pub struct CheckConfig {
 }
 
 /// Represents the configuration for the Sprocket `run` command.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct RunConfig {
     /// The engine configuration.
     #[serde(flatten)]
     pub engine: engine::config::Config,
+    
+    /// The "runs" directory under which new `run` invocation's execution directories will be placed.
+    pub runs_dir: PathBuf,
+}
+
+impl Default for RunConfig {
+    fn default() -> Self {
+        Self {
+            engine: engine::config::Config::default(),
+            runs_dir: "runs".into(),
+        }
+    }
 }
 
 impl Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,8 +97,9 @@ pub struct RunConfig {
     /// The engine configuration.
     #[serde(flatten)]
     pub engine: engine::config::Config,
-    
-    /// The "runs" directory under which new `run` invocation's execution directories will be placed.
+
+    /// The "runs" directory under which new `run` invocation's execution
+    /// directories will be placed.
     pub runs_dir: PathBuf,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,7 +98,7 @@ pub struct RunConfig {
     #[serde(flatten)]
     pub engine: engine::config::Config,
 
-    /// The "runs" directory under which new `run` invocation's execution
+    /// The "runs" directory under which new `run` invocations' execution
     /// directories will be placed.
     pub runs_dir: PathBuf,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,7 +106,7 @@ impl Default for RunConfig {
     fn default() -> Self {
         Self {
             engine: engine::config::Config::default(),
-            runs_dir: "runs".into(),
+            runs_dir: crate::commands::run::DEFAULT_RUNS_DIR.into(),
         }
     }
 }

--- a/tests/cli/run/help/stdout
+++ b/tests/cli/run/help/stdout
@@ -24,7 +24,7 @@ Options:
   -r, --runs-dir <ROOT_DIR>
           The root "runs" directory; defaults to `./runs/`.
           
-          Individual invocations of `sprocket run` will nest their execution directories beneath this root directory at the path `<entrypoint name>/<timestamp>/`. On Unix systems, the latest `run` invocation will be symlinked at `<entrypoint name>/latest`.
+          Individual invocations of `sprocket run` will nest their execution directories beneath this root directory at the path `<entrypoint name>/<timestamp>/`. On Unix systems, the latest `run` invocation will be symlinked at `<entrypoint name>/_latest`.
 
       --output <OUTPUT_DIR>
           The execution directory.

--- a/tests/cli/run/help/stdout
+++ b/tests/cli/run/help/stdout
@@ -21,11 +21,18 @@ Options:
           
           If `entrypoint` is specified, it will be appended with a `.` delimiter and then prepended to all key-value pair inputs on the command line. Keys specified within files are unchanged by this argument.
 
-  -o, --output <OUTPUT_DIR>
-          The execution output directory; defaults to the workflow or task name
+  -r, --runs-dir <ROOT_DIR>
+          The root "runs" directory; defaults to `./runs/`.
+          
+          Individual invocations of `sprocket run` will nest their execution directories beneath this root directory at the path `<entrypoint name>/<timestamp>/`. On Unix systems, the latest `run` invocation will be symlinked at `<entrypoint name>/_latest`.
+
+      --output <OUTPUT_DIR>
+          The execution directory.
+          
+          If this argument is supplied, the default output behavior of nesting execution directories using the entrypoint and timestamp will be disabled.
 
       --overwrite
-          Overwrites the execution output directory if it exists
+          Overwrites the execution directory if it exists
 
       --no-color
           Disables color output

--- a/tests/cli/run/help/stdout
+++ b/tests/cli/run/help/stdout
@@ -24,7 +24,7 @@ Options:
   -r, --runs-dir <ROOT_DIR>
           The root "runs" directory; defaults to `./runs/`.
           
-          Individual invocations of `sprocket run` will nest their execution directories beneath this root directory at the path `<entrypoint name>/<timestamp>/`. On Unix systems, the latest `run` invocation will be symlinked at `<entrypoint name>/_latest`.
+          Individual invocations of `sprocket run` will nest their execution directories beneath this root directory at the path `<entrypoint name>/<timestamp>/`. On Unix systems, the latest `run` invocation will be symlinked at `<entrypoint name>/latest`.
 
       --output <OUTPUT_DIR>
           The execution directory.


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

In short, the default run directories are now located at `./runs/<entrypoint>/<timestamp>/`.
Also we have a `latest` symlink now 😎 

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the `wdl` crates' [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
