### PR TITLE
refactor: pass execution request by reference.

### DIFF
--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   contained a broken symlink ([#549](https://github.com/stjude-rust-labs/sprocket/pull/549)).
 * Fixed the `glob` function not properly resolving symlinks to files ([#549](https://github.com/stjude-rust-labs/sprocket/pull/549)).
 
+#### Changed
+
+* Refactored how task execution backends are passed data relating to the tasks
+  to execute ([#552](https://github.com/stjude-rust-labs/sprocket/pull/552)).
+
 ## 0.11.1 - 01-12-2026
 
 #### Fixed

--- a/crates/wdl-engine/src/eval/v1/task.rs
+++ b/crates/wdl-engine/src/eval/v1/task.rs
@@ -77,11 +77,9 @@ use crate::TaskPostEvaluationData;
 use crate::TaskPostEvaluationValue;
 use crate::TaskPreEvaluationValue;
 use crate::Value;
-use crate::backend::Input;
+use crate::backend::ExecuteTaskRequest;
 use crate::backend::TaskExecutionConstraints;
 use crate::backend::TaskExecutionResult;
-use crate::backend::TaskSpawnInfo;
-use crate::backend::TaskSpawnRequest;
 use crate::cache::KeyRequest;
 use crate::config::CallCachingMode;
 use crate::config::DEFAULT_TASK_SHELL;
@@ -563,9 +561,9 @@ struct EvaluatedSections {
     /// The evaluated command.
     command: String,
     /// The evaluated requirements.
-    requirements: Arc<HashMap<String, Value>>,
+    requirements: HashMap<String, Value>,
     /// The evaluated hints.
-    hints: Arc<HashMap<String, Value>>,
+    hints: HashMap<String, Value>,
     /// The task's execution constraints.
     constraints: TaskExecutionConstraints,
 }
@@ -708,9 +706,8 @@ impl Evaluator {
             current += 1;
         }
 
-        let mut cached;
-        let env = Arc::new(mem::take(&mut state.env));
         // Spawn the task in a retry loop
+        let mut cached;
         let mut attempt = 0;
         let mut previous_task_data: Option<Arc<TaskPostEvaluationData>> = None;
         let mut evaluated = loop {
@@ -744,7 +741,8 @@ impl Evaluator {
                 .into());
             }
 
-            let backend_inputs = state.localize_inputs(id).await?;
+            // Localize the inputs now
+            state.localize_inputs(id).await?;
 
             // Calculate the cache key on the first attempt only
             let mut key = if attempt == 0
@@ -756,8 +754,8 @@ impl Evaluator {
                         task_name: task.name(),
                         inputs: &state.inputs,
                         command: &command,
-                        requirements: requirements.as_ref(),
-                        hints: hints.as_ref(),
+                        requirements: &requirements,
+                        hints: &hints,
                         container: &constraints
                             .container
                             .as_ref()
@@ -769,7 +767,7 @@ impl Evaluator {
                             .shell
                             .as_deref()
                             .unwrap_or(DEFAULT_TASK_SHELL),
-                        backend_inputs: &backend_inputs,
+                        backend_inputs: state.backend_inputs.as_slice(),
                     };
 
                     match cache.key(request).await {
@@ -880,23 +878,24 @@ impl Evaluator {
                     let mut attempt_dir = task_eval_root.clone();
                     attempt_dir.push("attempts");
                     attempt_dir.push(attempt.to_string());
-                    let request = TaskSpawnRequest::new(
-                        id.to_string(),
-                        TaskSpawnInfo::new(
-                            command,
-                            backend_inputs,
-                            requirements.clone(),
-                            hints.clone(),
-                            env.clone(),
-                        ),
-                        constraints,
-                        attempt_dir.clone(),
-                        temp_dir.clone(),
-                    );
 
                     match self
                         .backend
-                        .spawn(&inputs, request, self.transferer.clone())
+                        .execute(
+                            &self.transferer,
+                            ExecuteTaskRequest {
+                                id,
+                                command: &command,
+                                inputs: &inputs,
+                                backend_inputs: state.backend_inputs.as_slice(),
+                                requirements: &requirements,
+                                hints: &hints,
+                                env: &state.env,
+                                constraints: &constraints,
+                                attempt_dir: &attempt_dir,
+                                temp_dir: &temp_dir,
+                            },
+                        )
                         .await
                     {
                         Ok(None) => return Err(EvaluationError::Canceled),
@@ -1665,8 +1664,8 @@ impl<'a> State<'a> {
 
         Ok(EvaluatedSections {
             command,
-            requirements: Arc::new(requirements),
-            hints: Arc::new(hints),
+            requirements,
+            hints,
             constraints,
         })
     }
@@ -1779,9 +1778,7 @@ impl<'a> State<'a> {
     }
 
     /// Localizes inputs for execution.
-    ///
-    /// Returns the inputs to pass to the backend.
-    async fn localize_inputs(&mut self, task_id: &str) -> EvaluationResult<Vec<Input>> {
+    async fn localize_inputs(&mut self, task_id: &str) -> EvaluationResult<()> {
         // If the backend needs local inputs, download them now
         if self.evaluator.backend.needs_local_inputs() {
             let mut downloads = JoinSet::new();
@@ -1877,7 +1874,7 @@ impl<'a> State<'a> {
             }
         }
 
-        Ok(self.backend_inputs.as_slice().into())
+        Ok(())
     }
 }
 
@@ -2030,7 +2027,10 @@ task test {
             logs_contain("call cache miss"),
             "expected first run to miss the cache"
         );
-        assert!(logs_contain("spawning task"), "expected the task to spawn");
+        assert!(
+            logs_contain("running task"),
+            "expected the task to have executed"
+        );
 
         let evaluated = evaluate_task(CallCachingMode::On, root_dir.path(), SOURCE).await;
         assert!(evaluated.cached());
@@ -2221,7 +2221,10 @@ task test {
             logs_contain("call cache miss"),
             "expected first run to miss the cache"
         );
-        assert!(logs_contain("spawning task"), "expected the task to spawn");
+        assert!(
+            logs_contain("running task"),
+            "expected the task to have executed"
+        );
 
         let evaluated = evaluate_task(CallCachingMode::Explicit, root_dir.path(), SOURCE).await;
         assert!(evaluated.cached());

--- a/crates/wdl-engine/src/eval/v1/task.rs
+++ b/crates/wdl-engine/src/eval/v1/task.rs
@@ -706,7 +706,7 @@ impl Evaluator {
             current += 1;
         }
 
-        // Spawn the task in a retry loop
+        // Execute the task in a retry loop
         let mut cached;
         let mut attempt = 0;
         let mut previous_task_data: Option<Arc<TaskPostEvaluationData>> = None;
@@ -1521,7 +1521,7 @@ impl<'a> State<'a> {
         Ok(command)
     }
 
-    /// Evaluates sections prior to spawning the command.
+    /// Evaluates sections prior to executing the task.
     ///
     /// This method evaluates the following sections:
     ///   * runtime


### PR DESCRIPTION
With the recent refactoring to backends, the `execute` (previously "spawn" - renamed to reduce confusion with `tokio::spawn`) method implemented by backends can now take a reference to all of the task execution request's data.

As a result, we can eliminate several places where we wrap types with `Arc` or otherwise clone some data to execute a task.

The `TaskSpawnInfo` and `TaskSpawnRequest` structures were merged into `ExecuteTaskRequest`, which now just stores references to the task's data internally.

This commit also contains some other related cleanup to the backend implementations.

The `TaskManager` used by the Docker and local backends no longer calls `tokio::spawn` as the caller is already running in the context of its own Tokio task.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have either (a) made a PR to the `next` branch in the sprocket.bio repository [if you are a Sprocket team member] or (b) have suggested any changes you _think_ need to be made to sprocket.bio in the description of your PR [if you are an external contributor].

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
