### PR TITLE
fix: output diagnostics with styles.

### DIFF
--- a/crates/gauntlet/src/lib.rs
+++ b/crates/gauntlet/src/lib.rs
@@ -267,7 +267,7 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                         continue;
                     }
                     let mut buffer = Buffer::no_color();
-                    term::emit_to_io_write(
+                    term::emit_to_write_style(
                         &mut buffer,
                         &config,
                         &file,

--- a/crates/wdl-analysis/tests/analysis.rs
+++ b/crates/wdl-analysis/tests/analysis.rs
@@ -134,7 +134,7 @@ fn compare_results(test: &Path, results: Vec<AnalysisResult>) -> Result<()> {
             let source = result.document().root().text().to_string();
             let file = SimpleFile::new(path, &source);
             for diagnostic in diagnostics {
-                term::emit_to_io_write(
+                term::emit_to_write_style(
                     &mut buffer,
                     &CodespanConfig::default(),
                     &file,

--- a/crates/wdl-analysis/tests/validation.rs
+++ b/crates/wdl-analysis/tests/validation.rs
@@ -81,7 +81,7 @@ fn format_diagnostics<'a>(
     let file = SimpleFile::new(path.as_os_str().to_str().unwrap(), source);
     let mut buffer = Buffer::no_color();
     for diagnostic in diagnostics {
-        term::emit_to_io_write(
+        term::emit_to_write_style(
             &mut buffer,
             &CodespanConfig::default(),
             &file,

--- a/crates/wdl-engine/src/eval.rs
+++ b/crates/wdl-engine/src/eval.rs
@@ -444,7 +444,7 @@ impl EvaluationError {
                         }));
 
                 let mut buffer = Buffer::no_color();
-                term::emit_to_io_write(&mut buffer, &Config::default(), &files, &diagnostic)
+                term::emit_to_write_style(&mut buffer, &Config::default(), &files, &diagnostic)
                     .expect("failed to emit diagnostic");
 
                 String::from_utf8(buffer.into_inner()).expect("should be UTF-8")

--- a/crates/wdl-engine/tests/inputs.rs
+++ b/crates/wdl-engine/tests/inputs.rs
@@ -152,7 +152,7 @@ async fn run_test(test: &Path) -> Result<()> {
         let source = result.document().root().text().to_string();
         let file = SimpleFile::new(&path, &source);
 
-        term::emit_to_io_write(
+        term::emit_to_write_style(
             &mut buffer,
             &Config::default(),
             &file,

--- a/crates/wdl-format/tests/format.rs
+++ b/crates/wdl-format/tests/format.rs
@@ -64,7 +64,7 @@ fn format_diagnostics(diagnostics: &[Diagnostic], path: &Path, source: &str) -> 
     let file = SimpleFile::new(path.as_os_str().to_str().unwrap(), source);
     let mut buffer = Buffer::no_color();
     for diagnostic in diagnostics {
-        term::emit_to_io_write(
+        term::emit_to_write_style(
             &mut buffer,
             &Config::default(),
             &file,

--- a/crates/wdl-grammar/tests/parsing.rs
+++ b/crates/wdl-grammar/tests/parsing.rs
@@ -66,7 +66,7 @@ fn format_diagnostics(diagnostics: &[Diagnostic], path: &Path, source: &str) -> 
     let file = SimpleFile::new(path.as_os_str().to_str().unwrap(), source);
     let mut buffer = Buffer::no_color();
     for diagnostic in diagnostics {
-        term::emit_to_io_write(
+        term::emit_to_write_style(
             &mut buffer,
             &Config::default(),
             &file,

--- a/crates/wdl-lint/tests/lints.rs
+++ b/crates/wdl-lint/tests/lints.rs
@@ -79,7 +79,7 @@ fn format_diagnostics<'a>(
     let file = SimpleFile::new(path.as_os_str().to_str().unwrap(), source);
     let mut buffer = Buffer::no_color();
     for diagnostic in diagnostics {
-        term::emit_to_io_write(
+        term::emit_to_write_style(
             &mut buffer,
             &CodespanConfig::default(),
             &file,

--- a/crates/wdl/examples/explore.rs
+++ b/crates/wdl/examples/explore.rs
@@ -16,7 +16,7 @@ use anyhow::bail;
 use clap::Parser;
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term::Config;
-use codespan_reporting::term::emit_to_io_write;
+use codespan_reporting::term::emit_to_write_style;
 use codespan_reporting::term::termcolor::ColorChoice;
 use codespan_reporting::term::termcolor::StandardStream;
 use wdl::ast::Ast;
@@ -47,7 +47,7 @@ fn emit_diagnostics(path: &Path, source: &str, diagnostics: &[Diagnostic]) -> Re
         ColorChoice::Never
     });
     for diagnostic in diagnostics.iter() {
-        emit_to_io_write(
+        emit_to_write_style(
             &mut stream,
             &Config::default(),
             &file,

--- a/crates/wdl/examples/parse.rs
+++ b/crates/wdl/examples/parse.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use clap::Parser;
 use codespan_reporting::files::SimpleFile;
 use codespan_reporting::term::Config;
-use codespan_reporting::term::emit_to_io_write;
+use codespan_reporting::term::emit_to_write_style;
 use codespan_reporting::term::termcolor::ColorChoice;
 use codespan_reporting::term::termcolor::StandardStream;
 use wdl::ast::Diagnostic;
@@ -33,7 +33,7 @@ fn emit_diagnostics(path: &Path, source: &str, diagnostics: &[Diagnostic]) -> Re
         ColorChoice::Never
     });
     for diagnostic in diagnostics.iter() {
-        emit_to_io_write(
+        emit_to_write_style(
             &mut stream,
             &Config::default(),
             &file,

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -416,7 +416,7 @@ fn report_unknown_rules(
                 ))
                 .with_notes(notes);
 
-            codespan_reporting::term::emit_to_io_write(&mut writer, config, &files, &warning)
+            codespan_reporting::term::emit_to_write_style(&mut writer, config, &files, &warning)
                 .expect("failed to emit unknown rule warning");
         }
     }

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -12,7 +12,7 @@ use codespan_reporting::diagnostic::LabelStyle;
 use codespan_reporting::files::SimpleFiles;
 use codespan_reporting::term::Config as TermConfig;
 use codespan_reporting::term::DisplayStyle;
-use codespan_reporting::term::emit_to_io_write;
+use codespan_reporting::term::emit_to_write_style;
 use codespan_reporting::term::termcolor::ColorChoice;
 use codespan_reporting::term::termcolor::StandardStream;
 use serde::Deserialize;
@@ -174,7 +174,7 @@ pub fn emit_diagnostics<'a>(
             }),
         );
 
-        emit_to_io_write(&mut stream, config, &files, &diagnostic)
+        emit_to_write_style(&mut stream, config, &files, &diagnostic)
             .context("failed to emit diagnostic")?;
 
         if backtrace.len() > MAX_CALL_LOCATIONS {


### PR DESCRIPTION
This PR fixes the lack of colorization in diagnostic output by using the correct method to emit the diagnostic.

During the dependencies update, the `emit_to_write_style` method should have been used instead of the `emit_to_io_write` method.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
