### PR TITLE
fix: improve digest caching.

### DIFF
--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -15,7 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-* Cache file digests that are calculated during a directory digest calculation ([#488](https://github.com/stjude-rust-labs/sprocket/pull/488)).
+* Cache file digests that are calculated during local directory digest
+  calculation. Note: this change will bust existing local cache entries ([#488](https://github.com/stjude-rust-labs/sprocket/pull/488)).
 
 ## 0.10.0 - 11-21-2025
 

--- a/crates/wdl-engine/src/digest.rs
+++ b/crates/wdl-engine/src/digest.rs
@@ -171,7 +171,7 @@ fn calculate_directory_digest(path: &Path) -> impl Future<Output = Result<Digest
             // Hash the relative path to the entry
             let entry_rel_path = entry_path
                 .strip_prefix(path)
-                .unwrap_or(&entry_path)
+                .expect("entry path should be relative")
                 .to_str()
                 .with_context(|| {
                     format!("path `{path}` is not UTF-8", path = entry_path.display())


### PR DESCRIPTION
This PR improves digest caching where the calculation of a local directory digest will now cache any descendant file or directory digest that is calculated.

The fix should help improve performance when a task creates a large file in its working directory and a direct reference to the file is later used by another task.

Without this fix, the above would cause the referenced file to be digested twice: once as a descendant of the directory and again for the direct reference to the file.

Note: due to the change in how local directory digests are calculated, this fix will cause call cache misses for any entry that references a local directory (such as a local working directory).

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have either (a) made a PR to the `next` branch in the sprocket.bio repository [if you are a Sprocket team member] or (b) have suggested any changes you _think_ need to be made to sprocket.bio in the description of your PR [if you are an external contributor].

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
