### PR TITLE
feat: adds `max_retries` to the `task` type

### DIFF
--- a/crates/wdl-analysis/src/types/v1.rs
+++ b/crates/wdl-analysis/src/types/v1.rs
@@ -200,7 +200,7 @@ pub fn task_task_post_evaluation_member_type(
         n if n == TASK_FIELD_NAME || n == TASK_FIELD_ID => Some(PrimitiveType::String.into()),
         n if n == TASK_FIELD_CONTAINER => Some(Type::from(PrimitiveType::String).optional()),
         n if n == TASK_FIELD_CPU => Some(PrimitiveType::Float.into()),
-        n if n == TASK_FIELD_MEMORY || n == TASK_FIELD_ATTEMPT => {
+        n if n == TASK_FIELD_MEMORY || n == TASK_FIELD_ATTEMPT || n == TASK_FIELD_MAX_RETRIES => {
             Some(PrimitiveType::Integer.into())
         }
         n if n == TASK_FIELD_GPU || n == TASK_FIELD_FPGA => {

--- a/crates/wdl-analysis/tests/analysis/task-scope-command/source.wdl
+++ b/crates/wdl-analysis/tests/analysis/task-scope-command/source.wdl
@@ -9,10 +9,12 @@ task test_command_scope {
   }
 
   command <<<
-    # Post-evaluation fields are available: name, id, attempt, previous, cpu, memory, container, gpu, fpga, disks
+    # Post-evaluation fields are available: `name`, `id`, `attempt`, `max_retries`,
+    # `previous`, `cpu`, `memory`, `container`, `gpu`, `fpga`, `disks`
     echo "name: ~{task.name}"
     echo "id: ~{task.id}"
     echo "attempt: ~{task.attempt}"
+    echo "max_retries: ~{task.max_retries}"
     echo "cpu: ~{task.cpu}"
     echo "memory: ~{task.memory}"
     echo "container: ~{select_first([task.container, 'none'])}"

--- a/crates/wdl-analysis/tests/analysis/task-scope-full/source.diagnostics
+++ b/crates/wdl-analysis/tests/analysis/task-scope-full/source.diagnostics
@@ -1,18 +1,18 @@
 error: struct `TaskPrevious` does not have a member named `not_a_member`
-   ┌─ tests/analysis/task-scope-full/source.wdl:23:24
+   ┌─ tests/analysis/task-scope-full/source.wdl:24:24
    │
-23 │     gpu: task.previous.not_a_member
+24 │     gpu: task.previous.not_a_member
    │                        ^^^^^^^^^^^^
 
 error: the `task` variable does not have a member named `cpu`
-   ┌─ tests/analysis/task-scope-full/source.wdl:26:16
+   ┌─ tests/analysis/task-scope-full/source.wdl:27:16
    │
-26 │     fpga: task.cpu > 2
+27 │     fpga: task.cpu > 2
    │                ^^^
 
 error: the `task` variable does not have a member named `memory`
-   ┌─ tests/analysis/task-scope-full/source.wdl:29:22
+   ┌─ tests/analysis/task-scope-full/source.wdl:30:22
    │
-29 │     maxRetries: task.memory / 1000000000
+30 │     maxRetries: task.memory / 1000000000
    │                      ^^^^^^
 

--- a/crates/wdl-analysis/tests/analysis/task-scope-full/source.wdl
+++ b/crates/wdl-analysis/tests/analysis/task-scope-full/source.wdl
@@ -1,7 +1,8 @@
 ## This tests that accessing members produces appropriate errors/successes.
 ##
-## TaskPreEvaluation (requirements/hints/runtime) has: name, id, attempt, previous
-## TaskPostEvaluation (command/output) has: all fields including cpu, memory, etc.
+## The `task` variable is available in both pre-evaluation contexts
+## (requirements/hints/runtime) and post-evaluation contexts (command/output),
+## but with different fields available in each context.
 
 version 1.3
 
@@ -34,6 +35,7 @@ task test_invalid_member {
     echo "name: ~{task.name}"
     echo "id: ~{task.id}"
     echo "attempt: ~{task.attempt}"
+    echo "max_retries: ~{task.max_retries}"
     echo "cpu: ~{task.cpu}"
     echo "memory: ~{task.memory}"
     echo "container: ~{task.container}"
@@ -46,6 +48,7 @@ task test_invalid_member {
     String task_name = task.name
     String task_id = task.id
     Int attempt = task.attempt
+    Int max_retries = task.max_retries
     Float cpu = task.cpu
     Int memory = task.memory
     String? container = task.container

--- a/crates/wdl-analysis/tests/analysis/task-scope-output/source.wdl
+++ b/crates/wdl-analysis/tests/analysis/task-scope-output/source.wdl
@@ -17,6 +17,7 @@ task test_output_scope {
     String task_name = task.name
     String task_id = task.id
     Int attempt = task.attempt
+    Int max_retries = task.max_retries
     Float cpu = task.cpu
     Int memory = task.memory
     String? container = task.container

--- a/crates/wdl-ast/src/v1/task.rs
+++ b/crates/wdl-ast/src/v1/task.rs
@@ -76,6 +76,10 @@ pub const TASK_FIELDS: &[(&str, &str)] = &[
          cloud services).",
     ),
     (
+        TASK_FIELD_MAX_RETRIES,
+        "The maximum number of retry attempts.",
+    ),
+    (
         TASK_FIELD_ATTEMPT,
         "The current task attempt. The value must be 0 the first time the task is executed, and \
          incremented by 1 each time the task is retried (if any).",

--- a/crates/wdl-engine/src/eval/v1/task.rs
+++ b/crates/wdl-engine/src/eval/v1/task.rs
@@ -244,7 +244,8 @@ pub(crate) fn max_retries(
     requirements
         .get(TASK_REQUIREMENT_MAX_RETRIES)
         .or_else(|| requirements.get(TASK_REQUIREMENT_MAX_RETRIES_ALIAS))
-        .map(|v| v.as_integer().expect("`max_retries` should be an int") as u64)
+        // SAFETY: `max_retries` should always evaluate to an integer.
+        .map(|v| v.as_integer().unwrap() as u64)
         .or(config_retries)
         .unwrap_or(DEFAULT_TASK_REQUIREMENT_MAX_RETRIES)
 }

--- a/crates/wdl-engine/tests/tasks/task-retry-with-memory-increase/command
+++ b/crates/wdl-engine/tests/tasks/task-retry-with-memory-increase/command
@@ -1,9 +1,9 @@
 # Fail on first two attempts, succeed on third
 if [ 2 -lt 2 ]; then
-  echo "Attempt 2: Memory=512000000, FAILING"
+  echo "Attempt 2/2: Memory=512000000, FAILING"
   exit 1
 else
-  echo "Attempt 2: Memory=512000000, SUCCESS"
+  echo "Attempt 2/2: Memory=512000000, SUCCESS"
   echo "Previous memory was: 256000000"
   exit 0
 fi

--- a/crates/wdl-engine/tests/tasks/task-retry-with-memory-increase/outputs.json
+++ b/crates/wdl-engine/tests/tasks/task-retry-with-memory-increase/outputs.json
@@ -1,5 +1,6 @@
 {
   "test_retry_memory.final_attempt": 2,
+  "test_retry_memory.max_retries": 2,
   "test_retry_memory.final_memory": 512000000,
   "test_retry_memory.previous_memory": 256000000
 }

--- a/crates/wdl-engine/tests/tasks/task-retry-with-memory-increase/source.wdl
+++ b/crates/wdl-engine/tests/tasks/task-retry-with-memory-increase/source.wdl
@@ -11,10 +11,10 @@ task test_retry_memory {
   command <<<
     # Fail on first two attempts, succeed on third
     if [ ~{task.attempt} -lt 2 ]; then
-      echo "Attempt ~{task.attempt}: Memory=~{task.memory}, FAILING"
+      echo "Attempt ~{task.attempt}/~{task.max_retries}: Memory=~{task.memory}, FAILING"
       exit 1
     else
-      echo "Attempt ~{task.attempt}: Memory=~{task.memory}, SUCCESS"
+      echo "Attempt ~{task.attempt}/~{task.max_retries}: Memory=~{task.memory}, SUCCESS"
       echo "Previous memory was: ~{select_first([task.previous.memory, 0])}"
       exit 0
     fi
@@ -22,6 +22,7 @@ task test_retry_memory {
 
   output {
     Int final_attempt = task.attempt
+    Int max_retries = task.max_retries
     Int final_memory = task.memory
     Int? previous_memory = task.previous.memory
   }

--- a/crates/wdl-engine/tests/tasks/task-retry-with-memory-increase/stdout
+++ b/crates/wdl-engine/tests/tasks/task-retry-with-memory-increase/stdout
@@ -1,2 +1,2 @@
-Attempt 2: Memory=512000000, SUCCESS
+Attempt 2/2: Memory=512000000, SUCCESS
 Previous memory was: 256000000


### PR DESCRIPTION
This PR adds the `max_retries` member to the `task` type in support of https://github.com/openwdl/wdl/issues/732 and https://github.com/openwdl/wdl/pull/733. Those links, especially #732, give the best (albeit short) defense of why I think this member needs to be present. It is essentially an argument of completeness combined with the fact that I can think of a few scenarios where one might want to use the member to crank up the resources on the last attempt.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [ ] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have either (a) made a PR to the `next` branch in the sprocket.bio repository [if you are a Sprocket team member] or (b) have suggested any changes you _think_ need to be made to sprocket.bio in the description of your PR [if you are an external contributor].

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
