### PR TITLE
chore: allows the `CC0-1.0` license in `deny.toml`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -86,11 +86,10 @@ jobs:
         with:
           tool: nextest
 
-      # Normal wdl-doc runs can automatically install Pagefind, but since the tests run in parallel, they
-      # can step on each other's toes in CI.
+      # Pre-warm the npx cache so parallel tests don't race to install it.
       - name: Install Pagefind
         if: runner.os == 'Linux'
-        run: npm install -g pagefind
+        run: npx -y pagefind@1.5.0 --help
 
       # TODO: nextest doesn't support doc tests yet (https://github.com/nextest-rs/nextest/issues/16)
       - name: Run tests
@@ -135,7 +134,7 @@ jobs:
 
       # See the `test` job
       - name: Install Pagefind
-        run: npm install -g pagefind
+        run: npx -y pagefind@1.5.0 --help
 
       - name: Pull test images
         if: runner.os == 'Linux'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6005,9 +6005,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -813,7 +813,7 @@ dependencies = [
  "http-cache-stream-reqwest",
  "opool",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand 0.9.4",
  "reqwest 0.13.2",
  "reqwest-middleware",
  "secrecy",
@@ -1111,7 +1111,7 @@ dependencies = [
  "indexmap 2.13.0",
  "nix",
  "nonempty",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "shlex",
  "ssh2",
@@ -3788,7 +3788,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.4",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -3854,9 +3854,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4903,7 +4903,7 @@ dependencies = [
  "peak_alloc",
  "petname",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "reqwest 0.13.2",
  "serde",
@@ -5618,7 +5618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae5ed96d30859f64c721d9155b66c53c39867e2ced2f0614ba61da5665440b0a"
 dependencies = [
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.4",
  "tokio",
 ]
 
@@ -6481,7 +6481,7 @@ dependencies = [
  "path-clean",
  "petgraph",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand 0.9.4",
  "regex",
  "rev_buf_reader",
  "rowan",
@@ -6549,7 +6549,7 @@ dependencies = [
  "libtest-mimic",
  "path-clean",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rowan",
  "serde",
  "serde_json",

--- a/crates/wdl-doc/src/lib.rs
+++ b/crates/wdl-doc/src/lib.rs
@@ -157,7 +157,7 @@ pub fn build_stylesheet(theme_dir: &Path) -> DocResult<()> {
 pub fn build_search_index(dist_dir: &Path) -> DocResult<()> {
     let dist_dir = absolute(dist_dir)?;
     let output = std::process::Command::new(npx()?)
-        .arg("pagefind@1.5.0")
+        .arg("pagefind")
         .arg("--site")
         .arg(dist_dir)
         .output()?;

--- a/crates/wdl-doc/src/lib.rs
+++ b/crates/wdl-doc/src/lib.rs
@@ -157,7 +157,7 @@ pub fn build_stylesheet(theme_dir: &Path) -> DocResult<()> {
 pub fn build_search_index(dist_dir: &Path) -> DocResult<()> {
     let dist_dir = absolute(dist_dir)?;
     let output = std::process::Command::new(npx()?)
-        .arg("pagefind")
+        .arg("pagefind@1.5.0")
         .arg("--site")
         .arg(dist_dir)
         .output()?;

--- a/deny.toml
+++ b/deny.toml
@@ -100,6 +100,7 @@ allow = [
     "MPL-2.0",
     "Unicode-3.0",
     "BSL-1.0",
+    "CC0-1.0",
     "Zlib",
     "OpenSSL",
 ]


### PR DESCRIPTION
The `tiny-keccak` crate (a transitive dependency via `const-random-macro`) uses the CC0-1.0 license, which wasn't in the allow list. This caused the `cargo deny` CI check to fail on #814 and likely any other PR that pulls in this dependency. This adds `CC0-1.0` to the allowed licenses.

Before submitting this PR, please make sure:

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).