### PR TITLE
feat: add LSF job name prefix and byte limit

### DIFF
--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Added
+
+* Added a configurable prefix for LSF job names and ensured the byte-length
+  limit matches LSF's behavior ([#362](https://github.com/stjude-rust-labs/sprocket/issues/362)).
+
 #### Fixed
 
 * Fixed an issue where task requirements and hints sources from an inputs file

--- a/crates/wdl-engine/src/config.rs
+++ b/crates/wdl-engine/src/config.rs
@@ -1380,6 +1380,10 @@ pub struct LsfApptainerBackendConfig {
     /// Additional command-line arguments to pass to `bsub` when submitting jobs
     /// to LSF.
     pub extra_bsub_args: Option<Vec<String>>,
+    /// Prefix to add to every LSF job name before the task identifier. This is
+    /// truncated as needed to satisfy the byte-oriented LSF job name limit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub job_name_prefix: Option<String>,
     /// The configuration of Apptainer, which is used as the container runtime
     /// on the compute nodes where LSF dispatches tasks.
     ///

--- a/test-configs/lsf-apptainer-engine.toml
+++ b/test-configs/lsf-apptainer-engine.toml
@@ -5,4 +5,5 @@ backends.default.default_lsf_queue.name = "short"
 backends.default.default_lsf_queue.max_cpu_per_task = 4
 backends.default.default_lsf_queue.max_memory_per_task = "16 GiB"
 backends.default.max_scatter_concurrency = 200
+backends.default.job_name_prefix = "sprocket_"
 experimental_features_enabled = true


### PR DESCRIPTION
Add a customizable prefix to LSF job names and fix how their length is limited. This PR introduces an optional job_name_prefix for the LSF + Apptainer backend, uses a new helper to build prefix + identifier while enforcing LSF’s 4094‑byte UTF‑8 limit, and adds unit tests plus a sample config update to cover the new behavior.

Fixes #362 

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have either (a) made a PR to the `next` branch in the sprocket.bio repository [if you are a Sprocket team member] or (b) have suggested any changes you _think_ need to be made to sprocket.bio in the description of your PR [if you are an external contributor].

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
