### PR TITLE
fix(wdl-engine): skip pull when Apptainer image already exists in cache

### DIFF
--- a/crates/wdl-engine/src/backend/apptainer.rs
+++ b/crates/wdl-engine/src/backend/apptainer.rs
@@ -302,6 +302,11 @@ impl ApptainerRuntime {
 
             path.add_extension("sif");
 
+            if path.exists() {
+                info!(path = %path.display(), "Apptainer image `{container:#}` already cached; using existing image");
+                return Ok(path);
+            }
+
             if let Some(parent) = path.parent() {
                 tokio::fs::create_dir_all(parent).await.with_context(|| {
                     format!(


### PR DESCRIPTION
When `image_cache_dir` is configured to a shared location, subsequent runs fail because `singularity pull` refuses to overwrite an existing `.sif` file. This adds a check for the cached image before attempting the pull, returning the existing path if found.

Closes #688.

For all contributors:

- [x] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).