### PR TITLE
fix: add rule identifier to `UsingFallbackVersion` diagnostic

### DIFF
--- a/crates/wdl-analysis/src/graph.rs
+++ b/crates/wdl-analysis/src/graph.rs
@@ -37,6 +37,7 @@ use wdl_ast::SyntaxNode;
 use crate::Config;
 use crate::IncrementalChange;
 use crate::document::Document;
+use crate::rules::USING_FALLBACK_VERSION;
 
 /// Represents space for a DFS search of a document graph.
 pub type DfsSpace =
@@ -402,6 +403,7 @@ impl DocumentGraphNode {
                                 "unsupported WDL version `{unrecognized}`; interpreting document \
                                  as version `{fallback}`"
                             ))
+                            .with_rule(USING_FALLBACK_VERSION)
                             .with_severity(severity)
                             .with_label(
                                 "this version of WDL is not supported",

--- a/crates/wdl-analysis/tests/analysis/import-incompatible-versions-fallback/source.diagnostics
+++ b/crates/wdl-analysis/tests/analysis/import-incompatible-versions-fallback/source.diagnostics
@@ -1,4 +1,4 @@
-warning: unsupported WDL version `2.0`; interpreting document as version `1.2`
+warning[UsingFallbackVersion]: unsupported WDL version `2.0`; interpreting document as version `1.2`
   ┌─ tests/analysis/import-incompatible-versions-fallback/foo.wdl:1:9
   │
 1 │ version 2.0

--- a/crates/wdl-analysis/tests/validation/unsupported-version-fallback/source.errors
+++ b/crates/wdl-analysis/tests/validation/unsupported-version-fallback/source.errors
@@ -1,4 +1,4 @@
-warning: unsupported WDL version `devel`; interpreting document as version `1.2`
+warning[UsingFallbackVersion]: unsupported WDL version `devel`; interpreting document as version `1.2`
   ┌─ tests/validation/unsupported-version-fallback/source.wdl:5:9
   │
 5 │ version devel

--- a/tests/cli/check/fallback-version/with-config/stderr
+++ b/tests/cli/check/fallback-version/with-config/stderr
@@ -1,4 +1,4 @@
-warning: unsupported WDL version `development`; interpreting document as version `1.3`
+warning[UsingFallbackVersion]: unsupported WDL version `development`; interpreting document as version `1.3`
   ┌─ test.wdl:1:9
   │
 1 │ version development


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

Minor update to fallback-version branch to include rule name (`UsingFallbackVersion`) when generating diagnostic warning message.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [ ] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
