### PR TITLE
feat: re-implement the `format` subcommand with new API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* `format` subcommand has been re-implemented with a new CL API ([#365](https://github.com/stjude-rust-labs/sprocket/pull/365)).
+
 ### Added
 
+* `-c, --config` and `-s, --skip-config-search` are now global arguments (they can now appear after any subcommand) ([#365](https://github.com/stjude-rust-labs/sprocket/pull/365)).
 * Added experimental LSF + Apptainer backend ([#182](https://github.com/stjude-rust-labs/sprocket/pull/182))
 
 ## 0.17.1 - 09-17-2025

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5252,6 +5252,7 @@ dependencies = [
  "libtest-mimic",
  "nonempty",
  "pretty_assertions",
+ "thiserror 2.0.16",
  "wdl-ast",
 ]
 

--- a/crates/wdl-format/CHANGELOG.md
+++ b/crates/wdl-format/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* `MaxLineLength::try_new()` and `IndentationSize::try_new()` return appropriate errors ([#365](https://github.com/stjude-rust-labs/sprocket/pull/365)).
+
 ## 0.11.0 - 09-15-2025
 
 * Added support for sorting input sections ([#597](https://github.com/stjude-rust-labs/wdl/pull/597)).

--- a/crates/wdl-format/CHANGELOG.md
+++ b/crates/wdl-format/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+* Fixed edge case in single quote to double quote conversion for literal strings ([#365](https://github.com/stjude-rust-labs/sprocket/pull/365)).
 * `MaxLineLength::try_new()` and `IndentationSize::try_new()` return appropriate errors ([#365](https://github.com/stjude-rust-labs/sprocket/pull/365)).
 
 ## 0.11.0 - 09-15-2025

--- a/crates/wdl-format/Cargo.toml
+++ b/crates/wdl-format/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 
 [dependencies]
 nonempty.workspace = true
+thiserror.workspace = true
 wdl-ast = { path = "../wdl-ast", version = "0.17.0", features = ["codespan"] }
 
 [dev-dependencies]

--- a/crates/wdl-format/src/config/indent.rs
+++ b/crates/wdl-format/src/config/indent.rs
@@ -1,7 +1,17 @@
 //! Indentation within formatting configuration.
 
+use thiserror::Error;
+
 use crate::SPACE;
 use crate::TAB;
+
+#[derive(Error, Debug)]
+pub enum IndentError {
+    #[error("indentation with tabs cannot have a number of spaces")]
+    InvalidConfiguration,
+    #[error("`{0}` is more than the maximum allowed number of spaces: `{max}`", max = MAX_SPACE_INDENT)]
+    TooManySpaces(usize),
+}
 
 /// The default number of spaces to represent one indentation level.
 const DEFAULT_SPACE_INDENT: usize = 4;
@@ -27,18 +37,13 @@ impl Default for Indent {
 
 impl Indent {
     /// Attempts to create a new indentation level configuration.
-    pub fn try_new(tab: bool, num_spaces: Option<usize>) -> Result<Self, String> {
+    pub fn try_new(tab: bool, num_spaces: Option<usize>) -> Result<Self, IndentError> {
         match (tab, num_spaces) {
             (true, None) => Ok(Indent::Tabs),
-            (true, Some(_)) => {
-                Err("Indentation with tabs cannot have a number of spaces".to_string())
-            }
+            (true, Some(_)) => Err(IndentError::InvalidConfiguration),
             (false, Some(n)) => {
                 if n > MAX_SPACE_INDENT {
-                    Err(format!(
-                        "Indentation with spaces cannot have more than {MAX_SPACE_INDENT} \
-                         characters"
-                    ))
+                    Err(IndentError::TooManySpaces(n))
                 } else {
                     Ok(Indent::Spaces(n))
                 }

--- a/crates/wdl-format/src/config/indent.rs
+++ b/crates/wdl-format/src/config/indent.rs
@@ -5,10 +5,13 @@ use thiserror::Error;
 use crate::SPACE;
 use crate::TAB;
 
+/// Error while creating indentation configuration.
 #[derive(Error, Debug)]
 pub enum IndentError {
+    /// Invalid options
     #[error("indentation with tabs cannot have a number of spaces")]
     InvalidConfiguration,
+    /// Too many spaces
     #[error("`{0}` is more than the maximum allowed number of spaces: `{max}`", max = MAX_SPACE_INDENT)]
     TooManySpaces(usize),
 }

--- a/crates/wdl-format/src/config/max_line_length.rs
+++ b/crates/wdl-format/src/config/max_line_length.rs
@@ -1,5 +1,13 @@
 //! Configuration for max line length formatting.
 
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum MaxLineLengthError {
+    #[error("`{0}` is outside the allowed range for the max line length: `{min}-{max}`", min = MIN_MAX_LINE_LENGTH, max = MAX_MAX_LINE_LENGTH)]
+    OutsideAllowedRange(usize),
+}
+
 /// The default maximum line length.
 pub const DEFAULT_MAX_LINE_LENGTH: usize = 90;
 /// The minimum maximum line length.
@@ -15,15 +23,12 @@ impl MaxLineLength {
     /// Attempts to create a new `MaxLineLength` with the provided value.
     ///
     /// A value of `0` indicates no maximum.
-    pub fn try_new(value: usize) -> Result<Self, String> {
+    pub fn try_new(value: usize) -> Result<Self, MaxLineLengthError> {
         let val = match value {
             0 => Self(None),
             MIN_MAX_LINE_LENGTH..=MAX_MAX_LINE_LENGTH => Self(Some(value)),
             _ => {
-                return Err(format!(
-                    "The maximum line length must be between {MIN_MAX_LINE_LENGTH} and \
-                     {MAX_MAX_LINE_LENGTH} or 0"
-                ));
+                return Err(MaxLineLengthError::OutsideAllowedRange(value));
             }
         };
         Ok(val)

--- a/crates/wdl-format/src/config/max_line_length.rs
+++ b/crates/wdl-format/src/config/max_line_length.rs
@@ -2,9 +2,15 @@
 
 use thiserror::Error;
 
+/// Error while creating a max line length configuration.
 #[derive(Error, Debug)]
 pub enum MaxLineLengthError {
-    #[error("`{0}` is outside the allowed range for the max line length: `{min}-{max}`", min = MIN_MAX_LINE_LENGTH, max = MAX_MAX_LINE_LENGTH)]
+    /// Suppplied value outside allowed range.
+    #[error(
+        "`{0}` is outside the allowed range for the max line length: `{min}-{max}`",
+        min = MIN_MAX_LINE_LENGTH,
+        max = MAX_MAX_LINE_LENGTH
+    )]
     OutsideAllowedRange(usize),
 }
 

--- a/crates/wdl-format/src/v1/expr.rs
+++ b/crates/wdl-format/src/v1/expr.rs
@@ -173,7 +173,7 @@ pub fn format_literal_string(element: &FormatElement, stream: &mut TokenStream<P
                             replacement.push(c);
                         }
                         '"' => {
-                            if !prev_c.is_some_and(|c| c == '\\') {
+                            if prev_c.is_none_or(|c| c != '\\') {
                                 // This double quote sign is not escaped, so we need to escape
                                 // it. This happens when a single quoted string is re-formatted
                                 // as a double quoted string.

--- a/crates/wdl-format/src/v1/expr.rs
+++ b/crates/wdl-format/src/v1/expr.rs
@@ -173,9 +173,7 @@ pub fn format_literal_string(element: &FormatElement, stream: &mut TokenStream<P
                             replacement.push(c);
                         }
                         '"' => {
-                            if let Some(pc) = prev_c
-                                && pc != '\\'
-                            {
+                            if !prev_c.is_some_and(|c| c == '\\') {
                                 // This double quote sign is not escaped, so we need to escape
                                 // it. This happens when a single quoted string is re-formatted
                                 // as a double quoted string.

--- a/crates/wdl-format/tests/format/string-escaping/source.formatted.wdl
+++ b/crates/wdl-format/tests/format/string-escaping/source.formatted.wdl
@@ -1,0 +1,11 @@
+version 1.2
+
+task strings {
+    input {
+        String haplotypecallerPassthroughOptions = "embedded \"double\" quote"
+    }
+
+    command <<<
+        ~{"--haplotypecaller-options " + "\"" + haplotypecallerPassthroughOptions + "\""}
+    >>>
+}

--- a/crates/wdl-format/tests/format/string-escaping/source.wdl
+++ b/crates/wdl-format/tests/format/string-escaping/source.wdl
@@ -1,0 +1,11 @@
+version 1.2
+
+task strings {
+    input {
+        String haplotypecallerPassthroughOptions = 'embedded "double" quote'
+    }
+
+    command <<<
+        ~{"--haplotypecaller-options " + '"' + haplotypecallerPassthroughOptions + '"'}
+    >>>
+}

--- a/src/commands/analyzer.rs
+++ b/src/commands/analyzer.rs
@@ -28,6 +28,7 @@ pub struct Args {
         ignore_case = true,
         action = clap::ArgAction::Append,
         num_args = 1,
+        hide_possible_values = true,
     )]
     pub except: Vec<String>,
 }

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -62,7 +62,7 @@ pub struct Common {
     /// default set.
     ///
     /// `--except <RULE>` and `--filter-lint-tag <TAG>` can be used in
-    /// conjuction with this argument.
+    /// conjunction with this argument.
     #[clap(short, long, conflicts_with_all = ["only_lint_tag"])]
     pub all_lint_rules: bool,
 

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -43,7 +43,13 @@ pub struct Args {
     pub with_tabs: bool,
 
     /// The number of spaces to use for indentation levels (default is 4).
-    #[arg(short, long, value_name = "SIZE", conflicts_with = "with_tabs", global = true)]
+    #[arg(
+        short,
+        long,
+        value_name = "SIZE",
+        conflicts_with = "with_tabs",
+        global = true
+    )]
     pub indentation_size: Option<usize>,
 
     /// The maximum line length (default is 90).

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -11,8 +11,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use anyhow::bail;
 use clap::Parser;
-use serde::Deserialize;
-use serde::Serialize;
+use clap::Subcommand;
 use walkdir::WalkDir;
 use wdl::ast::Document;
 use wdl::ast::Node;
@@ -33,40 +32,31 @@ use crate::emit_diagnostics;
     author,
     version,
     about,
-    after_help = "Use the `--overwrite` option to replace a WDL document or a directory \
-                  containing WDL documents with the formatted source.\nUse the `--check` option \
-                  to verify that a document or a directory containing WDL documents is already \
-                  formatted and print the diff if not."
 )]
 pub struct Args {
-    /// The path to the local WDL document or directory containing WDL documents
-    /// to format or check.
-    #[arg(value_name = "PATH or DIR")]
-    pub source: Option<Source>,
-
     /// Disables color output.
     #[arg(long)]
     pub no_color: bool,
 
-    /// The report mode.
+    /// The report mode for any emitted diagnostics.
     #[arg(short = 'm', long, value_name = "MODE")]
     pub report_mode: Option<Mode>,
 
     /// Use tabs for indentation (default is spaces).
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub with_tabs: bool,
 
     /// The number of spaces to use for indentation levels (default is 4).
-    #[arg(long, value_name = "SIZE", conflicts_with = "with_tabs")]
+    #[arg(long, value_name = "SIZE", conflicts_with = "with_tabs", global = true)]
     pub indentation_size: Option<usize>,
 
     /// The maximum line length (default is 90).
-    #[arg(long, value_name = "LENGTH")]
+    #[arg(long, value_name = "LENGTH", global = true)]
     pub max_line_length: Option<usize>,
 
-    /// Argument group defining the mode of behavior.
-    #[command(flatten)]
-    pub mode: ModeGroup,
+    /// Subcommand for the `format` command.
+    #[command(subcommand)]
+    pub command: FormatSubcommand,
 }
 
 impl Args {
@@ -87,34 +77,23 @@ impl Args {
     }
 }
 
-/// Argument group defining the mode of behavior
-#[derive(Parser, Debug, Deserialize, Serialize)]
-#[group(required = true, multiple = false)]
-pub struct ModeGroup {
-    /// Overwrite the WDL documents with the formatted versions.
-    #[arg(long, conflicts_with = "check")]
-    pub overwrite: bool,
-
-    /// Check if files are formatted correctly and print diff if not.
-    #[arg(long)]
-    pub check: bool,
+/// Source argument for all `format` subcommands.
+#[derive(Parser, Debug, Clone)]
+pub struct SourceArg {
+    source: Option<Source>,
 }
 
-/// Reads source from the given path.
-///
-/// If the path is simply `-`, the source is read from STDIN.
-fn read_source(path: &Path) -> Result<String> {
-    if path.as_os_str() == "-" {
-        let mut source = String::new();
-        std::io::stdin()
-            .read_to_string(&mut source)
-            .context("failed to read source from STDIN")?;
-        Ok(source)
-    } else {
-        Ok(fs::read_to_string(path).with_context(|| {
-            format!("failed to read source file `{path}`", path = path.display())
-        })?)
-    }
+/// Subcommands for the `format` command.
+#[derive(Subcommand, Debug, Clone)]
+pub enum FormatSubcommand {
+    /// Check if files are formatted correctly and print diff if not.
+    Check(SourceArg),
+
+    /// Format a document and send the result to STDOUT.
+    View(SourceArg),
+
+    /// Reformat all WDL documents via overwriting.
+    Overwrite(SourceArg),
 }
 
 /// Formats a document.
@@ -134,64 +113,65 @@ fn format_document(
     no_color: bool,
     check_only: bool,
 ) -> Result<usize> {
-    let source = read_source(path)?;
-    let (document, diagnostics) = Document::parse(&source);
-    if !diagnostics.is_empty() {
-        emit_diagnostics(
-            path.as_os_str().to_str().expect("path is not UTF-8"),
-            source,
-            &diagnostics,
-            &[],
-            report_mode,
-            no_color,
-        )
-        .context("failed to emit diagnostics")?;
+    // let source = read_source(path)?;
+    // let (document, diagnostics) = Document::parse(&source);
+    // if !diagnostics.is_empty() {
+    //     emit_diagnostics(
+    //         path.as_os_str().to_str().expect("path is not UTF-8"),
+    //         source,
+    //         &diagnostics,
+    //         &[],
+    //         report_mode,
+    //         no_color,
+    //     )
+    //     .context("failed to emit diagnostics")?;
 
-        return Ok(diagnostics.len());
-    }
+    //     return Ok(diagnostics.len());
+    // }
 
-    let document = Node::Ast(
-        document
-            .ast()
-            .into_v1()
-            .ok_or_else(|| anyhow!("only WDL 1.x documents are currently supported"))?,
-    )
-    .into_format_element();
+    // let document = Node::Ast(
+    //     document
+    //         .ast()
+    //         .into_v1()
+    //         .ok_or_else(|| anyhow!("only WDL 1.x documents are currently supported"))?,
+    // )
+    // .into_format_element();
 
-    let formatter = Formatter::new(config);
-    let formatted = formatter.format(&document)?;
+    // let formatter = Formatter::new(config);
+    // let formatted = formatter.format(&document)?;
 
-    if check_only {
-        if formatted != source {
-            if !no_color && std::io::stderr().is_terminal() {
-                eprint!(
-                    "{}",
-                    pretty_assertions::StrComparison::new(&source, &formatted)
-                );
-            } else {
-                let diff = similar::TextDiff::from_lines(&source, &formatted);
-                eprint!("{}", diff.unified_diff());
-            }
-            return Ok(1);
-        }
-        println!("`{path}` is formatted correctly", path = path.display());
-        return Ok(0);
-    }
+    // if check_only {
+    //     if formatted != source {
+    //         if !no_color && std::io::stderr().is_terminal() {
+    //             eprint!(
+    //                 "{}",
+    //                 pretty_assertions::StrComparison::new(&source, &formatted)
+    //             );
+    //         } else {
+    //             let diff = similar::TextDiff::from_lines(&source, &formatted);
+    //             eprint!("{}", diff.unified_diff());
+    //         }
+    //         return Ok(1);
+    //     }
+    //     println!("`{path}` is formatted correctly", path = path.display());
+    //     return Ok(0);
+    // }
 
-    // Write file because check is not true
-    fs::write(path, formatted)
-        .with_context(|| format!("failed to write `{path}`", path = path.display()))?;
+    // // Write file because check is not true
+    // fs::write(path, formatted)
+    //     .with_context(|| format!("failed to write `{path}`", path = path.display()))?;
 
     Ok(0)
 }
 
 /// Runs the `format` command.
 pub fn format(args: Args) -> Result<()> {
-    if let Some(Source::Remote(_)) = args.source {
-        bail!("remote sources are not supported for the `format` command");
-    }
-
-    let source = args.source.unwrap_or_default();
+    let source = match args.command {
+        FormatSubcommand::Check(s) => s.source,
+        FormatSubcommand::Overwrite(s) => s.source,
+        FormatSubcommand::View(s) => s.source,
+    };
+    let source = source.unwrap_or_default();
     let indent = match Indent::try_new(args.with_tabs, args.indentation_size) {
         Ok(indent) => indent,
         Err(e) => bail!("failed to create indentation configuration: {}", e),
@@ -211,35 +191,35 @@ pub fn format(args: Args) -> Result<()> {
         .build();
 
     let mut diagnostics = 0;
-    if let Source::Directory(path) = source {
-        for entry in WalkDir::new(&path) {
-            let entry = entry.with_context(|| {
-                format!("failed to walk directory `{path}`", path = path.display())
-            })?;
-            let path = entry.path();
-            if !path.is_file() || path.extension().and_then(OsStr::to_str) != Some("wdl") {
-                continue;
-            }
+    // if let Source::Directory(path) = source {
+    //     for entry in WalkDir::new(&path) {
+    //         let entry = entry.with_context(|| {
+    //             format!("failed to walk directory `{path}`", path = path.display())
+    //         })?;
+    //         let path = entry.path();
+    //         if !path.is_file() || path.extension().and_then(OsStr::to_str) != Some("wdl") {
+    //             continue;
+    //         }
 
-            diagnostics += format_document(
-                config,
-                path,
-                args.report_mode.unwrap_or_default(),
-                args.no_color,
-                args.mode.check,
-            )?;
-        }
-    } else if let Source::File(path) = source {
-        diagnostics += format_document(
-            config,
-            &path.to_file_path().expect("should be local file path"),
-            args.report_mode.unwrap_or_default(),
-            args.no_color,
-            args.mode.check,
-        )?;
-    } else {
-        unreachable!()
-    }
+    //         // diagnostics += format_document(
+    //         //     config,
+    //         //     path,
+    //         //     args.report_mode.unwrap_or_default(),
+    //         //     args.no_color,
+    //         //     args.mode.check,
+    //         // )?;
+    //     }
+    // } else if let Source::File(path) = source {
+    //     // diagnostics += format_document(
+    //     //     config,
+    //     //     &path.to_file_path().expect("should be local file path"),
+    //     //     args.report_mode.unwrap_or_default(),
+    //     //     args.no_color,
+    //     //     args.mode.check,
+    //     // )?;
+    // } else {
+    //     unreachable!()
+    // }
 
     if diagnostics > 0 {
         bail!(

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -31,11 +31,11 @@ use crate::emit_diagnostics;
 #[command(author, version, about)]
 pub struct Args {
     /// Disables color output.
-    #[arg(long)]
+    #[arg(long, global = true)]
     pub no_color: bool,
 
     /// The report mode for any emitted diagnostics.
-    #[arg(short = 'm', long, value_name = "MODE")]
+    #[arg(short = 'm', long, value_name = "MODE", global = true)]
     pub report_mode: Option<Mode>,
 
     /// Use tabs for indentation (default is spaces).
@@ -43,7 +43,7 @@ pub struct Args {
     pub with_tabs: bool,
 
     /// The number of spaces to use for indentation levels (default is 4).
-    #[arg(long, value_name = "SIZE", conflicts_with = "with_tabs", global = true)]
+    #[arg(short, long, value_name = "SIZE", conflicts_with = "with_tabs", global = true)]
     pub indentation_size: Option<usize>,
 
     /// The maximum line length (default is 90).
@@ -304,7 +304,7 @@ pub async fn format(args: Args) -> Result<()> {
 
     if errors > 0 {
         bail!(
-            "aborting due to previous {errors} diagnostic{s}",
+            "failing due to previous {errors} error{s}",
             s = if errors == 1 { "" } else { "s" }
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ pub async fn inner() -> anyhow::Result<()> {
         }
         Commands::Config(args) => commands::config::config(args, config),
         Commands::Explain(args) => commands::explain::explain(args),
-        Commands::Format(args) => commands::format::format(args.apply(config)),
+        Commands::Format(args) => commands::format::format(args.apply(config)).await,
         Commands::Inputs(args) => commands::inputs::inputs(args).await,
         Commands::Lint(args) => commands::check::lint(args.apply(config)).await,
         Commands::Run(args) => commands::run::run(args.apply(config)).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,14 +35,14 @@ struct Cli {
     verbosity: Verbosity<WarnLevel>,
 
     /// Path to the configuration file.
-    #[arg(long, short)]
+    #[arg(long, short, global = true)]
     config: Option<PathBuf>,
 
     /// Skip searching for and loading configuration files.
     ///
     /// Only a configuration file specified as a command line argument will be
     /// used.
-    #[arg(long, short)]
+    #[arg(long, short, global = true)]
     skip_config_search: bool,
 }
 

--- a/tests/cli/config-init/help/stdout
+++ b/tests/cli/config-init/help/stdout
@@ -3,7 +3,22 @@ Generates a default configuration file
 Usage: sprocket config init [OPTIONS]
 
 Options:
-  -v, --verbose...  Increase logging verbosity
-  -q, --quiet...    Decrease logging verbosity
-  -h, --help        Print help
-  -V, --version     Print version
+  -v, --verbose...
+          Increase logging verbosity
+
+  -q, --quiet...
+          Decrease logging verbosity
+
+  -c, --config <CONFIG>
+          Path to the configuration file
+
+  -s, --skip-config-search
+          Skip searching for and loading configuration files.
+          
+          Only a configuration file specified as a command line argument will be used.
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version

--- a/tests/cli/config-resolve/help/stdout
+++ b/tests/cli/config-resolve/help/stdout
@@ -3,8 +3,25 @@ Displays the current configuration
 Usage: sprocket config resolve [OPTIONS]
 
 Options:
-      --unredact    Unredacts any redacted secrets in the configuration
-  -v, --verbose...  Increase logging verbosity
-  -q, --quiet...    Decrease logging verbosity
-  -h, --help        Print help
-  -V, --version     Print version
+      --unredact
+          Unredacts any redacted secrets in the configuration
+
+  -v, --verbose...
+          Increase logging verbosity
+
+  -q, --quiet...
+          Decrease logging verbosity
+
+  -c, --config <CONFIG>
+          Path to the configuration file
+
+  -s, --skip-config-search
+          Skip searching for and loading configuration files.
+          
+          Only a configuration file specified as a command line argument will be used.
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version

--- a/tests/cli/config/help/stdout
+++ b/tests/cli/config/help/stdout
@@ -3,7 +3,22 @@ Generates a default configuration file
 Usage: sprocket config init [OPTIONS]
 
 Options:
-  -v, --verbose...  Increase logging verbosity
-  -q, --quiet...    Decrease logging verbosity
-  -h, --help        Print help
-  -V, --version     Print version
+  -v, --verbose...
+          Increase logging verbosity
+
+  -q, --quiet...
+          Decrease logging verbosity
+
+  -c, --config <CONFIG>
+          Path to the configuration file
+
+  -s, --skip-config-search
+          Skip searching for and loading configuration files.
+          
+          Only a configuration file specified as a command line argument will be used.
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version

--- a/tests/cli/explain/help/stdout
+++ b/tests/cli/explain/help/stdout
@@ -5,17 +5,41 @@ Usage: sprocket explain [RULE]
     sprocket explain --definitions
 
 Arguments:
-  [RULE]  The name of the rule to explain
+  [RULE]
+          The name of the rule to explain
 
 Options:
-  -t, --tag <TAG>       List all rules with the given tag
-      --definitions     Display general WDL definitions
-      --list-all-rules  Lists all rules and exits
-      --list-all-tags   Lists all tags and exits
-  -v, --verbose...      Increase logging verbosity
-  -q, --quiet...        Decrease logging verbosity
-  -h, --help            Print help
-  -V, --version         Print version
+  -t, --tag <TAG>
+          List all rules with the given tag
+
+      --definitions
+          Display general WDL definitions
+
+      --list-all-rules
+          Lists all rules and exits
+
+      --list-all-tags
+          Lists all tags and exits
+
+  -v, --verbose...
+          Increase logging verbosity
+
+  -q, --quiet...
+          Decrease logging verbosity
+
+  -c, --config <CONFIG>
+          Path to the configuration file
+
+  -s, --skip-config-search
+          Skip searching for and loading configuration files.
+          
+          Only a configuration file specified as a command line argument will be used.
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 Available rules:
   - CallInputSpacing

--- a/tests/cli/format/check/format_check_does_not_overwrite_file.disabled/args
+++ b/tests/cli/format/check/format_check_does_not_overwrite_file.disabled/args
@@ -1,1 +1,1 @@
-format --check file.wdl 
+format check file.wdl 

--- a/tests/cli/format/overwrite/can_format_file_in_place/args
+++ b/tests/cli/format/overwrite/can_format_file_in_place/args
@@ -1,1 +1,1 @@
-format --overwrite file.wdl 
+format overwrite file.wdl 

--- a/tests/cli/inputs/help/stdout
+++ b/tests/cli/inputs/help/stdout
@@ -3,15 +3,41 @@ Writes the inputs schema for a WDL document
 Usage: sprocket inputs [OPTIONS] <PATH or URL>
 
 Arguments:
-  <PATH or URL>  A source WDL document or URL
+  <PATH or URL>
+          A source WDL document or URL
 
 Options:
-  -n, --name <NAME>       The name of the task or workflow for which to generate inputs
-      --show-expressions  Show inputs with non-literal default values
-      --hide-defaults     Hide inputs with default values
-      --nested-inputs     Generate inputs for all tasks called in the workflow
-      --yaml              Output the template as a YAML file
-  -v, --verbose...        Increase logging verbosity
-  -q, --quiet...          Decrease logging verbosity
-  -h, --help              Print help
-  -V, --version           Print version
+  -n, --name <NAME>
+          The name of the task or workflow for which to generate inputs
+
+      --show-expressions
+          Show inputs with non-literal default values
+
+      --hide-defaults
+          Hide inputs with default values
+
+      --nested-inputs
+          Generate inputs for all tasks called in the workflow
+
+      --yaml
+          Output the template as a YAML file
+
+  -v, --verbose...
+          Increase logging verbosity
+
+  -q, --quiet...
+          Decrease logging verbosity
+
+  -c, --config <CONFIG>
+          Path to the configuration file
+
+  -s, --skip-config-search
+          Skip searching for and loading configuration files.
+          
+          Only a configuration file specified as a command line argument will be used.
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version

--- a/tests/cli/run/help/stdout
+++ b/tests/cli/run/help/stdout
@@ -75,5 +75,13 @@ Options:
   -q, --quiet...
           Decrease logging verbosity
 
+  -c, --config <CONFIG>
+          Path to the configuration file
+
+  -s, --skip-config-search
+          Skip searching for and loading configuration files.
+          
+          Only a configuration file specified as a command line argument will be used.
+
   -h, --help
           Print help (see a summary with '-h')

--- a/tests/cli/validate/help/stdout
+++ b/tests/cli/validate/help/stdout
@@ -41,6 +41,14 @@ Options:
   -q, --quiet...
           Decrease logging verbosity
 
+  -c, --config <CONFIG>
+          Path to the configuration file
+
+  -s, --skip-config-search
+          Skip searching for and loading configuration files.
+          
+          Only a configuration file specified as a command line argument will be used.
+
   -h, --help
           Print help (see a summary with '-h')
 


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

closes #357 
closes #375 

new API uses clap subcommands instead of mutually exclusive flags. The subcommands are `check`, `view`, and `overwrite`.

```console
Formats a document or a directory containing documents

Usage: sprocket format [OPTIONS] <COMMAND>

Commands:
  check      Check if files are formatted correctly and print diff if not
  view       Format a document and send the result to STDOUT
  overwrite  Reformat all WDL documents via overwriting
  help       Print this message or the help of the given subcommand(s)

Options:
      --no-color                  Disables color output
  -m, --report-mode <MODE>        The report mode for any emitted diagnostics [possible values: full, one-line]
      --with-tabs                 Use tabs for indentation (default is spaces)
  -i, --indentation-size <SIZE>   The number of spaces to use for indentation levels (default is 4)
      --max-line-length <LENGTH>  The maximum line length (default is 90)
  -v, --verbose...                Increase logging verbosity
  -q, --quiet...                  Decrease logging verbosity
  -c, --config <CONFIG>           Path to the configuration file
  -s, --skip-config-search        Skip searching for and loading configuration files
  -h, --help                      Print help (see more with '--help')
  -V, --version                   Print version
```

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the `wdl` crates' [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have either (a) made a PR to the `next` branch in the sprocket.bio repository [if you are a Sprocket team member] or (b) have suggested any changes you _think_ need to be made to sprocket.bio in the description of your PR [if you are an external contributor].

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
