### PR TITLE
test(wdl-lint, wdl-analysis): enforce Rule::examples() WDL contracts …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6467,6 +6467,7 @@ dependencies = [
  "serde_json",
  "strsim",
  "strum",
+ "tempfile",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "tracing",

--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Added
+
+* Integration test that validates every analysis rule's `examples()` WDL snippets parse and emit the
+  corresponding rule diagnostic ([#771](https://github.com/stjude-rust-labs/sprocket/issues/771)).
+
 #### Changed
 
 * Type mismatch diagnostics now distinguish between custom types and references

--- a/crates/wdl-analysis/src/rules.rs
+++ b/crates/wdl-analysis/src/rules.rs
@@ -173,16 +173,16 @@ impl Rule for UnusedInputRule {
 
     fn examples(&self) -> &'static [&'static str] {
         &[r#"```wdl
-version 1.2
+version 1.1
 
 workflow example {
-    meta {}
-
     input {
         String unused
     }
 
-    output {}
+    output {
+        String out = "ok"
+    }
 }
 ```"#]
     }

--- a/crates/wdl-analysis/tests/rule_examples.rs
+++ b/crates/wdl-analysis/tests/rule_examples.rs
@@ -1,0 +1,150 @@
+//! Validates analysis rule `examples()` documentation strings.
+//!
+//! Each example may contain one or more ` ```wdl ` … ` ``` ` fenced blocks. **Every** block must:
+//!
+//! 1. Parse without parse diagnostics on the primary document being analyzed.
+//! 2. Produce **at least one** diagnostic whose rule id matches the rule being documented.
+//!
+//! # Special cases
+//!
+//! - **Temp directory**: snippets are written as `main.wdl` inside a [`tempfile::TempDir`] that is
+//!   kept alive until analysis finishes (a bare [`NamedTempFile`] would delete the path too early).
+//! - **UnusedImport**: the snippet imports `example2.wdl`. The test writes a minimal
+//!   `example2.wdl` next to `main.wdl` so resolution succeeds.
+//! - **UsingFallbackVersion**: the snippet uses an unsupported `version development` line. The test
+//!   runs the analyzer with `with_fallback_version(Some(1.2))` so the documented behavior occurs.
+//!   The expected diagnostic is reported as a parse diagnostic with that rule id; those messages
+//!   are excluded from the “must parse cleanly” assertion.
+
+use std::str::FromStr as _;
+
+use tempfile::tempdir;
+use wdl_analysis::Analyzer;
+use wdl_analysis::Config;
+use wdl_analysis::UNUSED_IMPORT_RULE_ID;
+use wdl_analysis::USING_FALLBACK_VERSION;
+use wdl_analysis::path_to_uri;
+use wdl_analysis::rules;
+use wdl_ast::SupportedVersion;
+
+fn wdl_snippets_from_example(markdown: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = markdown;
+    while let Some(idx) = rest.find("```wdl") {
+        let after = &rest[idx + "```wdl".len()..];
+        let body = after
+            .strip_prefix("\r\n")
+            .or_else(|| after.strip_prefix('\n'))
+            .unwrap_or(after);
+        let end_rel = body
+            .find("```")
+            .expect("unclosed ```wdl fence in rule example");
+        let snippet = body[..end_rel].trim();
+        assert!(
+            !snippet.is_empty(),
+            "empty ```wdl block in rule example:\n{markdown}"
+        );
+        out.push(snippet.to_string());
+        rest = &body[end_rel + 3..];
+    }
+    out
+}
+
+const IMPORT_STUB: &str = r#"version 1.2
+
+workflow imported_stub {
+    meta {}
+
+    output {}
+}
+"#;
+
+async fn analyze_snippet_for_rule(rule_id: &str, source: &str) -> (Vec<String>, Vec<String>) {
+    let (uri, _temp_dir): (_, Option<tempfile::TempDir>) = if rule_id == UNUSED_IMPORT_RULE_ID {
+        let dir = tempdir().expect("tempdir");
+        let main_path = dir.path().join("main.wdl");
+        std::fs::write(dir.path().join("example2.wdl"), IMPORT_STUB).expect("write stub");
+        std::fs::write(&main_path, source).expect("write WDL");
+        (path_to_uri(&main_path).expect("URI"), Some(dir))
+    } else {
+        let dir = tempdir().expect("tempdir");
+        let main_path = dir.path().join("main.wdl");
+        std::fs::write(&main_path, source).expect("write WDL");
+        (path_to_uri(&main_path).expect("URI"), Some(dir))
+    };
+
+    let analyzer = if rule_id == USING_FALLBACK_VERSION {
+        Analyzer::new(
+            Config::default()
+                .with_fallback_version(Some(SupportedVersion::from_str("1.2").expect("1.2"))),
+            |_, _, _, _| async {},
+        )
+    } else {
+        Analyzer::default()
+    };
+
+    analyzer
+        .add_document(uri.clone())
+        .await
+        .expect("add_document");
+    let results = analyzer.analyze(()).await.expect("analyze");
+    let result = results
+        .into_iter()
+        .find(|r| r.document().uri().as_ref() == &uri)
+        .expect("analysis result for temp file");
+
+    let parse_msgs: Vec<String> = result
+        .document()
+        .parse_diagnostics()
+        .iter()
+        .filter(|d| d.rule() != Some(USING_FALLBACK_VERSION))
+        .map(|d| d.message().to_string())
+        .collect();
+
+    let rule_ids: Vec<String> = result
+        .document()
+        .diagnostics()
+        .filter_map(|d| d.rule().map(ToString::to_string))
+        .collect();
+
+    (rule_ids, parse_msgs)
+}
+
+#[tokio::test]
+async fn analysis_rule_examples_parse_and_trigger_rule() {
+    for rule in rules() {
+        let id = rule.id();
+        let examples = rule.examples();
+        assert!(
+            !examples.is_empty(),
+            "analysis rule `{id}` has no examples()"
+        );
+
+        for (example_idx, md) in examples.iter().enumerate() {
+            let snippets = wdl_snippets_from_example(md);
+            assert!(
+                !snippets.is_empty(),
+                "analysis rule `{id}` example[{example_idx}] has no ```wdl blocks"
+            );
+
+            for (snip_idx, source) in snippets.iter().enumerate() {
+                let (rule_ids, parse_msgs) = analyze_snippet_for_rule(id, source).await;
+                assert!(
+                    parse_msgs.is_empty(),
+                    "analysis rule `{id}` example[{example_idx}] snippet[{snip_idx}] must parse; \
+                     snippet:\n{source}\nparse diagnostics:\n{}",
+                    parse_msgs.join("\n")
+                );
+
+                let hits: Vec<_> = rule_ids.iter().filter(|r| *r == id).collect();
+                assert!(
+                    !hits.is_empty(),
+                    "analysis rule `{id}` example[{example_idx}] snippet[{snip_idx}] should \
+                     trigger `{id}` but did not.\n\
+                     --- WDL ---\n{source}\n\
+                     --- emitted rule ids ---\n{rule_ids:?}"
+                );
+            }
+        }
+    }
+}

--- a/crates/wdl-lint/CHANGELOG.md
+++ b/crates/wdl-lint/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Integration test that validates every lint rule's `examples()` WDL snippets parse and match the
+  documented negative/positive convention ([#771](https://github.com/stjude-rust-labs/sprocket/issues/771)).
 * New lint rule `EmptyDocComment` to detect and flag empty documentation comments that serve no purpose ([#634](https://github.com/stjude-rust-labs/sprocket/pull/634)).
 * New lint rule `ParameterDescription` to ensure parameters and outputs have proper descriptions ([#449](https://github.com/stjude-rust-labs/sprocket/pull/449)).
 * New lint rule `DenyGlobStar` ([#749](https://github.com/stjude-rust-labs/sprocket/pull/749)).

--- a/crates/wdl-lint/Cargo.toml
+++ b/crates/wdl-lint/Cargo.toml
@@ -32,6 +32,7 @@ codespan-reporting = { workspace = true }
 libtest-mimic = { workspace = true }
 path-clean = { workspace = true }
 pretty_assertions = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/wdl-lint/TESTING.md
+++ b/crates/wdl-lint/TESTING.md
@@ -17,3 +17,8 @@ BLESS=1 cargo test [TEST_NAME]
 
 If a directory contains a `config.toml` file, the linter will be run twice. Once with the new config and once with the default
 config. The runs will generate `source.errors` and `source.errors.default` respectively.
+
+Rule documentation examples (`Rule::examples()`, Markdown fenced blocks tagged `wdl`) are checked by
+`tests/rule_examples.rs`: even-indexed examples must trigger the rule, odd-indexed must not (see that file’s module
+docs). `ShellCheck` examples are skipped when `shellcheck` is not on `PATH`.
+

--- a/crates/wdl-lint/src/rules/consistent_newlines.rs
+++ b/crates/wdl-lint/src/rules/consistent_newlines.rs
@@ -58,7 +58,34 @@ impl Rule for ConsistentNewlinesRule {
     }
 
     fn examples(&self) -> &'static [&'static str] {
-        &[]
+        // Line endings are built with `concat!` so we can mix `\n` and `\r\n` in a `&'static str`
+        // (a plain multiline string would be normalized by the repo / editor).
+        &[
+            concat!(
+                "This file mixes Unix (`\\n`) and Windows (`\\r\\n`) line endings:\n\n",
+                "```wdl\n",
+                "version 1.2\n",
+                "\n",
+                "workflow example {\r\n",
+                "    meta {}\n",
+                "\n",
+                "    output {}\n",
+                "}\n",
+                "```"
+            ),
+            concat!(
+                "Use one line-ending style throughout:\n\n",
+                "```wdl\n",
+                "version 1.2\n",
+                "\n",
+                "workflow example {\n",
+                "    meta {}\n",
+                "\n",
+                "    output {}\n",
+                "}\n",
+                "```"
+            ),
+        ]
     }
 
     fn tags(&self) -> TagSet {

--- a/crates/wdl-lint/src/rules/container_uri.rs
+++ b/crates/wdl-lint/src/rules/container_uri.rs
@@ -166,7 +166,7 @@ task say_hello {
     >>>
 
     requirements {
-        container: "ubuntu:latest"
+        container: "ubuntu@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     }
 }
 
@@ -180,7 +180,7 @@ task say_goodbye {
     >>>
 
     requirements {
-        container: "ubuntu:latest"
+        container: "ubuntu@sha256:ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
     }
 }
 ```"#,

--- a/crates/wdl-lint/src/rules/expected_runtime_keys.rs
+++ b/crates/wdl-lint/src/rules/expected_runtime_keys.rs
@@ -251,7 +251,7 @@ For WDL v1.2 documents and later, this rule does not evaluate because `runtime` 
 
     fn examples(&self) -> &'static [&'static str] {
         &[
-            r#"The following is missing a mandatory key:
+            r#"The following is missing a mandatory key, and the next has a non-reserved key:
 
 ```wdl
 version 1.1
@@ -263,11 +263,9 @@ task missing_required_keys {
 
     output {}
 
-    runtime {}  # Missing `container` key
+    runtime {}
 }
 ```
-"#,
-            r#"The following has an unexpected key:
 
 ```wdl
 version 1.1
@@ -282,6 +280,24 @@ task unexpected_runtime_key {
     runtime {
         container: "ubuntu"
         foo: "bar"
+    }
+}
+```
+"#,
+            r#"Use only reserved runtime keys for WDL 1.1 (for example `container`):
+
+```wdl
+version 1.1
+
+task ok_runtime {
+    meta {}
+
+    command <<<>>>
+
+    output {}
+
+    runtime {
+        container: "ubuntu"
     }
 }
 ```

--- a/crates/wdl-lint/src/rules/matching_output_meta.rs
+++ b/crates/wdl-lint/src/rules/matching_output_meta.rs
@@ -130,6 +130,10 @@ impl Rule for MatchingOutputMetaRule<'_> {
 version 1.2
 
 task generate_greeting {
+    meta {
+        description: "Generates a greeting"
+    }
+
     input {
         String name
     }

--- a/crates/wdl-lint/src/rules/meta_description.rs
+++ b/crates/wdl-lint/src/rules/meta_description.rs
@@ -69,6 +69,10 @@ impl Rule for MetaDescriptionRule {
 version 1.2
 
 task say_hello {
+    meta {
+        author: "You"
+    }
+
     input {
         String name
     }

--- a/crates/wdl-lint/src/rules/parameter_description.rs
+++ b/crates/wdl-lint/src/rules/parameter_description.rs
@@ -77,6 +77,16 @@ impl Rule for ParameterDescriptionRule {
 version 1.2
 
 task greet {
+    meta {
+        outputs: {
+            greeting: {}
+        }
+    }
+
+    parameter_meta {
+        name: {}
+    }
+
     input {
         String name
     }

--- a/crates/wdl-lint/tests/rule_examples.rs
+++ b/crates/wdl-lint/tests/rule_examples.rs
@@ -1,0 +1,159 @@
+//! Validates lint rule `examples()` documentation strings.
+//!
+//! # Convention
+//!
+//! Each entry in [`Rule::examples`](wdl_lint::Rule::examples) is Markdown that may contain one or
+//! more ` ```wdl ` … ` ``` ` fenced blocks. **All blocks in the same entry share the same
+//! expectation:**
+//!
+//! - **Even indices** (0, 2, …): *negative* examples — the WDL must emit **at least one**
+//!   diagnostic with **this rule’s id** when only that lint rule is enabled (analysis “unused *”
+//!   diagnostics are suppressed so they do not drown out the lint under test).
+//! - **Odd indices** (1, 3, …): *positive* examples — the WDL must **not** emit a diagnostic with
+//!   this rule’s id.
+//!
+//! # Exceptions
+//!
+//! - **ShellCheck**: skipped when the `shellcheck` executable is not on `PATH`, since the rule’s
+//!   behavior depends on that tool.
+
+use std::process::Command;
+
+use tempfile::NamedTempFile;
+use wdl_analysis::Analyzer;
+use wdl_analysis::Config as AnalysisConfig;
+use wdl_analysis::DiagnosticsConfig;
+use wdl_analysis::Validator;
+use wdl_analysis::path_to_uri;
+use wdl_lint::Config as LintConfig;
+use wdl_lint::Linter;
+use wdl_lint::rules as lint_rules;
+
+fn wdl_snippets_from_example(markdown: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = markdown;
+    while let Some(idx) = rest.find("```wdl") {
+        let after = &rest[idx + "```wdl".len()..];
+        let body = after
+            .strip_prefix("\r\n")
+            .or_else(|| after.strip_prefix('\n'))
+            .unwrap_or(after);
+        let end_rel = body
+            .find("```")
+            .expect("unclosed ```wdl fence in rule example");
+        let snippet = body[..end_rel].trim();
+        assert!(
+            !snippet.is_empty(),
+            "empty ```wdl block in rule example:\n{markdown}"
+        );
+        out.push(snippet.to_string());
+        rest = &body[end_rel + 3..];
+    }
+    out
+}
+
+fn shellcheck_on_path() -> bool {
+    Command::new("shellcheck")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+async fn lint_snippet_with_only_rule(source: &str, rule_id: &'static str) -> Vec<String> {
+    let temp = NamedTempFile::new().expect("temp file");
+    let path = temp.path().to_path_buf();
+    std::fs::write(&path, source).expect("write WDL");
+    let uri = path_to_uri(&path).expect("file URI");
+
+    let analyzer = Analyzer::new_with_validator(
+        AnalysisConfig::default().with_diagnostics_config(DiagnosticsConfig::except_all()),
+        |_, _, _, _| async {},
+        move || {
+            let mut validator = Validator::default();
+            let rule = lint_rules(&LintConfig::default())
+                .into_iter()
+                .find(|r| r.id() == rule_id)
+                .unwrap_or_else(|| panic!("lint rule `{rule_id}` not found in registry"));
+            validator.add_visitor(Linter::new(std::iter::once(rule)));
+            validator
+        },
+    );
+
+    analyzer
+        .add_document(uri.clone())
+        .await
+        .expect("add_document");
+    let results = analyzer.analyze(()).await.expect("analyze");
+    let result = results
+        .into_iter()
+        .find(|r| r.document().uri().as_ref() == &uri)
+        .expect("analysis result for temp file");
+
+    assert!(
+        result.error().is_none(),
+        "rule `{rule_id}` example failed to load: {:?}",
+        result.error()
+    );
+
+    let parse = result.document().parse_diagnostics();
+    assert!(
+        parse.is_empty(),
+        "rule `{rule_id}` example has parse diagnostics:\n{source}\n{}",
+        parse
+            .iter()
+            .map(|d| d.message().to_string())
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    result
+        .document()
+        .diagnostics()
+        .filter_map(|d| d.rule().map(ToString::to_string))
+        .collect()
+}
+
+#[tokio::test]
+async fn lint_rule_examples_parse_and_match_expectations() {
+    for rule in lint_rules(&LintConfig::default()) {
+        let id = rule.id();
+        if id == "ShellCheck" && !shellcheck_on_path() {
+            eprintln!("skipping ShellCheck examples: `shellcheck` not on PATH");
+            continue;
+        }
+
+        let examples = rule.examples();
+        assert!(!examples.is_empty(), "lint rule `{id}` has no examples()");
+
+        for (example_idx, md) in examples.iter().enumerate() {
+            let snippets = wdl_snippets_from_example(md);
+            assert!(
+                !snippets.is_empty(),
+                "lint rule `{id}` example[{example_idx}] has no ```wdl blocks"
+            );
+
+            for (snip_idx, source) in snippets.iter().enumerate() {
+                let rule_ids = lint_snippet_with_only_rule(source, id).await;
+                let hits: Vec<_> = rule_ids.iter().filter(|r| *r == id).collect();
+
+                if example_idx % 2 == 0 {
+                    assert!(
+                        !hits.is_empty(),
+                        "lint rule `{id}` negative example[{example_idx}] snippet[{snip_idx}] \
+                         should trigger `{id}` but did not.\n\
+                         --- WDL ---\n{source}\n\
+                         --- emitted rule ids ---\n{rule_ids:?}"
+                    );
+                } else {
+                    assert!(
+                        hits.is_empty(),
+                        "lint rule `{id}` positive example[{example_idx}] snippet[{snip_idx}] \
+                         should not trigger `{id}` but did.\n\
+                         --- WDL ---\n{source}\n\
+                         --- emitted rule ids ---\n{rule_ids:?}"
+                    );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
#771 

This pr adds tests for the rule doc examples in `wdl-lint` and `wdl-analysis`.
 the added tests now extract the `wdl` code blocks from each rule's examples() and run them through the analyzer to verify the expected diagnostics are produced.
for lint rules, the existing even/odd example convention is now enforced in tests. for analysis rules, the examples are checked to make sure they parse and trigger the rule they are documenting.

I also fixed a few existing examples that were broken or didn't accurately reflect the behavior of the rule.

### how to run the rule example validation tests

```bash
cargo test -p wdl-lint --test rule_examples --locked
cargo test -p wdl-analysis --test rule_examples --locked
```


Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
