### PR TITLE
feat: make Apptainer executable path configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* The Apptainer executable path is now configurable via the `executable` field in `ApptainerConfig`, enabling support for Singularity and custom install paths ([#682](https://github.com/stjude-rust-labs/sprocket/pull/682)).
 * Intermediate `test` results are logged as they complete ([#674](https://github.com/stjude-rust-labs/sprocket/pull/674)).
 * New lint rule `DocCommentTabs` to ensure doc comments do not contain tab characters ([#664](https://github.com/stjude-rust-labs/sprocket/pull/664)).
 

--- a/crates/wdl-engine/src/backend/apptainer.rs
+++ b/crates/wdl-engine/src/backend/apptainer.rs
@@ -29,7 +29,7 @@ use tracing::warn;
 
 use crate::Value;
 use crate::backend::ExecuteTaskRequest;
-use crate::config::Config;
+use crate::config::ApptainerConfig;
 use crate::config::DEFAULT_TASK_SHELL;
 use crate::v1::requirements::ContainerSource;
 
@@ -57,9 +57,6 @@ const SINGULARITY_ENV_PREFIX: &str = "SINGULARITYENV";
 /// Represents the Apptainer container runtime.
 #[derive(Debug)]
 pub struct ApptainerRuntime {
-    /// Path to the container runtime executable (e.g., `"apptainer"` or
-    /// `"singularity"`).
-    executable: String,
     /// The cache directory for `.sif` images.
     cache_dir: PathBuf,
     /// The map of container source to `.sif` path.
@@ -67,13 +64,11 @@ pub struct ApptainerRuntime {
 }
 
 impl ApptainerRuntime {
-    /// Creates a new [`ApptainerRuntime`] with the specified root directory
-    /// and executable path.
+    /// Creates a new [`ApptainerRuntime`] with the specified root directory.
     ///
     /// An images cache directory will be created in the given root.
-    pub fn new(root_dir: &Path, executable: impl Into<String>) -> Result<Self> {
+    pub fn new(root_dir: &Path) -> Result<Self> {
         Ok(Self {
-            executable: executable.into(),
             cache_dir: absolute(root_dir.join(IMAGES_CACHE_DIR)).with_context(|| {
                 format!(
                     "failed to make path `{root_dir}` absolute",
@@ -95,13 +90,14 @@ impl ApptainerRuntime {
     /// GPFS.
     pub async fn generate_script(
         &self,
-        config: &Config,
+        config: &ApptainerConfig,
+        shell: Option<&str>,
         request: &ExecuteTaskRequest<'_>,
-        extra_args: impl Iterator<Item = &str>,
         token: CancellationToken,
     ) -> Result<Option<String>> {
         let path = match self
             .pull_image(
+                &config.executable,
                 request
                     .constraints
                     .container
@@ -116,7 +112,7 @@ impl ApptainerRuntime {
         };
 
         Ok(Some(
-            self.generate_apptainer_script(config, &path, request, extra_args)
+            self.generate_apptainer_script(config, shell, &path, request)
                 .await?,
         ))
     }
@@ -128,10 +124,10 @@ impl ApptainerRuntime {
     /// be called from outside this module.
     async fn generate_apptainer_script(
         &self,
-        config: &Config,
+        config: &ApptainerConfig,
+        shell: Option<&str>,
         container_sif: &Path,
         request: &ExecuteTaskRequest<'_>,
-        extra_args: impl Iterator<Item = &str>,
     ) -> Result<String> {
         // Create a temp dir for the container's execution within the attempt dir
         // hierarchy. On many HPC systems, `/tmp` is mapped to a relatively
@@ -163,7 +159,7 @@ impl ApptainerRuntime {
                 )
             })?;
 
-        let env_prefix = if self.executable.contains("singularity") {
+        let env_prefix = if config.executable.contains("singularity") {
             SINGULARITY_ENV_PREFIX
         } else {
             APPTAINER_ENV_PREFIX
@@ -174,7 +170,7 @@ impl ApptainerRuntime {
         for (k, v) in request.env.iter() {
             writeln!(&mut apptainer_command, "export {env_prefix}_{k}={v:?}")?;
         }
-        writeln!(&mut apptainer_command, "{} -v exec \\", self.executable)?;
+        writeln!(&mut apptainer_command, "{} -v exec \\", config.executable)?;
         writeln!(&mut apptainer_command, "--pwd \"{GUEST_WORK_DIR}\" \\")?;
         writeln!(&mut apptainer_command, "--containall --cleanenv \\")?;
         for input in request.backend_inputs {
@@ -229,7 +225,11 @@ impl ApptainerRuntime {
             writeln!(&mut apptainer_command, "--nv \\")?;
         }
 
-        for arg in extra_args {
+        for arg in config
+            .extra_apptainer_exec_args
+            .as_deref()
+            .unwrap_or_default()
+        {
             writeln!(&mut apptainer_command, "{arg} \\")?;
         }
 
@@ -238,7 +238,7 @@ impl ApptainerRuntime {
             &mut apptainer_command,
             "{shell} -c \"\\\"{GUEST_COMMAND_PATH}\\\" > \\\"{GUEST_STDOUT_PATH}\\\" 2> \
              \\\"{GUEST_STDERR_PATH}\\\"\" \\",
-            shell = config.task.shell.as_deref().unwrap_or(DEFAULT_TASK_SHELL)
+            shell = shell.unwrap_or(DEFAULT_TASK_SHELL)
         )?;
         let attempt_dir = request.attempt_dir;
         let apptainer_stdout_path = attempt_dir.join("apptainer.stdout");
@@ -262,6 +262,7 @@ impl ApptainerRuntime {
     /// to the previous location is returned.
     pub(crate) async fn pull_image(
         &self,
+        executable: &str,
         container: &ContainerSource,
         token: CancellationToken,
     ) -> Result<Option<PathBuf>> {
@@ -305,7 +306,7 @@ impl ApptainerRuntime {
             }
 
             let container = format!("{container:#}");
-            let executable = self.executable.clone();
+            let executable = executable.to_string();
 
             Retry::spawn_notify(
                 // TODO ACF 2025-09-22: configure the retry behavior based on actual experience
@@ -417,8 +418,6 @@ impl ApptainerRuntime {
 
 #[cfg(test)]
 mod tests {
-    use std::iter::empty;
-
     use indexmap::IndexMap;
     use tempfile::TempDir;
     use url::Url;
@@ -437,10 +436,11 @@ mod tests {
         env.insert("FOO".to_string(), "bar".to_string());
         env.insert("BAZ".to_string(), "\"quux\"".to_string());
 
-        let runtime = ApptainerRuntime::new(&root.path().join("runs"), "apptainer").unwrap();
+        let runtime = ApptainerRuntime::new(&root.path().join("runs")).unwrap();
         let _ = runtime
             .generate_script(
-                &Default::default(),
+                &ApptainerConfig::default(),
+                None,
                 &ExecuteTaskRequest {
                     id: "example-task",
                     command: "echo hello",
@@ -466,7 +466,6 @@ mod tests {
                     attempt_dir: &root.path().join("0"),
                     temp_dir: &root.path().join("temp"),
                 },
-                empty(),
                 CancellationToken::new(),
             )
             .await
@@ -488,10 +487,11 @@ mod tests {
         env.insert("FOO".to_string(), "bar".to_string());
         env.insert("BAZ".to_string(), "\"quux\"".to_string());
 
-        let runtime = ApptainerRuntime::new(&root.path().join("runs"), "apptainer").unwrap();
+        let runtime = ApptainerRuntime::new(&root.path().join("runs")).unwrap();
         let script = runtime
             .generate_script(
-                &Default::default(),
+                &ApptainerConfig::default(),
+                None,
                 &ExecuteTaskRequest {
                     id: "example-task",
                     command: "echo hello",
@@ -517,7 +517,6 @@ mod tests {
                     attempt_dir: &root.path().join("0"),
                     temp_dir: &root.path().join("temp"),
                 },
-                empty(),
                 CancellationToken::new(),
             )
             .await

--- a/crates/wdl-engine/src/backend/apptainer.rs
+++ b/crates/wdl-engine/src/backend/apptainer.rs
@@ -48,9 +48,18 @@ const GUEST_STDOUT_PATH: &str = "/mnt/task/stdout";
 /// The path to the container's stderr.
 const GUEST_STDERR_PATH: &str = "/mnt/task/stderr";
 
+/// The environment variable prefix for Apptainer.
+const APPTAINER_ENV_PREFIX: &str = "APPTAINERENV";
+
+/// The environment variable prefix for Singularity.
+const SINGULARITY_ENV_PREFIX: &str = "SINGULARITYENV";
+
 /// Represents the Apptainer container runtime.
 #[derive(Debug)]
 pub struct ApptainerRuntime {
+    /// Path to the container runtime executable (e.g., `"apptainer"` or
+    /// `"singularity"`).
+    executable: String,
     /// The cache directory for `.sif` images.
     cache_dir: PathBuf,
     /// The map of container source to `.sif` path.
@@ -58,11 +67,13 @@ pub struct ApptainerRuntime {
 }
 
 impl ApptainerRuntime {
-    /// Creates a new [`ApptainerRuntime`] with the specified root directory.
+    /// Creates a new [`ApptainerRuntime`] with the specified root directory
+    /// and executable path.
     ///
     /// An images cache directory will be created in the given root.
-    pub fn new(root_dir: &Path) -> Result<Self> {
+    pub fn new(root_dir: &Path, executable: impl Into<String>) -> Result<Self> {
         Ok(Self {
+            executable: executable.into(),
             cache_dir: absolute(root_dir.join(IMAGES_CACHE_DIR)).with_context(|| {
                 format!(
                     "failed to make path `{root_dir}` absolute",
@@ -152,12 +163,18 @@ impl ApptainerRuntime {
                 )
             })?;
 
+        let env_prefix = if self.executable.contains("singularity") {
+            SINGULARITY_ENV_PREFIX
+        } else {
+            APPTAINER_ENV_PREFIX
+        };
+
         let mut apptainer_command = String::new();
         writeln!(&mut apptainer_command, "#!/usr/bin/env bash")?;
         for (k, v) in request.env.iter() {
-            writeln!(&mut apptainer_command, "export APPTAINERENV_{k}={v:?}")?;
+            writeln!(&mut apptainer_command, "export {env_prefix}_{k}={v:?}")?;
         }
-        writeln!(&mut apptainer_command, "apptainer -v exec \\")?;
+        writeln!(&mut apptainer_command, "{} -v exec \\", self.executable)?;
         writeln!(&mut apptainer_command, "--pwd \"{GUEST_WORK_DIR}\" \\")?;
         writeln!(&mut apptainer_command, "--containall --cleanenv \\")?;
         for input in request.backend_inputs {
@@ -288,6 +305,7 @@ impl ApptainerRuntime {
             }
 
             let container = format!("{container:#}");
+            let executable = self.executable.clone();
 
             Retry::spawn_notify(
                 // TODO ACF 2025-09-22: configure the retry behavior based on actual experience
@@ -298,9 +316,12 @@ impl ApptainerRuntime {
                 ExponentialBackoff::from_millis(50)
                     .max_delay_millis(60_000)
                     .take(10),
-                || Self::try_pull_image(&container, &path),
-                |e: &anyhow::Error, _| {
-                    warn!(e = %e, "`apptainer pull` failed");
+                || Self::try_pull_image(&executable, &container, &path),
+                {
+                    let executable = executable.clone();
+                    move |e: &anyhow::Error, _| {
+                        warn!(e = %e, "`{executable} pull` failed");
+                    }
                 },
             )
             .await
@@ -328,10 +349,14 @@ impl ApptainerRuntime {
     /// whether a failure is transient, but as we gain experience recognizing
     /// its output patterns, we can enhance the fidelity of the error
     /// handling.
-    async fn try_pull_image(image: &str, path: &Path) -> Result<(), RetryError<anyhow::Error>> {
-        info!("spawning `apptainer` to pull image `{image}`");
+    async fn try_pull_image(
+        executable: &str,
+        image: &str,
+        path: &Path,
+    ) -> Result<(), RetryError<anyhow::Error>> {
+        info!("spawning `{executable}` to pull image `{image}`");
 
-        let child = Command::new("apptainer")
+        let child = Command::new(executable)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -341,7 +366,7 @@ impl ApptainerRuntime {
             .spawn()
             .with_context(|| {
                 format!(
-                    "failed to spawn `apptainer pull '{path}' '{image}'",
+                    "failed to spawn `{executable} pull '{path}' '{image}'`",
                     path = path.display()
                 )
             })
@@ -351,7 +376,7 @@ impl ApptainerRuntime {
         let output = child
             .wait_with_output()
             .await
-            .context("failed to wait for `apptainer`")
+            .context(format!("failed to wait for `{executable}`"))
             .map_err(RetryError::permanent)?;
         if !output.status.success() {
             let permanent = if let Ok(stderr) = str::from_utf8(&output.stderr) {
@@ -373,7 +398,7 @@ impl ApptainerRuntime {
             };
 
             let e = anyhow!(
-                "`apptainer` failed: {status}: {stderr}",
+                "`{executable}` failed: {status}: {stderr}",
                 status = output.status,
                 stderr = str::from_utf8(&output.stderr)
                     .unwrap_or("<output not UTF-8>")
@@ -412,7 +437,7 @@ mod tests {
         env.insert("FOO".to_string(), "bar".to_string());
         env.insert("BAZ".to_string(), "\"quux\"".to_string());
 
-        let runtime = ApptainerRuntime::new(&root.path().join("runs")).unwrap();
+        let runtime = ApptainerRuntime::new(&root.path().join("runs"), "apptainer").unwrap();
         let _ = runtime
             .generate_script(
                 &Default::default(),
@@ -463,7 +488,7 @@ mod tests {
         env.insert("FOO".to_string(), "bar".to_string());
         env.insert("BAZ".to_string(), "\"quux\"".to_string());
 
-        let runtime = ApptainerRuntime::new(&root.path().join("runs")).unwrap();
+        let runtime = ApptainerRuntime::new(&root.path().join("runs"), "apptainer").unwrap();
         let script = runtime
             .generate_script(
                 &Default::default(),

--- a/crates/wdl-engine/src/backend/lsf_apptainer.rs
+++ b/crates/wdl-engine/src/backend/lsf_apptainer.rs
@@ -692,6 +692,8 @@ impl LsfApptainerBackend {
             .as_lsf_apptainer()
             .context("configured backend is not LSF Apptainer")?;
 
+        let executable = backend_config.apptainer_config.executable.clone();
+
         let monitor = Monitor::new(
             Duration::from_secs(backend_config.interval.unwrap_or(DEFAULT_MONITOR_INTERVAL)),
             backend_config.job_name_prefix.clone(),
@@ -708,7 +710,7 @@ impl LsfApptainerBackend {
             config,
             events,
             cancellation,
-            apptainer: ApptainerRuntime::new(run_root_dir)?,
+            apptainer: ApptainerRuntime::new(run_root_dir, executable)?,
             monitor,
             permits,
         })

--- a/crates/wdl-engine/src/backend/lsf_apptainer.rs
+++ b/crates/wdl-engine/src/backend/lsf_apptainer.rs
@@ -692,8 +692,6 @@ impl LsfApptainerBackend {
             .as_lsf_apptainer()
             .context("configured backend is not LSF Apptainer")?;
 
-        let executable = backend_config.apptainer_config.executable.clone();
-
         let monitor = Monitor::new(
             Duration::from_secs(backend_config.interval.unwrap_or(DEFAULT_MONITOR_INTERVAL)),
             backend_config.job_name_prefix.clone(),
@@ -710,7 +708,7 @@ impl LsfApptainerBackend {
             config,
             events,
             cancellation,
-            apptainer: ApptainerRuntime::new(run_root_dir, executable)?,
+            apptainer: ApptainerRuntime::new(run_root_dir)?,
             monitor,
             permits,
         })
@@ -888,15 +886,9 @@ impl TaskExecutionBackend for LsfApptainerBackend {
             let Some(apptainer_script) = self
                 .apptainer
                 .generate_script(
-                    &self.config,
+                    &backend_config.apptainer_config,
+                    self.config.task.shell.as_deref(),
                     &request,
-                    backend_config
-                        .apptainer_config
-                        .extra_apptainer_exec_args
-                        .as_deref()
-                        .unwrap_or_default()
-                        .iter()
-                        .map(String::as_str),
                     self.cancellation.first(),
                 )
                 .await?

--- a/crates/wdl-engine/src/backend/slurm_apptainer.rs
+++ b/crates/wdl-engine/src/backend/slurm_apptainer.rs
@@ -791,6 +791,8 @@ impl SlurmApptainerBackend {
             .as_slurm_apptainer()
             .context("configured backend is not Slurm Apptainer")?;
 
+        let executable = backend_config.apptainer_config.executable.clone();
+
         let monitor = Monitor::new(
             Duration::from_secs(backend_config.interval.unwrap_or(DEFAULT_MONITOR_INTERVAL)),
             events.clone(),
@@ -806,7 +808,7 @@ impl SlurmApptainerBackend {
             config,
             events,
             cancellation,
-            apptainer: ApptainerRuntime::new(run_root_dir)?,
+            apptainer: ApptainerRuntime::new(run_root_dir, executable)?,
             monitor,
             permits,
         })

--- a/crates/wdl-engine/src/backend/slurm_apptainer.rs
+++ b/crates/wdl-engine/src/backend/slurm_apptainer.rs
@@ -791,8 +791,6 @@ impl SlurmApptainerBackend {
             .as_slurm_apptainer()
             .context("configured backend is not Slurm Apptainer")?;
 
-        let executable = backend_config.apptainer_config.executable.clone();
-
         let monitor = Monitor::new(
             Duration::from_secs(backend_config.interval.unwrap_or(DEFAULT_MONITOR_INTERVAL)),
             events.clone(),
@@ -808,7 +806,7 @@ impl SlurmApptainerBackend {
             config,
             events,
             cancellation,
-            apptainer: ApptainerRuntime::new(run_root_dir, executable)?,
+            apptainer: ApptainerRuntime::new(run_root_dir)?,
             monitor,
             permits,
         })
@@ -996,15 +994,9 @@ impl TaskExecutionBackend for SlurmApptainerBackend {
             let Some(apptainer_script) = self
                 .apptainer
                 .generate_script(
-                    &self.config,
+                    &backend_config.apptainer_config,
+                    self.config.task.shell.as_deref(),
                     &request,
-                    backend_config
-                        .apptainer_config
-                        .extra_apptainer_exec_args
-                        .as_deref()
-                        .unwrap_or_default()
-                        .iter()
-                        .map(String::as_str),
                     self.cancellation.first(),
                 )
                 .await?

--- a/crates/wdl-engine/src/config.rs
+++ b/crates/wdl-engine/src/config.rs
@@ -1286,12 +1286,37 @@ impl TesBackendConfig {
 }
 
 /// Configuration for the Apptainer container runtime.
-#[derive(Debug, Clone, Default, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct ApptainerConfig {
+    /// Path to the Apptainer (or Singularity) executable.
+    ///
+    /// Defaults to `"apptainer"`. Set to `"singularity"` or a full path
+    /// (e.g., `/usr/local/bin/apptainer`) if the executable is not on `PATH`
+    /// or if using Singularity instead.
+    #[serde(default = "default_apptainer_executable")]
+    pub executable: String,
+
     /// Additional command-line arguments to pass to `apptainer exec` when
     /// executing tasks.
     pub extra_apptainer_exec_args: Option<Vec<String>>,
+}
+
+/// The default Apptainer executable name.
+const DEFAULT_APPTAINER_EXECUTABLE: &str = "apptainer";
+
+/// Returns the default Apptainer executable name for serde deserialization.
+fn default_apptainer_executable() -> String {
+    String::from(DEFAULT_APPTAINER_EXECUTABLE)
+}
+
+impl Default for ApptainerConfig {
+    fn default() -> Self {
+        Self {
+            executable: default_apptainer_executable(),
+            extra_apptainer_exec_args: None,
+        }
+    }
 }
 
 impl ApptainerConfig {


### PR DESCRIPTION
This was a request from @williamrowell: apparently there is a project called [SingularityCE](https://sylabs.io/singularity/) that some folks use that is basically identical in the commands we use from Apptainer (see [this comment](https://github.com/sylabs/singularity/discussions/2948#discussioncomment-9578289) for a bit more info).

Adds an `executable` field to `ApptainerConfig` so users can specify a custom path to the Apptainer (or Singularity) binary. The field defaults to `"apptainer"` and is threaded through `ApptainerRuntime` to the script generation and image pull sites. The environment variable prefix is derived from the executable name (`SINGULARITYENV_` vs `APPTAINERENV_`).

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.