### PR TITLE
feat: new `wdl-engine` evaluation entrypoints and Apptainer cache management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was renamed from `experimental_versions` to `wdl_1_3` ([#435](https://github.com/stjude-rust-labs/sprocket/pull/435)).
 * Removed the `wdl-cli` crate, absorbing its code into the `sprocket` library
   crate in preparation for future refactoring ([#450](https://github.com/stjude-rust-labs/sprocket/pull/450)).
-* Apptainer-based backends now store converted container images within each run directory, rather than in a user-specified directory ([#463](https://github.com/stjude-rust-labs/sprocket/pull/460)).
+* Apptainer-based backends now store converted container images within each run directory, rather than in a user-specified directory ([#463](https://github.com/stjude-rust-labs/sprocket/pull/463)).
 
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was renamed from `experimental_versions` to `wdl_1_3` ([#435](https://github.com/stjude-rust-labs/sprocket/pull/435)).
 * Removed the `wdl-cli` crate, absorbing its code into the `sprocket` library
   crate in preparation for future refactoring ([#450](https://github.com/stjude-rust-labs/sprocket/pull/450)).
+* Apptainer-based backends now store converted container images within each run directory, rather than in a user-specified directory ([#463](https://github.com/stjude-rust-labs/sprocket/pull/460)).
+
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ edition = "2024"
 authors = ["The Sprocket project contributors"]
 homepage = "https://sprocket.bio"
 repository = "https://github.com/stjude-rust-labs/sprocket"
-rust-version = "1.89.0"
+rust-version = "1.91.1"
 
 [workspace.dependencies]
 ammonia = "4.1.2"

--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed how cancellation is supported by the engine; the engine can now wait for executing tasks to complete before canceling them (slow failure mode) or immediately cancel the executing tasks (fast failure mode) ([#444](https://github.com/stjude-rust-labs/sprocket/pull/444)).
 * Added optional CPU and memory limits to the queue definitions in the LSF + Apptainer backend configuration. This is a breaking change for previous LSF configurations, as the queues are now a struct with a required `name` string field, rather than just a bare string ([#429](https://github.com/stjude-rust-labs/sprocket/pull/429)).
 * Changed a number of types in the public interface in preparation for a larger refactoring ([#460](https://github.com/stjude-rust-labs/sprocket/pull/460)).
+* Introduced a unified `TopLevelEvaluator` type as a common context for task and workflow evaluations ([#463](https://github.com/stjude-rust-labs/sprocket/pull/460)).
+* Apptainer-based backends now store converted container images within each run directory, rather than in a user-specified directory ([#463](https://github.com/stjude-rust-labs/sprocket/pull/460)).
 
 #### Fixed
 

--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -24,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added optional CPU and memory limits to the queue definitions in the LSF + Apptainer backend configuration. This is a breaking change for previous LSF configurations, as the queues are now a struct with a required `name` string field, rather than just a bare string ([#429](https://github.com/stjude-rust-labs/sprocket/pull/429)).
 * Changed a number of types in the public interface in preparation for a larger refactoring ([#460](https://github.com/stjude-rust-labs/sprocket/pull/460)).
 
-
 #### Fixed
 
 * Improved the portability of generated Apptainer scripts ([#442](https://github.com/stjude-rust-labs/sprocket/pull/442)).

--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -23,8 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Changed how cancellation is supported by the engine; the engine can now wait for executing tasks to complete before canceling them (slow failure mode) or immediately cancel the executing tasks (fast failure mode) ([#444](https://github.com/stjude-rust-labs/sprocket/pull/444)).
 * Added optional CPU and memory limits to the queue definitions in the LSF + Apptainer backend configuration. This is a breaking change for previous LSF configurations, as the queues are now a struct with a required `name` string field, rather than just a bare string ([#429](https://github.com/stjude-rust-labs/sprocket/pull/429)).
 * Changed a number of types in the public interface in preparation for a larger refactoring ([#460](https://github.com/stjude-rust-labs/sprocket/pull/460)).
-* Introduced a unified `TopLevelEvaluator` type as a common context for task and workflow evaluations ([#463](https://github.com/stjude-rust-labs/sprocket/pull/460)).
-* Apptainer-based backends now store converted container images within each run directory, rather than in a user-specified directory ([#463](https://github.com/stjude-rust-labs/sprocket/pull/460)).
+* Introduced a unified `TopLevelEvaluator` type as a common context for task and workflow evaluations ([#463](https://github.com/stjude-rust-labs/sprocket/pull/463)).
+* Apptainer-based backends now store converted container images within each run directory, rather than in a user-specified directory ([#463](https://github.com/stjude-rust-labs/sprocket/pull/463)).
 
 #### Fixed
 

--- a/crates/wdl-engine/src/backend.rs
+++ b/crates/wdl-engine/src/backend.rs
@@ -158,7 +158,7 @@ pub struct TaskSpawnRequest {
     /// The attempt directory for the task's execution.
     attempt_dir: PathBuf,
     /// The root directory for the evaluation.
-    root_dir: PathBuf,
+    task_eval_root: PathBuf,
     /// The temp directory for the evaluation.
     temp_dir: PathBuf,
 }
@@ -170,7 +170,7 @@ impl TaskSpawnRequest {
         info: TaskSpawnInfo,
         attempt: u64,
         attempt_dir: PathBuf,
-        root_dir: PathBuf,
+        task_eval_root: PathBuf,
         temp_dir: PathBuf,
     ) -> Self {
         Self {
@@ -178,7 +178,7 @@ impl TaskSpawnRequest {
             info,
             attempt,
             attempt_dir,
-            root_dir,
+            task_eval_root,
             temp_dir,
         }
     }
@@ -230,9 +230,9 @@ impl TaskSpawnRequest {
         &self.attempt_dir
     }
 
-    /// The root directory for the evaluation.
-    pub fn root_dir(&self) -> &Path {
-        &self.root_dir
+    /// The root directory for the task's evaluation.
+    pub fn task_eval_root_dir(&self) -> &Path {
+        &self.task_eval_root
     }
 
     /// The temp directory for the evaluation.

--- a/crates/wdl-engine/src/backend/apptainer.rs
+++ b/crates/wdl-engine/src/backend/apptainer.rs
@@ -38,13 +38,20 @@ pub struct ApptainerConfig {
     /// executing tasks.
     pub extra_apptainer_exec_args: Option<Vec<String>>,
     /// Deprecated field.
+    ///
+    /// This was kept for compatibility with previous versions of the Apptainer
+    /// configuration fields, and may be removed in a future version. The
+    /// Apptainer images are now stored at the top level root directory of an
+    /// evaluation.
     #[serde(default)]
+    #[deprecated]
     pub apptainer_images_dir: Option<String>,
 }
 
 impl ApptainerConfig {
     /// Validate that Apptainer is appropriately configured.
     pub async fn validate(&self) -> Result<(), anyhow::Error> {
+        #[expect(deprecated)]
         if self.apptainer_images_dir.is_some() {
             warn!(
                 "`apptainer_images_dir` is deprecated and no longer has an effect. Converted \
@@ -266,7 +273,7 @@ mod tests {
             info,
             attempt: 0,
             attempt_dir: tmp.path().join("0"),
-            root_dir: tmp.path().to_path_buf(),
+            task_eval_root: tmp.path().to_path_buf(),
             temp_dir: tmp.path().join("tmp"),
         };
         (tmp, state, spawn_request)

--- a/crates/wdl-engine/src/backend/apptainer.rs
+++ b/crates/wdl-engine/src/backend/apptainer.rs
@@ -10,8 +10,9 @@ use std::path::Path;
 
 use anyhow::Context as _;
 use anyhow::anyhow;
-use images::sif_for_container;
+use images::ApptainerImages;
 use tokio_util::sync::CancellationToken;
+use tracing::warn;
 
 use super::TaskSpawnRequest;
 use crate::Value;
@@ -31,54 +32,60 @@ const GUEST_STDOUT_PATH: &str = "/mnt/task/stdout";
 const GUEST_STDERR_PATH: &str = "/mnt/task/stderr";
 
 /// Configuration for the Apptainer container runtime.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
 pub struct ApptainerConfig {
     /// Additional command-line arguments to pass to `apptainer exec` when
     /// executing tasks.
     pub extra_apptainer_exec_args: Option<Vec<String>>,
-    /// The directory in which temporary directories will be created containing
-    /// Apptainer `.sif` files.
-    ///
-    /// This should be a location that is accessible by all locations where a
-    /// task may be executed via Apptainer.
-    ///
-    /// By default, this is `$HOME/.cache/sprocket-apptainer-images`, or
-    /// `/tmp/sprocket-apptainer-images` if the home directory cannot be
-    /// determined.
-    ///
-    /// Shell-expansion is performed on this path before use, so configurations
-    /// can contain environment variables. Note that these are expanded on
-    /// the host where this code is executing, which may be different from
-    /// hosts where a scheduler may dispatch tasks for execution. Errors
-    /// will occur if the same path is not accessible in both environments.
-    #[serde(default = "default_apptainer_images_dir")]
-    pub apptainer_images_dir: String,
-}
-
-fn default_apptainer_images_dir() -> String {
-    if let Some(cache) = dirs::cache_dir() {
-        cache
-            .join("sprocket-apptainer-images")
-            .display()
-            .to_string()
-    } else {
-        std::env::temp_dir()
-            .join("sprocket-apptainer-images")
-            .display()
-            .to_string()
-    }
-}
-
-impl Default for ApptainerConfig {
-    fn default() -> Self {
-        Self {
-            extra_apptainer_exec_args: None,
-            apptainer_images_dir: default_apptainer_images_dir(),
-        }
-    }
+    /// Deprecated field.
+    #[serde(default)]
+    pub apptainer_images_dir: Option<String>,
 }
 
 impl ApptainerConfig {
+    /// Validate that Apptainer is appropriately configured.
+    pub async fn validate(&self) -> Result<(), anyhow::Error> {
+        if self.apptainer_images_dir.is_some() {
+            warn!(
+                "`apptainer_images_dir` is deprecated and no longer has an effect. Converted \
+                 images are stored in the output directory for each run."
+            );
+        }
+        Ok(())
+    }
+}
+
+/// The state of an Apptainer backend for a given top-level execution.
+///
+/// As Apptainer-converted images are shared throughout all task executions of a
+/// given invocation, only one of these state structures should be constructed
+/// per top-level task/workflow execution.
+#[derive(Debug)]
+pub struct ApptainerState {
+    /// The config.
+    config: ApptainerConfig,
+    /// The images.
+    images: ApptainerImages,
+}
+
+impl ApptainerState {
+    /// Create a new [`ApptainerState`].
+    // TODO ACF 2025-11-18: Here's a good example of why we should have separate
+    // config types for user-facing configuration and internal use. The root dir is
+    // really a configuration option, but we want the engine to be able to specify
+    // it based on how it's invoked. We *don't* want it to be something the user of
+    // `sprocket` can put in their `sprocket.toml`. We can and have played games
+    // with hiding certain fields from `serde`, but really we should rearrange these
+    // types so that we have more direct control over what's in the user interface
+    // vs not.
+    pub fn new(config: &ApptainerConfig, run_root_dir: &Path) -> Self {
+        let images = ApptainerImages::new(run_root_dir);
+        Self {
+            config: config.clone(),
+            images,
+        }
+    }
+
     /// Prepare for an Apptainer execution by ensuring the image cache is
     /// populated with the necessary container, and return a Bash script
     /// that invokes the task's `command` in the container context.
@@ -96,7 +103,10 @@ impl ApptainerConfig {
         cancellation_token: CancellationToken,
         spawn_request: &TaskSpawnRequest,
     ) -> Result<String, anyhow::Error> {
-        let container_sif = sif_for_container(self, container, cancellation_token).await?;
+        let container_sif = self
+            .images
+            .sif_for_container(container, cancellation_token)
+            .await?;
         self.generate_apptainer_script(&container_sif, spawn_request)
             .await
     }
@@ -199,7 +209,7 @@ impl ApptainerConfig {
         {
             writeln!(&mut apptainer_command, "--nv \\")?;
         }
-        if let Some(args) = &self.extra_apptainer_exec_args {
+        if let Some(args) = &self.config.extra_apptainer_exec_args {
             for arg in args {
                 writeln!(&mut apptainer_command, "{arg} \\")?;
             }
@@ -237,12 +247,9 @@ mod tests {
     use crate::http::Transferer;
     use crate::v1::test::TestEnv;
 
-    fn mk_example_task() -> (TempDir, ApptainerConfig, TaskSpawnRequest) {
+    fn mk_example_task() -> (TempDir, ApptainerState, TaskSpawnRequest) {
         let tmp = tempfile::tempdir().unwrap();
-        let config = ApptainerConfig {
-            apptainer_images_dir: tmp.path().display().to_string(),
-            ..ApptainerConfig::default()
-        };
+        let state = ApptainerState::new(&ApptainerConfig::default(), tmp.path());
         let mut env = IndexMap::new();
         env.insert("FOO".to_string(), "bar".to_string());
         env.insert("BAZ".to_string(), "\"quux\"".to_string());
@@ -262,13 +269,13 @@ mod tests {
             root_dir: tmp.path().to_path_buf(),
             temp_dir: tmp.path().join("tmp"),
         };
-        (tmp, config, spawn_request)
+        (tmp, state, spawn_request)
     }
 
     #[tokio::test]
     async fn example_task_generates() {
-        let (tmp, config, spawn_request) = mk_example_task();
-        let _ = config
+        let (tmp, state, spawn_request) = mk_example_task();
+        let _ = state
             .generate_apptainer_script(&tmp.path().join("non-existent.sif"), &spawn_request)
             .await
             .inspect_err(|e| eprintln!("{e:#?}"))
@@ -280,8 +287,8 @@ mod tests {
     // on Windows anytime soon, we limit this test to Unixy systems
     #[cfg(unix)]
     async fn example_task_shellchecks() {
-        let (tmp, config, spawn_request) = mk_example_task();
-        let script = config
+        let (tmp, state, spawn_request) = mk_example_task();
+        let script = state
             .generate_apptainer_script(&tmp.path().join("non-existent.sif"), &spawn_request)
             .await
             .inspect_err(|e| eprintln!("{e:#?}"))

--- a/crates/wdl-engine/src/backend/apptainer/images.rs
+++ b/crates/wdl-engine/src/backend/apptainer/images.rs
@@ -24,39 +24,16 @@
 //! still benefit from the Apptainer cache when building new `.sif` files, so
 //! this is not much of a slowdown, but it does increase disk space consumption
 //! depending on where the images directory is created.
-//!
-//! NOTE ACF 2025-09-22: This is currently a ⚠️ Hack Zone ⚠️ and is not meant to
-//! reflect final behavior.
-//!
-//! We don't currently have a notion of a top-level directory for an entire
-//! workflow execution; the `root` path for each workflow and task evaluator is
-//! specific to _that_ workflow or task, but the point of keeping our own cache
-//! of Apptainer images is to avoid pushing our luck with spotty
-//! container registries by inducing repeated requests for the same image.
-//!
-//! For expedience, this implementation makes the simplifying assumption that we
-//! have one top-level workflow execution per process, and keeps the images
-//! directory in a global variable. This should be replaced with something more
-//! robust, but currently fits the execution model of the `sprocket`
-//! CLI well enough to proceed.
-//!
-//! Since an ordinary `cargo test` runs each test executable once, and each
-//! executable can contain many targets, this hack has a particularly distorting
-//! effect on tests of this backend. Consider using `cargo nextest` to run each
-//! target in a separate process in order to eliminate cross-test target
-//! interference.
 
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Stdio;
 use std::sync::Arc;
-use std::sync::LazyLock;
 use std::sync::Mutex;
 
-use anyhow::Context as _;
+use anyhow::Context;
 use anyhow::anyhow;
-use tempfile::TempDir;
 use tokio::io::AsyncBufReadExt as _;
 use tokio::io::BufReader;
 use tokio::process::Command;
@@ -70,89 +47,77 @@ use tracing::info;
 use tracing::trace;
 use tracing::warn;
 
-use super::ApptainerConfig;
-
-/// The path to the global cache of `.sif`-format container images.
-static APPTAINER_IMAGES_DIR: OnceCell<PathBuf> = OnceCell::const_new();
-/// A global map from container strings to paths pointing to the `.sif` version
-/// of that container.
-static APPTAINER_IMAGES: LazyLock<Mutex<HashMap<String, Arc<OnceCell<PathBuf>>>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-/// Get the directory containing converted `.sif`-format container images.
-///
-/// See the module-level documentation for details about the current behavior,
-/// which unfortunately depends on global variables.
-pub(crate) async fn global_apptainer_images_dir(
-    config: &ApptainerConfig,
-) -> Result<&'static Path, anyhow::Error> {
-    APPTAINER_IMAGES_DIR
-        .get_or_try_init(|| async {
-            // Create a new temp directory to hold the images for this run. This approach
-            // leaks space, but when using the default tmpdir or a
-            // user-controlled destination, the system or user is hopefully able
-            // to manage consumption appropriately enough for this interim
-            // solution.
-            let path = {
-                let expanded =
-                    PathBuf::from(shellexpand::full(&config.apptainer_images_dir)?.into_owned());
-                tokio::fs::create_dir_all(&expanded).await?;
-                TempDir::with_prefix_in("sprocket-apptainer-images-", &expanded)?.keep()
-            };
-            Ok::<PathBuf, anyhow::Error>(path)
-        })
-        .await
-        .context("initializing Apptainer images directory")
-        .map(|buf| buf.as_path())
+/// Apptainer images that have been converted to `.sif` from OCI format.
+#[derive(Debug)]
+pub struct ApptainerImages {
+    /// The directory in which the `.sif` images should be created.
+    images_dir: PathBuf,
+    /// The map of `container` specifications to `.sif` paths.
+    images: Mutex<HashMap<String, Arc<OnceCell<PathBuf>>>>,
 }
 
-/// Get the path to the container image in `.sif` format, potentially performing
-/// an `apptainer pull` if the image cache has not already been populated.
-pub(crate) async fn sif_for_container(
-    config: &ApptainerConfig,
-    container: &str,
-    cancellation_token: CancellationToken,
-) -> Result<PathBuf, anyhow::Error> {
-    let once = {
-        let mut map = APPTAINER_IMAGES.lock().unwrap();
-        map.entry(container.to_owned())
-            .or_insert_with(|| Arc::new(OnceCell::new()))
-            .clone()
-    };
-    let container = container.to_owned();
-    once.get_or_try_init(|| async move {
-        let sif_filename = container.replace("/", "_2f_").replace(":", "_3a_");
-        let sif_path = global_apptainer_images_dir(config)
-            .await?
-            // Append `.sif` to the filename. It would be nice to use a method like
-            // [`with_added_extension()`](https://doc.rust-lang.org/std/path/struct.Path.html#method.with_added_extension)
-            // instead, but it's not stable yet.
-            .join(format!("{sif_filename}.sif"));
+impl ApptainerImages {
+    /// Make a new [`ApptainerImages`].
+    pub fn new(run_root_dir: &Path) -> Self {
+        Self {
+            images_dir: run_root_dir.join("apptainer-images"),
+            images: Mutex::new(HashMap::new()),
+        }
+    }
 
-        let retry = Retry::spawn_notify(
-            // TODO ACF 2025-09-22: configure the retry behavior based on actual experience with
-            // flakiness of the container registries. This is a finger-in-the-wind guess at some
-            // reasonable parameters that shouldn't lead to us making our own problems worse by
-            // overwhelming registries with repeated retries.
-            ExponentialBackoff::from_millis(50)
-                .max_delay_millis(60_000)
-                .take(10),
-            || try_pull(&sif_path, &container),
-            |e, _| {
-                warn!(e = %e, "`apptainer pull` failed");
-            },
-        );
-
-        tokio::select! {
-            _ = cancellation_token.cancelled() => return Err(anyhow!("task execution cancelled")),
-            res = retry => res?,
+    /// Get the path to the container image in `.sif` format, potentially
+    /// performing an `apptainer pull` if the image cache has not already
+    /// been populated.
+    pub(crate) async fn sif_for_container(
+        &self,
+        container: &str,
+        cancellation_token: CancellationToken,
+    ) -> Result<PathBuf, anyhow::Error> {
+        let once = {
+            let mut map = self.images.lock().unwrap();
+            map.entry(container.to_owned())
+                .or_insert_with(|| Arc::new(OnceCell::new()))
+                .clone()
         };
+        let container = container.to_owned();
+        once.get_or_try_init(|| async move {
+            tokio::fs::create_dir_all(&self.images_dir).await?;
+            let sif_filename = container.replace("/", "_2f_").replace(":", "_3a_");
+            let sif_path = self
+                .images_dir
+                .join(sif_filename)
+                .with_added_extension("sif");
 
-        info!(sif_path = %sif_path.display(), container, "image pulled successfully");
-        Ok(sif_path)
-    })
-    .await
-    .cloned()
+            let retry = Retry::spawn_notify(
+                // TODO ACF 2025-09-22: configure the retry behavior based on actual experience
+                // with flakiness of the container registries. This is a
+                // finger-in-the-wind guess at some reasonable parameters that
+                // shouldn't lead to us making our own problems worse by
+                // overwhelming registries with repeated retries.
+                ExponentialBackoff::from_millis(50)
+                    .max_delay_millis(60_000)
+                    .take(10),
+                || try_pull(&sif_path, &container),
+                |e, _| {
+                    warn!(e = %e, "`apptainer pull` failed");
+                },
+            );
+
+            tokio::select! {
+                _ = cancellation_token.cancelled() =>
+                    return Err(anyhow!("task execution cancelled")),
+                res = retry =>
+                    res.with_context(
+                        || format!("pulling Apptainer image for container `{container}`")
+                    )?,
+            };
+
+            info!(sif_path = %sif_path.display(), container, "image pulled successfully");
+            Ok(sif_path)
+        })
+        .await
+        .cloned()
+    }
 }
 
 /// Try once to use `apptainer pull` to build the `.sif` file.

--- a/crates/wdl-engine/src/backend/lsf_apptainer.rs
+++ b/crates/wdl-engine/src/backend/lsf_apptainer.rs
@@ -11,6 +11,7 @@
 //! `bsub`/`apptainer` scripts.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::process::Stdio;
 use std::sync::Arc;
 
@@ -33,6 +34,7 @@ use tracing::error;
 use tracing::trace;
 use tracing::warn;
 
+use super::ApptainerState;
 use super::TaskExecutionBackend;
 use super::TaskManager;
 use super::TaskManagerRequest;
@@ -63,6 +65,8 @@ const LSF_JOB_NAME_MAX_LENGTH: usize = 4094;
 struct LsfApptainerTaskRequest {
     /// The desired configuration of the backend.
     backend_config: Arc<LsfApptainerBackendConfig>,
+    /// The Apptainer state for the backend,
+    apptainer_state: Arc<ApptainerState>,
     /// The name of the task, potentially truncated to fit within the LSF job
     /// name length limit.
     name: String,
@@ -144,8 +148,7 @@ impl TaskManagerRequest for LsfApptainerTaskRequest {
         .await?;
 
         let apptainer_command = self
-            .backend_config
-            .apptainer_config
+            .apptainer_state
             .prepare_apptainer_command(
                 &self.container,
                 self.cancellation_token.clone(),
@@ -357,15 +360,25 @@ pub struct LsfApptainerBackend {
     manager: TaskManager<LsfApptainerTaskRequest>,
     /// Sender for crankshaft events.
     crankshaft_events: Option<broadcast::Sender<Event>>,
+    /// Apptainer state.
+    apptainer_state: Arc<ApptainerState>,
 }
 
 impl LsfApptainerBackend {
     /// Create a new backend.
+    ///
+    /// The `run_root_dir` argument should be a directory that exists for the
+    /// duration of the entire top-level evaluation. It is used to store
+    /// Apptainer images which should only be created once per container per
+    /// run.
     pub fn new(
+        run_root_dir: &Path,
         engine_config: Arc<Config>,
         backend_config: Arc<LsfApptainerBackendConfig>,
         crankshaft_events: Option<broadcast::Sender<Event>>,
     ) -> Self {
+        let apptainer_state =
+            ApptainerState::new(&backend_config.apptainer_config, run_root_dir).into();
         Self {
             engine_config,
             backend_config,
@@ -375,6 +388,7 @@ impl LsfApptainerBackend {
             // throw jobs at the cluster.
             manager: TaskManager::new_unlimited(u64::MAX, u64::MAX),
             crankshaft_events,
+            apptainer_state,
         }
     }
 }
@@ -571,6 +585,7 @@ impl TaskExecutionBackend for LsfApptainerBackend {
         self.manager.send(
             LsfApptainerTaskRequest {
                 backend_config: self.backend_config.clone(),
+                apptainer_state: self.apptainer_state.clone(),
                 spawn_request: request,
                 name,
                 container,
@@ -786,6 +801,9 @@ impl LsfApptainerBackendConfig {
         if let Some(queue) = self.fpga_lsf_queue.as_ref() {
             queue.validate("fpga").await?;
         }
+
+        self.apptainer_config.validate().await?;
+
         Ok(())
     }
 

--- a/crates/wdl-engine/src/backend/slurm_apptainer.rs
+++ b/crates/wdl-engine/src/backend/slurm_apptainer.rs
@@ -11,6 +11,7 @@
 //! generated `srun`/`apptainer` scripts.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::process::Stdio;
 use std::sync::Arc;
 
@@ -34,6 +35,7 @@ use tracing::trace;
 use tracing::warn;
 
 use super::ApptainerConfig;
+use super::ApptainerState;
 use super::TaskExecutionBackend;
 use super::TaskManager;
 use super::TaskManagerRequest;
@@ -65,6 +67,8 @@ const SLURM_JOB_NAME_MAX_LENGTH: usize = 1024;
 struct SlurmApptainerTaskRequest {
     /// The desired configuration of the backend.
     backend_config: Arc<SlurmApptainerBackendConfig>,
+    /// The Apptainer state for the backend,
+    apptainer_state: Arc<ApptainerState>,
     /// The name of the task, potentially truncated to fit within the Slurm job
     /// name length limit.
     name: String,
@@ -146,8 +150,7 @@ impl TaskManagerRequest for SlurmApptainerTaskRequest {
         .await?;
 
         let apptainer_command = self
-            .backend_config
-            .apptainer_config
+            .apptainer_state
             .prepare_apptainer_command(
                 &self.container,
                 self.cancellation_token.clone(),
@@ -366,15 +369,20 @@ pub struct SlurmApptainerBackend {
     manager: TaskManager<SlurmApptainerTaskRequest>,
     /// Sender for crankshaft events.
     crankshaft_events: Option<broadcast::Sender<Event>>,
+    /// Apptainer state.
+    apptainer_state: Arc<ApptainerState>,
 }
 
 impl SlurmApptainerBackend {
     /// Create a new backend.
     pub fn new(
+        run_root_dir: &Path,
         engine_config: Arc<Config>,
         backend_config: Arc<SlurmApptainerBackendConfig>,
         crankshaft_events: Option<broadcast::Sender<Event>>,
     ) -> Self {
+        let apptainer_state =
+            ApptainerState::new(&backend_config.apptainer_config, run_root_dir).into();
         Self {
             engine_config,
             backend_config,
@@ -384,6 +392,7 @@ impl SlurmApptainerBackend {
             // just throw jobs at the cluster.
             manager: TaskManager::new_unlimited(u64::MAX, u64::MAX),
             crankshaft_events,
+            apptainer_state,
         }
     }
 }
@@ -592,6 +601,7 @@ impl TaskExecutionBackend for SlurmApptainerBackend {
         self.manager.send(
             SlurmApptainerTaskRequest {
                 backend_config: self.backend_config.clone(),
+                apptainer_state: self.apptainer_state.clone(),
                 spawn_request: request,
                 name,
                 container,
@@ -821,6 +831,9 @@ impl SlurmApptainerBackendConfig {
         if let Some(partition) = &self.fpga_slurm_partition {
             partition.validate("fpga").await?;
         }
+
+        self.apptainer_config.validate().await?;
+
         Ok(())
     }
 

--- a/crates/wdl-engine/src/config.rs
+++ b/crates/wdl-engine/src/config.rs
@@ -1,6 +1,7 @@
 //! Implementation of engine configuration.
 
 use std::borrow::Cow;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -299,6 +300,7 @@ impl Config {
     /// Creates a new task execution backend based on this configuration.
     pub async fn create_backend(
         self: &Arc<Self>,
+        run_root_dir: &Path,
         events: Option<broadcast::Sender<Event>>,
     ) -> Result<Arc<dyn TaskExecutionBackend>> {
         let config = if self.backend.is_none() && self.backends.len() < 2 {
@@ -332,11 +334,13 @@ impl Config {
                 TesBackend::new(self.clone(), config, events).await?,
             )),
             BackendConfig::LsfApptainer(config) => Ok(Arc::new(LsfApptainerBackend::new(
+                run_root_dir,
                 self.clone(),
                 config.clone(),
                 events,
             ))),
             BackendConfig::SlurmApptainer(config) => Ok(Arc::new(SlurmApptainerBackend::new(
+                run_root_dir,
                 self.clone(),
                 config.clone(),
                 events,

--- a/crates/wdl-engine/src/eval/v1.rs
+++ b/crates/wdl-engine/src/eval/v1.rs
@@ -15,7 +15,6 @@ use anyhow::Result;
 pub use expr::*;
 use serde::Serialize;
 pub use task::*;
-pub use workflow::*;
 
 use super::CancellationContext;
 use super::Events;

--- a/crates/wdl-engine/src/eval/v1.rs
+++ b/crates/wdl-engine/src/eval/v1.rs
@@ -46,6 +46,10 @@ fn write_json_file(path: impl AsRef<Path>, value: &impl Serialize) -> Result<()>
 /// an entire execution. This type is suitable for once-per-execution values
 /// like a shared container image cache, and new instances should not be created
 /// for evaluating subgraphs of the initial execution.
+///
+/// This type is meant to be cheaply cloned and sendable between threads. When
+/// adding to it, make sure to use an `Arc` for any non-trivially-sized data.
+#[derive(Clone)]
 pub struct TopLevelEvaluator {
     /// The associated evaluation configuration.
     config: Arc<Config>,
@@ -83,41 +87,5 @@ impl TopLevelEvaluator {
             cancellation,
             transferer: Arc::new(transferer),
         })
-    }
-
-    /// Creates a new task evaluator with the given configuration, backend,
-    /// cancellation token, and transferer.
-    ///
-    /// This method does not validate the configuration.
-    pub(crate) fn new_unchecked(
-        config: Arc<Config>,
-        backend: Arc<dyn TaskExecutionBackend>,
-        cancellation: CancellationContext,
-        transferer: Arc<dyn Transferer>,
-    ) -> Self {
-        Self {
-            config,
-            backend,
-            cancellation,
-            transferer,
-        }
-    }
-
-    // TODO ACF 2025-11-17: we shouldn't need to leak Arcs in these types once we
-    // stop cloning and recreating the top-level stuff
-    pub fn config(&self) -> &Arc<Config> {
-        &self.config
-    }
-
-    pub fn backend(&self) -> &Arc<dyn TaskExecutionBackend> {
-        &self.backend
-    }
-
-    pub fn cancellation(&self) -> &CancellationContext {
-        &self.cancellation
-    }
-
-    pub fn transferer(&self) -> &Arc<dyn Transferer> {
-        &self.transferer
     }
 }

--- a/crates/wdl-engine/src/eval/v1/task.rs
+++ b/crates/wdl-engine/src/eval/v1/task.rs
@@ -645,6 +645,7 @@ impl EvaluationContext for TaskEvaluationContext<'_, '_> {
 
 /// Represents task evaluation state.
 struct State<'a> {
+    /// The top-level evaluation context.
     top_level: TopLevelEvaluator,
     /// The temp directory.
     temp_dir: &'a Path,
@@ -676,6 +677,7 @@ struct State<'a> {
 }
 
 impl<'a> State<'a> {
+    /// Get the [`Transferer`] for this evaluation.
     fn transferer(&self) -> &Arc<dyn Transferer> {
         &self.top_level.transferer
     }

--- a/crates/wdl-engine/src/eval/v1/task.rs
+++ b/crates/wdl-engine/src/eval/v1/task.rs
@@ -925,6 +925,24 @@ impl TopLevelEvaluator {
             transferer,
         }
     }
+
+    // TODO ACF 2025-11-17: we shouldn't need to leak Arcs in these types once we
+    // stop cloning and recreating the top-level stuff
+    pub fn config(&self) -> &Arc<Config> {
+        &self.config
+    }
+
+    pub fn backend(&self) -> &Arc<dyn TaskExecutionBackend> {
+        &self.backend
+    }
+
+    pub fn cancellation(&self) -> &CancellationContext {
+        &self.cancellation
+    }
+
+    pub fn transferer(&self) -> &Arc<dyn Transferer> {
+        &self.transferer
+    }
 }
 
 /// Evaluates the given task.
@@ -942,7 +960,7 @@ pub async fn evaluate_task(
         return Err(anyhow!("cannot evaluate a document with errors").into());
     }
 
-    let result = perform_evaluation(
+    let result = perform_task_evaluation(
         top_level,
         document,
         task,
@@ -963,7 +981,7 @@ pub async fn evaluate_task(
 ///
 /// This method skips checking the document (and its transitive imports) for
 /// analysis errors as the check occurs at the `evaluate` entrypoint.
-pub(crate) async fn perform_evaluation(
+pub(crate) async fn perform_task_evaluation(
     top_level: &TopLevelEvaluator,
     document: &Document,
     task: &Task,

--- a/crates/wdl-engine/src/eval/v1/workflow.rs
+++ b/crates/wdl-engine/src/eval/v1/workflow.rs
@@ -574,6 +574,7 @@ pub async fn evaluate_workflow(
     top_level: &TopLevelEvaluator,
     document: &Document,
     inputs: WorkflowInputs,
+    // TODO ACF 2025-11-18: redundant with top_level
     root_dir: impl AsRef<Path>,
 ) -> EvaluationResult<Outputs> {
     let workflow = document
@@ -1847,9 +1848,10 @@ workflow test {
             .into(),
             ..Default::default()
         };
-        let evaluator = TopLevelEvaluator::new(config, Default::default(), Events::none())
-            .await
-            .unwrap();
+        let evaluator =
+            TopLevelEvaluator::new(root_dir.path(), config, Default::default(), Events::none())
+                .await
+                .unwrap();
 
         // Evaluate the `test` workflow in `source.wdl` using the default local backend
         let mut inputs = WorkflowInputs::default();
@@ -2003,9 +2005,10 @@ workflow foo {
             experimental_features_enabled: true,
             ..Default::default()
         };
-        let evaluator = TopLevelEvaluator::new(config, Default::default(), Events::none())
-            .await
-            .unwrap();
+        let evaluator =
+            TopLevelEvaluator::new(root_dir.path(), config, Default::default(), Events::none())
+                .await
+                .unwrap();
 
         let mut inputs = WorkflowInputs::default();
         inputs.set("useBlue", true);
@@ -2246,7 +2249,7 @@ workflow w {
             }
         });
 
-        let evaluator = TopLevelEvaluator::new(config, Default::default(), events)
+        let evaluator = TopLevelEvaluator::new(root_dir.path(), config, Default::default(), events)
             .await
             .unwrap();
 
@@ -2323,9 +2326,14 @@ workflow w {
             ..Default::default()
         };
         let cancellation = CancellationContext::new(FailureMode::Slow);
-        let evaluator = TopLevelEvaluator::new(config, cancellation.clone(), Events::none())
-            .await
-            .unwrap();
+        let evaluator = TopLevelEvaluator::new(
+            root_dir.path(),
+            config,
+            cancellation.clone(),
+            Events::none(),
+        )
+        .await
+        .unwrap();
 
         let mut evaluation = evaluate_workflow(
             &evaluator,

--- a/crates/wdl-engine/src/eval/v1/workflow.rs
+++ b/crates/wdl-engine/src/eval/v1/workflow.rs
@@ -561,6 +561,7 @@ struct State {
 }
 
 impl State {
+    /// Get the [`Transferer`] for this evaluation.
     fn transferer(&self) -> &dyn Transferer {
         self.top_level.transferer.as_ref()
     }
@@ -1498,6 +1499,7 @@ async fn evaluate_call(
     scope: ScopeIndex,
     stmt: &CallStatement<SyntaxNode>,
 ) -> EvaluationResult<()> {
+    #[allow(clippy::missing_docs_in_private_items)]
     enum Target<'a> {
         Task(&'a Task),
         Workflow,
@@ -1520,7 +1522,7 @@ async fn evaluate_call(
                 Target::Task(task) => {
                     debug!(caller_id, callee_id, "evaluating call to task");
                     perform_task_evaluation(
-                        &top_level,
+                        top_level,
                         document,
                         task,
                         &inputs.unwrap_task_inputs(),
@@ -1533,7 +1535,7 @@ async fn evaluate_call(
                 Target::Workflow => {
                     debug!(caller_id, callee_id, "evaluating call to workflow");
                     perform_workflow_evaluation(
-                        &top_level,
+                        top_level,
                         document,
                         inputs.unwrap_workflow_inputs(),
                         root_dir,

--- a/crates/wdl-engine/tests/tasks.rs
+++ b/crates/wdl-engine/tests/tasks.rs
@@ -50,7 +50,6 @@ use wdl_engine::Events;
 use wdl_engine::Inputs;
 use wdl_engine::path::EvaluationPath;
 use wdl_engine::v1::TopLevelEvaluator;
-use wdl_engine::v1::evaluate_task;
 
 mod common;
 
@@ -148,7 +147,10 @@ fn run_test(test: &Path, config: TestConfig) -> BoxFuture<'_, Result<()>> {
             Events::none(),
         )
         .await?;
-        match evaluate_task(&evaluator, result.document(), task, &inputs, dir.path()).await {
+        match evaluator
+            .evaluate_task(result.document(), task, &inputs, dir.path())
+            .await
+        {
             Ok(evaluated) => {
                 compare_evaluation_results(&test_dir, dir.path(), &evaluated)?;
 

--- a/crates/wdl-engine/tests/workflows.rs
+++ b/crates/wdl-engine/tests/workflows.rs
@@ -39,7 +39,6 @@ use wdl_engine::Events;
 use wdl_engine::Inputs;
 use wdl_engine::path::EvaluationPath;
 use wdl_engine::v1::TopLevelEvaluator;
-use wdl_engine::v1::evaluate_workflow;
 
 mod common;
 
@@ -111,7 +110,10 @@ fn run_test(test: &Path, config: TestConfig) -> BoxFuture<'_, Result<()>> {
             Events::none(),
         )
         .await?;
-        match evaluate_workflow(&evaluator, result.document(), inputs.clone(), &dir).await {
+        match evaluator
+            .evaluate_workflow(result.document(), inputs.clone(), &dir)
+            .await
+        {
             Ok(outputs) => {
                 let outputs = outputs.with_name(workflow.name());
                 let outputs = to_string_pretty(&outputs).context("failed to serialize outputs")?;

--- a/crates/wdl-engine/tests/workflows.rs
+++ b/crates/wdl-engine/tests/workflows.rs
@@ -38,7 +38,8 @@ use wdl_engine::EvaluationError;
 use wdl_engine::Events;
 use wdl_engine::Inputs;
 use wdl_engine::path::EvaluationPath;
-use wdl_engine::v1::WorkflowEvaluator;
+use wdl_engine::v1::TopLevelEvaluator;
+use wdl_engine::v1::evaluate_workflow;
 
 mod common;
 
@@ -104,11 +105,8 @@ fn run_test(test: &Path, config: TestConfig) -> BoxFuture<'_, Result<()>> {
             info!(dir = %dir.path().display(), "test temp dir created");
         }
         let evaluator =
-            WorkflowEvaluator::new(config.engine, Default::default(), Events::none()).await?;
-        match evaluator
-            .evaluate(result.document(), inputs.clone(), &dir)
-            .await
-        {
+            TopLevelEvaluator::new(config.engine, Default::default(), Events::none()).await?;
+        match evaluate_workflow(&evaluator, result.document(), inputs.clone(), &dir).await {
             Ok(outputs) => {
                 let outputs = outputs.with_name(workflow.name());
                 let outputs = to_string_pretty(&outputs).context("failed to serialize outputs")?;

--- a/crates/wdl-engine/tests/workflows.rs
+++ b/crates/wdl-engine/tests/workflows.rs
@@ -104,8 +104,13 @@ fn run_test(test: &Path, config: TestConfig) -> BoxFuture<'_, Result<()>> {
         } else {
             info!(dir = %dir.path().display(), "test temp dir created");
         }
-        let evaluator =
-            TopLevelEvaluator::new(config.engine, Default::default(), Events::none()).await?;
+        let evaluator = TopLevelEvaluator::new(
+            dir.path(),
+            config.engine,
+            Default::default(),
+            Events::none(),
+        )
+        .await?;
         match evaluate_workflow(&evaluator, result.document(), inputs.clone(), &dir).await {
             Ok(outputs) => {
                 let outputs = outputs.with_name(workflow.name());

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -13,8 +13,6 @@ use wdl::engine::Inputs;
 use wdl::engine::Outputs;
 use wdl::engine::config::Config;
 use wdl::engine::v1::TopLevelEvaluator;
-use wdl::engine::v1::evaluate_task;
-use wdl::engine::v1::evaluate_workflow;
 
 use crate::inputs::OriginPaths;
 
@@ -87,7 +85,8 @@ impl<'a> Evaluator<'a> {
                 let evaluator =
                     TopLevelEvaluator::new(self.output_dir, self.config, cancellation, events)
                         .await?;
-                evaluate_task(&evaluator, self.document, task, inputs, self.output_dir)
+                evaluator
+                    .evaluate_task(self.document, task, inputs, self.output_dir)
                     .await
                     .and_then(EvaluatedTask::into_result)
             }
@@ -117,7 +116,9 @@ impl<'a> Evaluator<'a> {
                 let evaluator =
                     TopLevelEvaluator::new(self.output_dir, self.config, cancellation, events)
                         .await?;
-                evaluate_workflow(&evaluator, self.document, inputs, self.output_dir).await
+                evaluator
+                    .evaluate_workflow(self.document, inputs, self.output_dir)
+                    .await
             }
         }
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -13,8 +13,8 @@ use wdl::engine::Inputs;
 use wdl::engine::Outputs;
 use wdl::engine::config::Config;
 use wdl::engine::v1::TopLevelEvaluator;
-use wdl::engine::v1::WorkflowEvaluator;
 use wdl::engine::v1::evaluate_task;
+use wdl::engine::v1::evaluate_workflow;
 
 use crate::inputs::OriginPaths;
 
@@ -112,10 +112,8 @@ impl<'a> Evaluator<'a> {
                     })
                     .await?;
 
-                let evaluator = WorkflowEvaluator::new(self.config, cancellation, events).await?;
-                evaluator
-                    .evaluate(self.document, inputs, self.output_dir)
-                    .await
+                let evaluator = TopLevelEvaluator::new(self.config, cancellation, events).await?;
+                evaluate_workflow(&evaluator, self.document, inputs, self.output_dir).await
             }
         }
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -12,8 +12,9 @@ use wdl::engine::Events;
 use wdl::engine::Inputs;
 use wdl::engine::Outputs;
 use wdl::engine::config::Config;
-use wdl::engine::v1::TaskEvaluator;
+use wdl::engine::v1::TopLevelEvaluator;
 use wdl::engine::v1::WorkflowEvaluator;
+use wdl::engine::v1::evaluate_task;
 
 use crate::inputs::OriginPaths;
 
@@ -83,10 +84,8 @@ impl<'a> Evaluator<'a> {
                     })
                     .await?;
 
-                let evaluator = TaskEvaluator::new(self.config, cancellation, events).await?;
-
-                evaluator
-                    .evaluate(self.document, task, inputs, self.output_dir)
+                let evaluator = TopLevelEvaluator::new(self.config, cancellation, events).await?;
+                evaluate_task(&evaluator, self.document, task, inputs, self.output_dir)
                     .await
                     .and_then(EvaluatedTask::into_result)
             }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -84,7 +84,9 @@ impl<'a> Evaluator<'a> {
                     })
                     .await?;
 
-                let evaluator = TopLevelEvaluator::new(self.config, cancellation, events).await?;
+                let evaluator =
+                    TopLevelEvaluator::new(self.output_dir, self.config, cancellation, events)
+                        .await?;
                 evaluate_task(&evaluator, self.document, task, inputs, self.output_dir)
                     .await
                     .and_then(EvaluatedTask::into_result)
@@ -112,7 +114,9 @@ impl<'a> Evaluator<'a> {
                     })
                     .await?;
 
-                let evaluator = TopLevelEvaluator::new(self.config, cancellation, events).await?;
+                let evaluator =
+                    TopLevelEvaluator::new(self.output_dir, self.config, cancellation, events)
+                        .await?;
                 evaluate_workflow(&evaluator, self.document, inputs, self.output_dir).await
             }
         }


### PR DESCRIPTION
Closes #360, and provides a small measure of unification for the `wdl-engine` evaluator entrypoints.

For implementors, there is now a `TopLevelEvaluator` struct that's available throughout task and workflow evaluation and is suitable for tracking once-per-run data like the Apptainer image cache. Previously, only the root of the current task or workflow's execution was available, which would have led to no image reuse at all if it had been used for Apptainer.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have either (a) made a PR to the `next` branch in the sprocket.bio repository [if you are a Sprocket team member] or (b) have suggested any changes you _think_ need to be made to sprocket.bio in the description of your PR [if you are an external contributor].