### PR TITLE
fix(wdl-lint): properly handle empty lines in `ShellCheck` lint

### DIFF
--- a/crates/wdl-lint/CHANGELOG.md
+++ b/crates/wdl-lint/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 
 * Fixed `LineWidth` rule incorrectly emitting diagnostics for import statements ([#501](https://github.com/stjude-rust-labs/sprocket/pull/501)).
+* Fixed `ShellCheck` diagnostic spans for command sections with leading empty lines ([#545](https://github.com/stjude-rust-labs/sprocket/pull/545)).
 
 ## 0.19.0 - 01-12-2026
 

--- a/crates/wdl-lint/tests/lints/shellcheck-warn/source.errors
+++ b/crates/wdl-lint/tests/lints/shellcheck-warn/source.errors
@@ -380,3 +380,25 @@ note[ShellCheck]: rc is referenced but not assigned.
     │
     = fix: address the diagnostic as recommended in the message
 
+note[ShellCheck]: Use $(...) notation instead of legacy backticks `...`.
+    ┌─ tests/lints/shellcheck-warn/source.wdl:202:9
+    │
+202 │         `true`
+    │         ^^^^^^
+    │         │
+    │         SC2006[style]: Use $(...) notation instead of legacy backticks `...`.
+    │         more info: https://www.shellcheck.net/wiki/SC2006
+    │
+    = fix: did you mean `$(true)`?
+
+note[ShellCheck]: Remove backticks to avoid executing output (or use eval if intentional).
+    ┌─ tests/lints/shellcheck-warn/source.wdl:202:9
+    │
+202 │         `true`
+    │         ^^^^^^
+    │         │
+    │         SC2092[warning]: Remove backticks to avoid executing output (or use eval if intentional).
+    │         more info: https://www.shellcheck.net/wiki/SC2092
+    │
+    = fix: address the diagnostic as recommended in the message
+

--- a/crates/wdl-lint/tests/lints/shellcheck-warn/source.wdl
+++ b/crates/wdl-lint/tests/lints/shellcheck-warn/source.wdl
@@ -186,3 +186,23 @@ task test7 {
 
     runtime {}
 }
+
+# https://github.com/stjude-rust-labs/sprocket/issues/146
+task issue_146 {
+    meta {}
+
+    parameter_meta {}
+
+    input {}
+
+    # Multiple leading empty lines
+    command <<<
+
+
+        `true`
+    >>>
+
+    output {}
+
+    runtime {}
+}


### PR DESCRIPTION
When skipping the first empty line, it would accidentally skip *all* leading empty lines, messing up the line numbers.

closes #146

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have either (a) made a PR to the `next` branch in the sprocket.bio repository [if you are a Sprocket team member] or (b) have suggested any changes you _think_ need to be made to sprocket.bio in the description of your PR [if you are an external contributor].

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
