### PR TITLE
chore: updates `rustls-webpki` to v0.103.12 to fix advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4355,9 +4355,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
Updates `rustls-webpki` from v0.103.10 to v0.103.12, fixing two recently published security advisories related to incorrect name constraint handling in certificate validation:

- [RUSTSEC-2026-0098](https://rustsec.org/advisories/RUSTSEC-2026-0098): URI name constraints were incorrectly accepted.
- [RUSTSEC-2026-0099](https://rustsec.org/advisories/RUSTSEC-2026-0099): Wildcard DNS names were incorrectly accepted under name constraints.

Both require certificate misissuance to exploit, so risk is low, but `cargo deny` correctly flags them.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).