### PR TITLE
chore: makes Codecov status checks informational

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,15 @@ codecov:
   ignore:
     - "crates/gauntlet"
 
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
 comment:
   behavior: once
   require_changes: "coverage_drop"


### PR DESCRIPTION
Codecov's project and patch status checks currently block CI when coverage drops. This changes both checks to `informational: true` so they still appear on PRs but never block merging. The PR comment reporting coverage details is unaffected.

Before submitting this PR, please make sure:

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).