### PR TITLE
fix: use a `tmp` location to allow for hardlinking.

### DIFF
--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -7,11 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
+#### Added
 
 * Added support for passing `None` for non-optional inputs with default
   expressions in WDL 1.2 call statements ([#356](https://github.com/stjude-rust-labs/sprocket/pull/356)).
 * Added experimental LSF + Apptainer backend ([#182](https://github.com/stjude-rust-labs/sprocket/pull/182), [#372](https://github.com/stjude-rust-labs/sprocket/pull/372), [#378](https://github.com/stjude-rust-labs/sprocket/pull/378), [#379](https://github.com/stjude-rust-labs/sprocket/pull/379))
+
+#### Fixed
+
+* Make linking to download cache files more likely by using a tmp directory in
+  the cache ([#393](https://github.com/stjude-rust-labs/sprocket/pull/393)).
 
 ## 0.8.1 - 09-17-2025
 


### PR DESCRIPTION
Currently the file transferer uses the system tmp directory for linking files in the download cache to a location that can be used by Sprocket.

On many systems, though, the location is likely to be a different file system than where `sprocket` is configured to store its download cache; this prevents hardlinks and forces a fallback to a copy.

This fixes the transferer such that it uses a tmp directory within the cache root to maximum the success of creating a hardlink to the cache file.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the `wdl` crates' [CONTRIBUTING](https://github.com/stjude-rust-labs/wdl/blob/main/CONTRIBUTING.md) guide in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have either (a) made a PR to the `next` branch in the sprocket.bio repository [if you are a Sprocket team member] or (b) have suggested any changes you _think_ need to be made to sprocket.bio in the description of your PR [if you are an external contributor].

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
