### PR TITLE
chore: fix bump CI job.

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -29,7 +29,7 @@ jobs:
           submodules: true
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - run: cargo --locked run --release --bin ci -- bump --crates-to-bump ${{ inputs.crate }}
+      - run: cargo --locked run --release -p ci --bin ci -- bump --crates-to-bump ${{ inputs.crate }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
This commit fixes the bump CI job to work now that the `wdl` and `sprocket` repos have merged.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have either (a) made a PR to the `next` branch in the sprocket.bio repository [if you are a Sprocket team member] or (b) have suggested any changes you _think_ need to be made to sprocket.bio in the description of your PR [if you are an external contributor].

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
