### PR TITLE
fix: correct pattern matching for attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,3 @@
 # Don't count test files for GitHub repo stats
 # see - https://github.com/github-linguist/linguist/blob/1040da7115035a67fd0b8bfeb12f38b9719b16af/docs/overrides.md#using-gitattributes
-docs/** linguist-vendored
+**/docs/** linguist-vendored


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

In #161 I erroneously assumed that `.gitattributes` files follow the same pattern matching rules as `.gitignore` files, but they have some differences. See the git docs for more info - https://git-scm.com/docs/gitattributes

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the `wdl` crates' [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [ ] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
