### PR TITLE
wip: add top-level eval dir and use it for apptainer image cache

### DIFF
--- a/crates/wdl-engine/src/backend/lsf_apptainer.rs
+++ b/crates/wdl-engine/src/backend/lsf_apptainer.rs
@@ -77,6 +77,7 @@ const LSF_JOB_NAME_MAX_LENGTH: usize = 4094;
 
 #[derive(Debug)]
 struct LsfApptainerTaskRequest {
+    engine_config: Arc<Config>,
     backend_config: Arc<LsfApptainerBackendConfig>,
     name: String,
     spawn_request: TaskSpawnRequest,
@@ -109,7 +110,10 @@ impl TaskManagerRequest for LsfApptainerTaskRequest {
         let crankshaft_task_id = crankshaft::events::next_task_id();
 
         let container_sif = sif_for_container(
-            &self.backend_config,
+            self.engine_config
+                .output_dir
+                .as_deref()
+                .expect("valid Config must contain output_dir"),
             &self.container,
             self.cancellation_token.clone(),
         )
@@ -616,6 +620,7 @@ impl TaskExecutionBackend for LsfApptainerBackend {
 
         self.manager.send(
             LsfApptainerTaskRequest {
+                engine_config: self.engine_config.clone(),
                 backend_config: self.backend_config.clone(),
                 spawn_request: request,
                 name,

--- a/crates/wdl-engine/src/eval/v1/workflow.rs
+++ b/crates/wdl-engine/src/eval/v1/workflow.rs
@@ -1799,6 +1799,7 @@ workflow test {
                 BackendConfig::Local(Default::default()),
             )]
             .into(),
+            output_dir: Some(PathBuf::from("doesnt_exist")),
             ..Default::default()
         };
         let evaluator = WorkflowEvaluator::new(config, CancellationToken::new(), Events::none())
@@ -1944,6 +1945,7 @@ workflow w {
                 BackendConfig::Local(Default::default()),
             )]
             .into(),
+            output_dir: Some(PathBuf::from("doesnt_exist")),
             ..Default::default()
         };
         let state = Arc::<State>::default();

--- a/crates/wdl-engine/tests/tasks.rs
+++ b/crates/wdl-engine/tests/tasks.rs
@@ -238,7 +238,7 @@ fn compare_result(path: &Path, result: &str) -> Result<()> {
 }
 
 /// Runs a single test.
-async fn run_test(test: &Path, config: config::Config) -> Result<()> {
+async fn run_test(test: &Path, mut config: config::Config) -> Result<()> {
     let analyzer = Analyzer::default();
     analyzer
         .add_directory(test)
@@ -301,10 +301,11 @@ async fn run_test(test: &Path, config: config::Config) -> Result<()> {
         .ok_or_else(|| anyhow!("document does not contain a task named `{name}`"))?;
     inputs.join_paths(task, |_| Ok(&test_dir_path))?;
 
-    let evaluator = TaskEvaluator::new(config, CancellationToken::new(), Events::none()).await?;
     let dir = TempDir::new().context("failed to create temporary directory")?;
     info!(dir = %dir.path().display(), "test temp dir created");
+    config.output_dir = Some(dir.path().to_path_buf());
 
+    let evaluator = TaskEvaluator::new(config, CancellationToken::new(), Events::none()).await?;
     match evaluator
         .evaluate(result.document(), task, &inputs, dir.path())
         .await

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -571,14 +571,10 @@ pub async fn run(args: Args) -> Result<()> {
         span,
     ));
 
-    let evaluator = Evaluator::new(
-        document,
-        &entrypoint,
-        inputs,
-        origins,
-        args.engine,
-        &output_dir,
-    );
+    let mut engine_config = args.engine;
+    engine_config.output_dir = Some(output_dir);
+
+    let evaluator = Evaluator::new(document, &entrypoint, inputs, origins, engine_config);
 
     let mut evaluate = evaluator.run(token.clone(), events).boxed();
 


### PR DESCRIPTION
Reduces the pain of #360, but I'm not sold on this interim solution.

Basically, I attempted to make a minimal change that would move the Apptainer image cache into the top level of the run directory by adding that dir as a field in `wdl_engine::Config`. After seeing it through to the point of making the tests pass, I think it's too much of a hack to want to land as-is.

I mention some of the reasoning in TODO comments on this branch, but I think we need a top-level `Engine` struct that contains `Config` as a field but also contains potentially-stateful fields for internal use, which is what this really amounts to. Using `#[serde(skip)]` is a tell that I'm trying to overload the `Config` as both an internally-usable structure and as a user interface for `sprocket.toml` and such.

Additionally, I think this is probably a decent opportunity to coalesce the `Evaluator` type from `wdl-cli` into either `sprocket` or (probably) `wdl-engine`, as it is currently the top-level entrypoint. Having the top-level entrypoint in `wdl-engine` will (probably?) let us do away with the awkward `Option` that currently infects the tests on this branch.

For all contributors:

- [ ] You have added a few sentences describing the PR here.
- [ ] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [ ] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have either (a) made a PR to the `next` branch in the sprocket.bio repository [if you are a Sprocket team member] or (b) have suggested any changes you _think_ need to be made to sprocket.bio in the description of your PR [if you are an external contributor].

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
