### PR TITLE
fix: vendor Swagger UI to avoid build-time download failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5996,8 +5996,15 @@ dependencies = [
  "serde_json",
  "url",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip 3.0.0",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,7 @@ tracing-test = "0.2.5"
 url = "2.5.8"
 urlencoding = "2.1.3"
 utoipa = { version = "5.4.0", features = ["axum_extras", "chrono", "uuid"] }
-utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
+utoipa-swagger-ui = { version = "9.0.2", features = ["axum", "vendored"] }
 uuid = { version = "1.20.0", features = ["serde", "v4"] }
 walkdir = "2.5.0"
 wdl = { version = "0.21.1", path = "crates/wdl", features = ["engine", "lint", "lsp", "doc"] }


### PR DESCRIPTION
Enable the `vendored` feature on `utoipa-swagger-ui` so that the Swagger UI assets are provided by the `utoipa-swagger-ui-vendored` crate at build time instead of being downloaded via curl/reqwest.

This fixes build failures in restricted network environments (e.g., HPC clusters) where SSL certificate issues or missing CA bundles prevent the download from succeeding.

There are currently no open issues about this topic, but the HPC team got an error from a user trying to build `sprocket` on a compute node.

Before submitting this PR, please make sure:

*This is a very trivial configuration change, so many of the points below don't apply. If the point doesn't apply,  I marked it as checked.*

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.

Thank you!
Walid