### PR TITLE
fix(wdl-lsp): stop rendering workflow descriptions as headers

### DIFF
--- a/crates/wdl-ast/src/v1/workflow.rs
+++ b/crates/wdl-ast/src/v1/workflow.rs
@@ -152,7 +152,7 @@ impl<N: TreeNode> WorkflowDefinition<N> {
             && let MetadataValue::String(s) = desc.value()
             && let Some(text) = s.text()
         {
-            writeln!(f, "# {}\n", text.text())?;
+            writeln!(f, "{}\n", text.text())?;
         }
 
         write_input_section(f, self.input().as_ref(), self.parameter_metadata().as_ref())?;


### PR DESCRIPTION
Workflow descriptions were getting rendered as `h1`s, while every other item was plaintext.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
