### PR TITLE
fix(wdl-lsp): make `ServerOptions` fields camelCase

### DIFF
--- a/crates/wdl-lsp/src/server.rs
+++ b/crates/wdl-lsp/src/server.rs
@@ -230,6 +230,7 @@ impl ProgressToken {
     }
 }
 
+// NOTE: Renamed camelCase to make it play nicely with the vscode extension.
 /// Represents options for running the LSP server.
 #[derive(Debug, Clone, Patch)]
 #[patch(attribute(derive(Debug, Default, Deserialize)))]


### PR DESCRIPTION
Needed for `sprocket-vscode`, since config fields in vscode extensions are pretty much forced to be camelCase

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
