### PR TITLE
fix: don't prepend protocol when one already exists in `apptainer pull`

### DIFF
--- a/crates/wdl-engine/src/backend/apptainer/images.rs
+++ b/crates/wdl-engine/src/backend/apptainer/images.rs
@@ -123,8 +123,9 @@ impl ApptainerImages {
 
 /// Ensures a container reference has a URI scheme.
 ///
-/// If the container already has a URI scheme (e.g., `docker://`, `library://`, `oras://`),
-/// it is returned as-is. Otherwise, the `docker://` scheme is prepended.
+/// If the container already has a URI scheme (e.g., `docker://`, `library://`,
+/// `oras://`), it is returned as-is. Otherwise, the `docker://` scheme is
+/// prepended.
 fn ensure_image_scheme(container: &str) -> Cow<'_, str> {
     if container.contains("://") {
         Cow::Borrowed(container)
@@ -148,8 +149,8 @@ async fn try_pull(sif_path: &Path, container: &str) -> Result<(), RetryError<any
     let container = ensure_image_scheme(container);
     info!(container = container.as_ref(), "pulling image");
 
-    // Pipe the stdio handles, both for tracing and to inspect for telltale signs of permanent
-    // errors
+    // Pipe the stdio handles, both for tracing and to inspect for telltale signs of
+    // permanent errors
     let mut apptainer_pull_child = Command::new("apptainer")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -166,7 +167,7 @@ async fn try_pull(sif_path: &Path, container: &str) -> Result<(), RetryError<any
         .stdout
         .take()
         .ok_or_else(|| RetryError::permanent(anyhow!("apptainer pull child stdout missing")))?;
-    let stdout_container: String  = container.clone().into();
+    let stdout_container: String = container.clone().into();
     let _stdout_is_permanent = is_permanent.clone();
     tokio::spawn(async move {
         let mut lines = BufReader::new(child_stdout).lines();


### PR DESCRIPTION
This fixes the issue where the Apptainer backend always prepends `docker://` to the container image regardless of whether the container already has a protocol.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have either (a) made a PR to the `next` branch in the sprocket.bio repository [if you are a Sprocket team member] or (b) have suggested any changes you _think_ need to be made to sprocket.bio in the description of your PR [if you are an external contributor].

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
