### PR TITLE
feat: test throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* New `test.throttle` configuration entry for adding a delay between initial test submissions ([#798](https://github.com/stjude-rust-labs/sprocket/pull/798)).
 * Added `--show-task-stderr` option to the `run` subcommand to show task stderr during execution ([#743](https://github.com/stjude-rust-labs/sprocket/pull/743)).
 * Added `--fixtures-dir` and `--run-dir` options to the `sprocket dev test`
   command ([#747](https://github.com/stjude-rust-labs/sprocket/pull/747)).

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -9,6 +9,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::path::absolute;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -23,6 +24,7 @@ use serde_json::Value as JsonValue;
 use tokio::fs::remove_dir_all;
 use tokio::select;
 use tokio::task::JoinSet;
+use tokio::time::sleep;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
@@ -402,6 +404,7 @@ struct Runner {
     fixtures: Arc<EvaluationPath>,
     engine_config: Arc<wdl::engine::Config>,
     permits: usize,
+    throttle: u64,
     cancellation: CancellationContext,
 }
 
@@ -442,12 +445,14 @@ impl Runner {
                 break;
             }
 
-            if permits == 0 {
+            let throttle = if permits == 0 {
                 self.process_next_result(&mut futures, &mut all_results, clean, quiet)
                     .await?;
+                false
             } else {
                 permits -= 1;
-            }
+                true
+            };
 
             self.spawn_future(
                 &mut futures,
@@ -458,6 +463,10 @@ impl Runner {
                 task.inputs,
             )
             .await;
+
+            if throttle {
+                sleep(Duration::from_millis(self.throttle)).await;
+            }
         }
 
         while !futures.is_empty() {
@@ -767,6 +776,7 @@ fn resolve_test_paths(
 pub async fn test(args: Args, mut config: Config, colorize: bool) -> CommandResult<()> {
     let source = args.source.unwrap_or_default();
     let parallelism = args.parallelism.unwrap_or(config.test.parallelism);
+    let throttle = config.test.throttle;
     let (source, workspace) = match (&source, args.workspace) {
         (Source::Url(_), _) => {
             return Err(anyhow!("the `test` subcommand does not accept remote sources").into());
@@ -872,6 +882,7 @@ pub async fn test(args: Args, mut config: Config, colorize: bool) -> CommandResu
         fixtures: fixture_origins.into(),
         engine_config: config.run.engine.into(),
         permits: parallelism,
+        throttle,
         cancellation: cancellation.clone(),
     };
 
@@ -1015,9 +1026,9 @@ mod tests {
         let workspace = PathBuf::from("/workspace");
         let args = args_with_overrides(None, None);
         let config = TestConfig {
-            parallelism: 50,
             fixtures_dir: Some(PathBuf::from("/config-fixtures")),
             run_dir: Some(PathBuf::from("/config-runs")),
+            ..Default::default()
         };
 
         let (fixtures_dir, run_dir) =
@@ -1035,9 +1046,9 @@ mod tests {
             Some(PathBuf::from("/cli-runs")),
         );
         let config = TestConfig {
-            parallelism: 50,
             fixtures_dir: Some(PathBuf::from("/config-fixtures")),
             run_dir: Some(PathBuf::from("/config-runs")),
+            ..Default::default()
         };
 
         let (fixtures_dir, run_dir) =

--- a/src/config.rs
+++ b/src/config.rs
@@ -445,8 +445,12 @@ impl ServerConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", deny_unknown_fields)]
 pub struct TestConfig {
-    /// Number of test executions to run in parallel. The default is `50`.
+    /// Number of test executions to run in parallel.
+    ///
+    /// The default is `50`.
     pub parallelism: usize,
+    /// Delay between submitting test executions, in milliseconds.
+    pub throttle: u64,
     /// Directory containing test fixture files.
     ///
     /// If not set, fixtures are resolved from `<workspace>/test/fixtures`.
@@ -462,7 +466,8 @@ pub struct TestConfig {
 impl Default for TestConfig {
     fn default() -> Self {
         Self {
-            parallelism: 50,
+            parallelism: 25,
+            throttle: 150,
             fixtures_dir: None,
             run_dir: None,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -449,7 +449,11 @@ pub struct TestConfig {
     ///
     /// The default is `50`.
     pub parallelism: usize,
-    /// Delay between submitting test executions, in milliseconds.
+    /// Delay between submitting initial test executions, in milliseconds.
+    ///
+    /// Once the `parallelism`` permits are exhausted, this throttle delay is
+    /// ignored and new tests are submitted eagerly as prior tests complete and
+    /// free permits.
     pub throttle: u64,
     /// Directory containing test fixture files.
     ///
@@ -466,8 +470,8 @@ pub struct TestConfig {
 impl Default for TestConfig {
     fn default() -> Self {
         Self {
-            parallelism: 25,
-            throttle: 150,
+            parallelism: 50,
+            throttle: 100,
             fixtures_dir: None,
             run_dir: None,
         }

--- a/tests/cli/config-init/run/stdout
+++ b/tests/cli/config-init/run/stdout
@@ -107,8 +107,8 @@ excluded_cache_inputs = []
 [server.engine.storage.google]
 
 [test]
-parallelism = 25
-throttle = 150
+parallelism = 50
+throttle = 100
 
 [doc]
 index_page = "none"

--- a/tests/cli/config-init/run/stdout
+++ b/tests/cli/config-init/run/stdout
@@ -107,7 +107,8 @@ excluded_cache_inputs = []
 [server.engine.storage.google]
 
 [test]
-parallelism = 50
+parallelism = 25
+throttle = 150
 
 [doc]
 index_page = "none"

--- a/tests/cli/config-resolve/multi/stdout
+++ b/tests/cli/config-resolve/multi/stdout
@@ -117,8 +117,8 @@ excluded_cache_inputs = []
 [server.engine.storage.google]
 
 [test]
-parallelism = 25
-throttle = 150
+parallelism = 50
+throttle = 100
 
 [doc]
 index_page = "none"

--- a/tests/cli/config-resolve/multi/stdout
+++ b/tests/cli/config-resolve/multi/stdout
@@ -117,7 +117,8 @@ excluded_cache_inputs = []
 [server.engine.storage.google]
 
 [test]
-parallelism = 50
+parallelism = 25
+throttle = 150
 
 [doc]
 index_page = "none"

--- a/tests/cli/config-resolve/run/stdout
+++ b/tests/cli/config-resolve/run/stdout
@@ -128,8 +128,8 @@ excluded_cache_inputs = []
 [server.engine.storage.google]
 
 [test]
-parallelism = 25
-throttle = 150
+parallelism = 50
+throttle = 100
 
 [doc]
 index_page = "none"

--- a/tests/cli/config-resolve/run/stdout
+++ b/tests/cli/config-resolve/run/stdout
@@ -128,7 +128,8 @@ excluded_cache_inputs = []
 [server.engine.storage.google]
 
 [test]
-parallelism = 50
+parallelism = 25
+throttle = 150
 
 [doc]
 index_page = "none"

--- a/tests/cli/config-resolve/sentinels/stdout
+++ b/tests/cli/config-resolve/sentinels/stdout
@@ -107,8 +107,8 @@ excluded_cache_inputs = []
 [server.engine.storage.google]
 
 [test]
-parallelism = 25
-throttle = 150
+parallelism = 50
+throttle = 100
 
 [doc]
 index_page = "none"

--- a/tests/cli/config-resolve/sentinels/stdout
+++ b/tests/cli/config-resolve/sentinels/stdout
@@ -107,7 +107,8 @@ excluded_cache_inputs = []
 [server.engine.storage.google]
 
 [test]
-parallelism = 50
+parallelism = 25
+throttle = 150
 
 [doc]
 index_page = "none"

--- a/tests/cli/config-resolve/unredacted/stdout
+++ b/tests/cli/config-resolve/unredacted/stdout
@@ -128,8 +128,8 @@ excluded_cache_inputs = []
 [server.engine.storage.google]
 
 [test]
-parallelism = 25
-throttle = 150
+parallelism = 50
+throttle = 100
 
 [doc]
 index_page = "none"

--- a/tests/cli/config-resolve/unredacted/stdout
+++ b/tests/cli/config-resolve/unredacted/stdout
@@ -128,7 +128,8 @@ excluded_cache_inputs = []
 [server.engine.storage.google]
 
 [test]
-parallelism = 50
+parallelism = 25
+throttle = 150
 
 [doc]
 index_page = "none"


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

Adds a `test.throttle` config entry for adding a delay between _initial_ test submissions. Once the `test.parallelism` permits are exhausted, the delay is ignored and new tests are submitted eagerly as prior tests complete and free permits.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
