### PR TITLE
fix(wdl-doc): normalize doc comment indentation

### DIFF
--- a/crates/wdl-doc/src/enum.rs
+++ b/crates/wdl-doc/src/enum.rs
@@ -160,3 +160,78 @@ fn parse_meta(
 
     (enum_docs, choice_docs)
 }
+
+#[cfg(test)]
+mod tests {
+    use wdl_ast::AstToken;
+    use wdl_ast::Document;
+    use wdl_ast::SupportedVersion;
+    use wdl_ast::version::V1;
+
+    use crate::r#enum::Enum;
+    use crate::meta::DESCRIPTION_KEY;
+    use crate::meta::MetaMapExt;
+
+    #[test]
+    fn test_enum() {
+        let (doc, _) = Document::parse(
+            r##"
+            version 1.3
+            ## An RGB24 color enum
+            ##
+            ## Each variant is represented as a 24-bit hexadecimal RGB string with exactly one non-zero channel.
+            enum Color[String] {
+                ## Pure red
+                Red = "#FF0000",
+                ## Pure green
+                Green = "#00FF00",
+                Blue = "#0000FF" # No description
+            }
+            "##,
+        );
+
+        let doc_item = doc.ast().into_v1().unwrap().items().next().unwrap();
+        let ast_enum = doc_item.into_enum_definition().unwrap();
+
+        let enum_def = Enum::new(ast_enum, SupportedVersion::V1(V1::Three), true);
+        assert_eq!(
+            enum_def.meta.full_description().as_deref(),
+            Some(
+                "An RGB24 color enum\nEach variant is represented as a 24-bit hexadecimal RGB \
+                 string with exactly one non-zero channel."
+            )
+        );
+        assert_eq!(enum_def.definition.name().text(), "Color");
+
+        let mut found_red = false;
+        let mut found_green = false;
+        let mut found_blue = false;
+        for choice in enum_def.choices {
+            match choice.choice.name().text() {
+                "Red" => {
+                    assert_eq!(
+                        choice.meta.get(DESCRIPTION_KEY).unwrap().text().unwrap(),
+                        "Pure red"
+                    );
+                    found_red = true;
+                }
+                "Green" => {
+                    assert_eq!(
+                        choice.meta.get(DESCRIPTION_KEY).unwrap().text().unwrap(),
+                        "Pure green"
+                    );
+                    found_green = true;
+                }
+                "Blue" => {
+                    assert!(!choice.meta.contains_key(DESCRIPTION_KEY));
+                    found_blue = true;
+                }
+                other => unreachable!("unexpected choice: {other}"),
+            }
+        }
+
+        assert!(found_red);
+        assert!(found_green);
+        assert!(found_blue);
+    }
+}


### PR DESCRIPTION
Removes as much leading space from doc comment lines as possible. Prior to this, the space in `## ` was being included in the paragraphs.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.

For all contributors:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
