### PR TITLE
feat: support a `sprocket.toml` next to the `sprocket` executable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added reading configuration from a `sprocket.toml` next to the sprocket
+  executable ([#588](https://github.com/stjude-rust-labs/sprocket/pull/588)).
 * Added `sprocket dev server` command for running an HTTP API server for
   workflow execution ([#540](https://github.com/stjude-rust-labs/sprocket/pull/540)).
 * Added SQLite-backed database layer for tracking sessions, runs, and tasks

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -77,7 +77,7 @@ pub async fn server(args: Args, mut config: Config) -> CommandResult<()> {
     // Validate that at least one source type is allowed
     if config.server.allowed_file_paths.is_empty() && config.server.allowed_urls.is_empty() {
         return Err(anyhow::anyhow!(
-            "at least one of `allowed_file_paths` or `allowed_urls` must be specified"
+            "at least one of `allowed-file-paths` or `allowed-urls` must be specified"
         )
         .into());
     }


### PR DESCRIPTION
This PR implements loading configuration from a `sprocket.toml` that sits next to the sprocket executable.

It will allow for common configuration (e.g. in a shared HPC environment) for all users of the same sprocket executable.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
