### PR TITLE
feat: implement independent fixtures and run directory configuration for `dev test`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added `--fixtures-dir` and `--run-dir` options to the `sprocket dev test`
+  command ([#747](https://github.com/stjude-rust-labs/sprocket/pull/747)).
+
 ### Fixed
 
 * `sprocket dev server` will canonicalize paths passed as CLI arguments ([#913](https://github.com/stjude-rust-labs/sprocket/pull/913))

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -79,6 +79,10 @@ pub struct Args {
     /// fixtures will be loaded from `<workspace>/test/fixtures/` if it is
     /// present.
     ///
+    /// If a `<workspace>/test/` directory does not exist, one will be created
+    /// and it will contain a `runs/` directory for test executions, unless
+    /// otherwise specified.
+    ///
     /// If not specified and the `source` argument is a directory, it's assumed
     /// that directory is also the workspace. This can be specified in addition
     /// to a source directory if they are different.

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::fs::create_dir_all;
 use std::fs::read;
 use std::fs::read_to_string;
 use std::fs::remove_dir;
@@ -79,9 +78,6 @@ pub struct Args {
     /// Root of the workspace where the `test/` directory will be located. Test
     /// fixtures will be loaded from `<workspace>/test/fixtures/` if it is
     /// present.
-    ///
-    /// If a `<workspace>/test/` directory does not exist, one will be created
-    /// and it will contain a `runs/` directory for test executions.
     ///
     /// If not specified and the `source` argument is a directory, it's assumed
     /// that directory is also the workspace. This can be specified in addition
@@ -763,22 +759,6 @@ fn resolve_test_paths(
     (fixtures_dir, run_dir)
 }
 
-fn ensure_test_dirs(fixtures_dir: &Path, run_dir: &Path) -> Result<()> {
-    create_dir_all(fixtures_dir).with_context(|| {
-        format!(
-            "failed to create test fixtures directory `{path}`",
-            path = fixtures_dir.display()
-        )
-    })?;
-    create_dir_all(run_dir).with_context(|| {
-        format!(
-            "failed to create test run directory `{path}`",
-            path = run_dir.display()
-        )
-    })?;
-    Ok(())
-}
-
 /// Performs the `test` command.
 pub async fn test(args: Args, mut config: Config, colorize: bool) -> CommandResult<()> {
     let source = args.source.unwrap_or_default();
@@ -875,7 +855,6 @@ pub async fn test(args: Args, mut config: Config, colorize: bool) -> CommandResu
 
     let (fixtures_dir, run_dir) =
         resolve_test_paths(&config.test, &workspace, &args.fixtures_dir, &args.run_dir);
-    ensure_test_dirs(&fixtures_dir, &run_dir)?;
     let fixture_origins = EvaluationPath::from(fixtures_dir.as_path());
 
     config.run.engine.task.cache = CallCachingMode::Off;
@@ -954,8 +933,6 @@ pub async fn test(args: Args, mut config: Config, colorize: bool) -> CommandResu
 
 #[cfg(test)]
 mod tests {
-    use tempfile::TempDir;
-
     use super::*;
 
     fn args_with_overrides(fixtures_dir: Option<PathBuf>, run_dir: Option<PathBuf>) -> Args {
@@ -1064,17 +1041,5 @@ mod tests {
 
         assert_eq!(fixtures_dir, PathBuf::from("/cli-fixtures"));
         assert_eq!(run_dir, PathBuf::from("/cli-runs"));
-    }
-
-    #[test]
-    fn ensure_test_dirs_creates_both_directories() {
-        let temp = TempDir::new().expect("should create temp dir");
-        let fixtures_dir = temp.path().join("fixtures");
-        let run_dir = temp.path().join("runs");
-
-        ensure_test_dirs(&fixtures_dir, &run_dir).expect("should create test directories");
-
-        assert!(fixtures_dir.is_dir());
-        assert!(run_dir.is_dir());
     }
 }

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -122,7 +122,7 @@ pub struct Args {
     /// If not specified, defaults to `<workspace>/test/fixtures`.
     #[clap(long)]
     pub fixtures_dir: Option<PathBuf>,
-    /// Directory to write test run outputs to.
+    /// Directory to execute tests in.
     ///
     /// If not specified, defaults to `<workspace>/test/runs`.
     #[clap(long)]

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::fs::create_dir_all;
 use std::fs::read;
 use std::fs::read_to_string;
 use std::fs::remove_dir;
@@ -49,6 +50,7 @@ use crate::analysis::Analysis;
 use crate::analysis::Source;
 use crate::commands::CommandError;
 use crate::commands::CommandResult;
+use crate::config::TestConfig;
 use crate::eval::Evaluator;
 use crate::system::v1::fs::RUNS_DIR;
 use crate::test::DocumentTests;
@@ -119,6 +121,16 @@ pub struct Args {
     /// The number of test executions to run in parallel.
     #[clap(short, long)]
     pub parallelism: Option<usize>,
+    /// Directory containing fixture files used by tests.
+    ///
+    /// If not specified, defaults to `<workspace>/test/fixtures`.
+    #[clap(long)]
+    pub fixtures_dir: Option<PathBuf>,
+    /// Directory to write test run outputs to.
+    ///
+    /// If not specified, defaults to `<workspace>/test/runs`.
+    #[clap(long)]
+    pub run_dir: Option<PathBuf>,
     /// Do not print results as tests complete.
     #[clap(long)]
     pub no_status: bool,
@@ -733,6 +745,40 @@ async fn summarize_results(
     }
 }
 
+fn resolve_test_paths(
+    config: &TestConfig,
+    workspace: &Path,
+    fixtures_dir: &Option<PathBuf>,
+    run_dir: &Option<PathBuf>,
+) -> (PathBuf, PathBuf) {
+    let test_dir = workspace.join(WORKSPACE_TEST_DIR);
+    let fixtures_dir = fixtures_dir
+        .clone()
+        .or_else(|| config.fixtures_dir.clone())
+        .unwrap_or_else(|| test_dir.join(FIXTURES_DIR));
+    let run_dir = run_dir
+        .clone()
+        .or_else(|| config.run_dir.clone())
+        .unwrap_or_else(|| test_dir.join(RUNS_DIR));
+    (fixtures_dir, run_dir)
+}
+
+fn ensure_test_dirs(fixtures_dir: &Path, run_dir: &Path) -> Result<()> {
+    create_dir_all(fixtures_dir).with_context(|| {
+        format!(
+            "failed to create test fixtures directory `{path}`",
+            path = fixtures_dir.display()
+        )
+    })?;
+    create_dir_all(run_dir).with_context(|| {
+        format!(
+            "failed to create test run directory `{path}`",
+            path = run_dir.display()
+        )
+    })?;
+    Ok(())
+}
+
 /// Performs the `test` command.
 pub async fn test(args: Args, mut config: Config, colorize: bool) -> CommandResult<()> {
     let source = args.source.unwrap_or_default();
@@ -827,8 +873,10 @@ pub async fn test(args: Args, mut config: Config, colorize: bool) -> CommandResu
         return Err(e.into());
     }
 
-    let test_dir = workspace.join(WORKSPACE_TEST_DIR);
-    let fixture_origins = EvaluationPath::from(test_dir.join(FIXTURES_DIR).as_path());
+    let (fixtures_dir, run_dir) =
+        resolve_test_paths(&config.test, &workspace, &args.fixtures_dir, &args.run_dir);
+    ensure_test_dirs(&fixtures_dir, &run_dir)?;
+    let fixture_origins = EvaluationPath::from(fixtures_dir.as_path());
 
     config.run.engine.task.cache = CallCachingMode::Off;
     config.run.engine.task.cpu_limit_behavior = TaskResourceLimitBehavior::TryWithMax;
@@ -837,7 +885,7 @@ pub async fn test(args: Args, mut config: Config, colorize: bool) -> CommandResu
 
     let cancellation = CancellationContext::new(FailureMode::Fast);
     let runner = Runner {
-        root: test_dir.join(RUNS_DIR),
+        root: run_dir,
         fixtures: fixture_origins.into(),
         engine_config: config.run.engine.into(),
         permits: parallelism,
@@ -902,4 +950,131 @@ pub async fn test(args: Args, mut config: Config, colorize: bool) -> CommandResu
     };
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn args_with_overrides(fixtures_dir: Option<PathBuf>, run_dir: Option<PathBuf>) -> Args {
+        Args {
+            source: None,
+            workspace: None,
+            include_tag: Vec::new(),
+            filter_tag: Vec::new(),
+            no_clean: false,
+            clean_all: false,
+            parallelism: None,
+            fixtures_dir,
+            run_dir,
+            no_status: false,
+        }
+    }
+
+    #[test]
+    fn resolve_test_paths_defaults_to_workspace_test_layout() {
+        let workspace = PathBuf::from("/workspace");
+        let args = args_with_overrides(None, None);
+        let config = TestConfig::default();
+
+        let (fixtures_dir, run_dir) =
+            resolve_test_paths(&config, &workspace, &args.fixtures_dir, &args.run_dir);
+
+        assert_eq!(fixtures_dir, workspace.join("test").join("fixtures"));
+        assert_eq!(run_dir, workspace.join("test").join("runs"));
+    }
+
+    #[test]
+    fn resolve_test_paths_uses_custom_fixtures_dir() {
+        let workspace = PathBuf::from("/workspace");
+        let custom_fixtures = PathBuf::from("/custom-fixtures");
+        let args = args_with_overrides(Some(custom_fixtures.clone()), None);
+        let config = TestConfig::default();
+
+        let (fixtures_dir, run_dir) =
+            resolve_test_paths(&config, &workspace, &args.fixtures_dir, &args.run_dir);
+
+        assert_eq!(fixtures_dir, custom_fixtures);
+        assert_eq!(run_dir, workspace.join("test").join("runs"));
+    }
+
+    #[test]
+    fn resolve_test_paths_uses_custom_run_dir() {
+        let workspace = PathBuf::from("/workspace");
+        let custom_run_dir = PathBuf::from("/custom-runs");
+        let args = args_with_overrides(None, Some(custom_run_dir.clone()));
+        let config = TestConfig::default();
+
+        let (fixtures_dir, run_dir) =
+            resolve_test_paths(&config, &workspace, &args.fixtures_dir, &args.run_dir);
+
+        assert_eq!(fixtures_dir, workspace.join("test").join("fixtures"));
+        assert_eq!(run_dir, custom_run_dir);
+    }
+
+    #[test]
+    fn resolve_test_paths_can_set_both_independently() {
+        let workspace = PathBuf::from("/workspace");
+        let custom_fixtures = PathBuf::from("/custom-fixtures");
+        let custom_run_dir = PathBuf::from("/custom-runs");
+        let args = args_with_overrides(Some(custom_fixtures.clone()), Some(custom_run_dir.clone()));
+        let config = TestConfig::default();
+
+        let (fixtures_dir, run_dir) =
+            resolve_test_paths(&config, &workspace, &args.fixtures_dir, &args.run_dir);
+
+        assert_eq!(fixtures_dir, custom_fixtures);
+        assert_eq!(run_dir, custom_run_dir);
+    }
+
+    #[test]
+    fn resolve_test_paths_uses_config_when_cli_not_set() {
+        let workspace = PathBuf::from("/workspace");
+        let args = args_with_overrides(None, None);
+        let config = TestConfig {
+            parallelism: 50,
+            fixtures_dir: Some(PathBuf::from("/config-fixtures")),
+            run_dir: Some(PathBuf::from("/config-runs")),
+        };
+
+        let (fixtures_dir, run_dir) =
+            resolve_test_paths(&config, &workspace, &args.fixtures_dir, &args.run_dir);
+
+        assert_eq!(fixtures_dir, PathBuf::from("/config-fixtures"));
+        assert_eq!(run_dir, PathBuf::from("/config-runs"));
+    }
+
+    #[test]
+    fn resolve_test_paths_cli_overrides_config() {
+        let workspace = PathBuf::from("/workspace");
+        let args = args_with_overrides(
+            Some(PathBuf::from("/cli-fixtures")),
+            Some(PathBuf::from("/cli-runs")),
+        );
+        let config = TestConfig {
+            parallelism: 50,
+            fixtures_dir: Some(PathBuf::from("/config-fixtures")),
+            run_dir: Some(PathBuf::from("/config-runs")),
+        };
+
+        let (fixtures_dir, run_dir) =
+            resolve_test_paths(&config, &workspace, &args.fixtures_dir, &args.run_dir);
+
+        assert_eq!(fixtures_dir, PathBuf::from("/cli-fixtures"));
+        assert_eq!(run_dir, PathBuf::from("/cli-runs"));
+    }
+
+    #[test]
+    fn ensure_test_dirs_creates_both_directories() {
+        let temp = TempDir::new().expect("should create temp dir");
+        let fixtures_dir = temp.path().join("fixtures");
+        let run_dir = temp.path().join("runs");
+
+        ensure_test_dirs(&fixtures_dir, &run_dir).expect("should create test directories");
+
+        assert!(fixtures_dir.is_dir());
+        assert!(run_dir.is_dir());
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -406,11 +406,25 @@ impl ServerConfig {
 pub struct TestConfig {
     /// Number of test executions to run in parallel. The default is `50`.
     pub parallelism: usize,
+    /// Optional directory containing test fixture files.
+    ///
+    /// If not set, fixtures are resolved from `<workspace>/test/fixtures`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fixtures_dir: Option<PathBuf>,
+    /// Optional directory to write test run directories to.
+    ///
+    /// If not set, runs are written to `<workspace>/test/runs`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_dir: Option<PathBuf>,
 }
 
 impl Default for TestConfig {
     fn default() -> Self {
-        Self { parallelism: 50 }
+        Self {
+            parallelism: 50,
+            fixtures_dir: None,
+            run_dir: None,
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -411,7 +411,7 @@ pub struct TestConfig {
     /// If not set, fixtures are resolved from `<workspace>/test/fixtures`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fixtures_dir: Option<PathBuf>,
-    /// Optional directory to write test run directories to.
+    /// Directory to use for executing tests.
     ///
     /// If not set, runs are written to `<workspace>/test/runs`.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -406,7 +406,7 @@ impl ServerConfig {
 pub struct TestConfig {
     /// Number of test executions to run in parallel. The default is `50`.
     pub parallelism: usize,
-    /// Optional directory containing test fixture files.
+    /// Directory containing test fixture files.
     ///
     /// If not set, fixtures are resolved from `<workspace>/test/fixtures`.
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Fixes #739 

## What changed

- Added new test config fields in TestConfig:
      - fixtures_dir: Option<PathBuf>
      - run_dir: Option<PathBuf>

- Added new CLI flags to dev test:
      - fixtures-dir <path>
      - run-dir <path>

- Refactored test path resolution into a helper with clear precedence:
      - CLI arg > config value > default workspace path

- Added explicit directory creation for both resolved directories with contextual errors.
- Updated Runner setup to use the resolved run_dir and resolved fixtures_dir.
Before submitting this PR, please make sure:
 
 ## Tests added
Added unit tests in src/commands/test.rs covering:

- default behavior (no overrides)
- custom fixtures_dir
- custom run_dir
- both independently set
- config-only override behavior
- CLI-over-config precedence
- directory creation for both paths

 For external contributors:
 
 * [x]  You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
 * [x]  You have not used AI on any parts of this pull request.
 * [x]  You have added a few sentences describing the PR here.
 * [x]  Your code builds clean without any errors or warnings.
 
 For all contributors:
 
 * [x]  You have added tests (when appropriate).
 * [x]  You have added an entry in the CHANGELOG (when appropriate).
 * [x]  You have updated the README or other documentation to account for these changes (when appropriate).
 * [x]  You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).
 
 For PRs containing lint rule changes:
 
 * [x]  You have updated any and all effected entries within `RULES.md`.
 * [x]  You have added a test case in `crates/wdl-lint/tests/lints` that covers every
   possible diagnostic emitted for the rule within the file where the rule
   is implemented.

