### PR TITLE
fix: expand coverage to all workspace crates

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,7 @@
+codecov:
+  notify:
+    after_n_builds: 6
+
 comment:
   behavior: once
   require_changes: "coverage_drop"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -60,7 +60,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/install-shellcheck
       - name: Update Rust
-        run: rustup update stable && rustup default stable
+        run: rustup update stable && rustup default stable && rustup component add llvm-tools
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov
       # Disabling cache as the size is now consistently running out of disk for certain actions
       # - uses: actions/cache@v4
       #   with:
@@ -86,7 +88,14 @@ jobs:
       # TODO: nextest doesn't support doc tests yet (https://github.com/nextest-rs/nextest/issues/16)
       - name: Run tests
         shell: bash
-        run: cargo nextest run --profile=ci --workspace --locked --all-targets --all-features --no-fail-fast && cargo test --workspace --doc
+        run: cargo llvm-cov nextest --profile=ci --workspace --locked --all-targets --all-features --no-fail-fast --codecov --output-path codecov.json && cargo test --workspace --doc
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov.json
+          fail_ci_if_error: true
 
   engine-test:
     runs-on: ${{ matrix.os }}
@@ -100,7 +109,7 @@ jobs:
       - name: Update Rust
         run: rustup update stable && rustup default stable && rustup component add llvm-tools
       - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --version 0.6.21
+        run: cargo install cargo-llvm-cov
       - uses: actions/cache@v4
         with:
           path: |


### PR DESCRIPTION
The `engine-test` CI job was only collecting coverage for `wdl-engine` and `sprocket` (`-p wdl-engine -p sprocket`). This meant tests in other crates—`wdl-analysis` in particular—weren't contributing to the coverage report at all.

This switches the `cargo llvm-cov` invocation to `--workspace` so every crate's tests are instrumented and included in the Codecov upload.

Before submitting this PR, please make sure:

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).