### PR TITLE
wdl-format: split long #@ except directives into multiple lines

### DIFF
--- a/crates/wdl-format/CHANGELOG.md
+++ b/crates/wdl-format/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Split long `#@ except:` lint directives across multiple lines when they exceed the configured maximum line length.
+
 ## 0.14.0 - 01-12-2026
 
 #### Added

--- a/crates/wdl-format/src/token/post.rs
+++ b/crates/wdl-format/src/token/post.rs
@@ -189,7 +189,7 @@ fn can_be_line_broken(kind: SyntaxKind) -> Option<LineBreak> {
 /// ensures at least one rule per line.
 fn split_except_directive_lines(value: &str, max_len: usize) -> Option<Vec<String>> {
     let remainder = value.strip_prefix("#@")?;
-    let rules_text = remainder.trim_start().strip_prefix("except:")?
+    let rules_text = remainder.trim_start().strip_prefix("except:")?;
 
     // If the whole line fits, no splitting needed
     if value.len() <= max_len {

--- a/crates/wdl-format/src/token/post.rs
+++ b/crates/wdl-format/src/token/post.rs
@@ -188,14 +188,8 @@ fn can_be_line_broken(kind: SyntaxKind) -> Option<LineBreak> {
 /// splitting is required. Splitting occurs only at comma boundaries and
 /// ensures at least one rule per line.
 fn split_except_directive_lines(value: &str, max_len: usize) -> Option<Vec<String>> {
-    // Check if this is an except directive
-    let Some(remainder) = value.strip_prefix("#@") else {
-        return None;
-    };
-
-    let Some(rules_text) = remainder.trim_start().strip_prefix("except:") else {
-        return None;
-    };
+    let remainder = value.strip_prefix("#@")?;
+    let rules_text = remainder.trim_start().strip_prefix("except:")?
 
     // If the whole line fits, no splitting needed
     if value.len() <= max_len {

--- a/crates/wdl-format/tests/format/except-directive-line-splitting/source.formatted.wdl
+++ b/crates/wdl-format/tests/format/except-directive-line-splitting/source.formatted.wdl
@@ -1,0 +1,35 @@
+version 1.2
+
+# Test 1: Directive under length - should not split
+#@ except: ShortRule
+task test1 {
+}
+
+# Test 2: Directive slightly over length - should split into 2 lines
+#@ except: CommentWhitespace, DeprecatedObject, InputSorted, MetaDescription
+#@ except: ParameterMetaMatched
+task test2 {
+}
+
+# Test 3: Very long directive - should split into 3+ lines
+#@ except: CommentWhitespace, DeprecatedObject, HintsSectionKeys, InputSorted
+#@ except: MatchingOutputMeta, MetaDescription, OutputSectionKeys, ParameterMetaMatched
+#@ except: RequirementsSectionKeys, RuntimeSectionKeys
+task test3 {
+}
+
+# Test 4: Already multiline - each line normalized independently
+#@ except: FirstRule, SecondRule
+#@ except: FourthRule, ThirdRule
+task test4 {
+}
+
+# Test 5: Exactly at max length - should not split (edge case)
+#@ except: Rule1, Rule2, Rule3, Rule4, Rule5, Rule6, Rule7, Rule8
+task test5 {
+}
+
+# Test 6: Single very long rule name - must keep on one line (minimum 1 rule per line)
+#@ except: ThisIsAnExtremelyLongRuleNameThatExceedsMaxLineLengthByItselfAndCannotBeSplitFurtherBecauseItsASingleRule
+task test6 {
+}

--- a/crates/wdl-format/tests/format/except-directive-line-splitting/source.wdl
+++ b/crates/wdl-format/tests/format/except-directive-line-splitting/source.wdl
@@ -1,0 +1,26 @@
+version 1.2
+
+# Test 1: Directive under length - should not split
+#@ except: ShortRule
+task test1 {}
+
+# Test 2: Directive slightly over length - should split into 2 lines
+#@ except: CommentWhitespace, DeprecatedObject, MetaDescription, InputSorted, ParameterMetaMatched
+task test2 {}
+
+# Test 3: Very long directive - should split into 3+ lines
+#@ except: CommentWhitespace, DeprecatedObject, MetaDescription, InputSorted, ParameterMetaMatched, MatchingOutputMeta, RuntimeSectionKeys, RequirementsSectionKeys, HintsSectionKeys, OutputSectionKeys
+task test3 {}
+
+# Test 4: Already multiline - each line normalized independently
+#@ except: FirstRule, SecondRule
+#@ except: ThirdRule, FourthRule
+task test4 {}
+
+# Test 5: Exactly at max length - should not split (edge case)
+#@ except: Rule1, Rule2, Rule3, Rule4, Rule5, Rule6, Rule7, Rule8
+task test5 {}
+
+# Test 6: Single very long rule name - must keep on one line (minimum 1 rule per line)
+#@ except: ThisIsAnExtremelyLongRuleNameThatExceedsMaxLineLengthByItselfAndCannotBeSplitFurtherBecauseItsASingleRule
+task test6 {}


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

This PR adds formatter support for splitting long single-line `#@ except:` lint directives into multiple lines when they exceed the configured maximum line length.
The splitting logic preserves the normalized (alphabetically sorted) rule order while redistributing rules across lines based on length constraints. Splits occur only at comma boundaries, ensure at least one rule per line, and leave already-multiline directives unchanged. This follows up on the earlier normalization work and completes the formatter behavior discussed in issue #247.
Formatter tests have been added to cover under-length, single-split, multi-split, edge-length, and single-rule cases.


Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have either (a) made a PR to the `next` branch in the sprocket.bio repository [if you are a Sprocket team member] or (b) have suggested any changes you _think_ need to be made to sprocket.bio in the description of your PR [if you are an external contributor].

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
