### PR TITLE
fix: prevent panic on duplicate workflow outputs section.

### DIFF
--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+* Fixed a panic when a workflow contains more than one non-empty `output`
+  section ([#568](https://github.com/stjude-rust-labs/sprocket/pull/568)).
 * Fix name conflict detection to match WDL spec ([#554](https://github.com/stjude-rust-labs/sprocket/pull/554)).
 
 ## 0.16.0 - 01-12-2026

--- a/crates/wdl-analysis/src/eval/v1.rs
+++ b/crates/wdl-analysis/src/eval/v1.rs
@@ -657,7 +657,7 @@ impl<N: TreeNode> WorkflowGraphBuilder<N> {
                         );
                     }
                 }
-                WorkflowItem::Output(section) => {
+                WorkflowItem::Output(section) if outputs.is_none() => {
                     outputs = Some(section);
                 }
                 WorkflowItem::Conditional(statement) => {

--- a/crates/wdl-analysis/tests/validation/duplicate-output/source.wdl
+++ b/crates/wdl-analysis/tests/validation/duplicate-output/source.wdl
@@ -4,11 +4,11 @@ version 1.1
 
 task t {
     output {
-
+        String a = ""
     }
 
     output {
-
+        String b = ""
     }
 
     command <<<>>>
@@ -17,11 +17,11 @@ task t {
 # A duplicate task should trigger a single error and then be ignored.
 task t {
     output {
-
+        String a = ""
     }
 
     output {
-
+        String b = ""
     }
 
     command <<<>>>
@@ -29,10 +29,10 @@ task t {
 
 workflow w {
     output {
-
+        String a = ""
     }
 
     output {
-
+        String b = ""
     }
 }


### PR DESCRIPTION
If a workflow has a non-empty duplicate `output` section, the workflow evaluation graph populates nodes for the duplicate section.

This results in a panic later on in evaluation where we process the nodes from the duplicate section and attempt to look up type information for each output; the lookup panics because the type information is populated from the first output section only.

The fix is to prevent workflow evaluation graph nodes from being populated by the duplicate output section.

Task evaluation graph building already has this same fix.

Fixes #567.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
