### PR TITLE
fix: honor `#@ except:` directives on ancestor nodes for `UnnecessaryFunctionCall`

### DIFF
--- a/crates/wdl-analysis/src/types/v1.rs
+++ b/crates/wdl-analysis/src/types/v1.rs
@@ -1561,7 +1561,10 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                         Ok(binding) => {
                             if let Some(severity) =
                                 self.context.diagnostics_config().unnecessary_function_call
-                                && !expr.inner().is_rule_excepted(UNNECESSARY_FUNCTION_CALL)
+                                && !expr
+                                    .inner()
+                                    .ancestors()
+                                    .any(|node| node.is_rule_excepted(UNNECESSARY_FUNCTION_CALL))
                             {
                                 self.check_unnecessary_call(
                                     &target,

--- a/crates/wdl-analysis/tests/analysis/unnecessary-function-calls/source.wdl
+++ b/crates/wdl-analysis/tests/analysis/unnecessary-function-calls/source.wdl
@@ -22,4 +22,8 @@ workflow test {
     # OK
     File? file = None
     Boolean quuux = defined(file)
+
+    # OK
+    #@ except: UnnecessaryFunctionCall
+    String excepted = select_first(['foo', 'bar', 'baz'])
 }

--- a/crates/wdl-lint/CHANGELOG.md
+++ b/crates/wdl-lint/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added `HostPathLiterals` lint rule to flag absolute path defaults in `File` and `Directory` declarations ([#736](https://github.com/stjude-rust-labs/sprocket/pull/736)).
 
+#### Fixed
+
+* `#@ except:` directives on ancestor nodes are now honored by the
+  `UnnecessaryFunctionCall` lint rule
+  ([#842](https://github.com/stjude-rust-labs/sprocket/pull/842)).
+
 ## 0.22.1 - 2026-04-22
 
 ## 0.22.0 - 2026-04-02


### PR DESCRIPTION
The `UnnecessaryFunctionCall` analysis rule checks `expr.inner().is_rule_excepted()`, which only examines preceding siblings of the expression node. When `#@ except: UnnecessaryFunctionCall` is placed on a containing declaration—the natural place to put it—the directive has no effect because the expression is a child of the declaration, not a sibling of the comment.

This changes the check to walk `expr.inner().ancestors()`, matching the pattern already used by `Diagnostics::exceptable_add` in `validation.rs:52`. A concrete case where this matters: the `giraffe.wdl` workflow in [vgteam/vg_wdl](https://github.com/vgteam/vg_wdl) uses an `if (false)` block to manufacture a `None`-valued `File?` (since WDL 1.0 has no `None` literal), and the `select_first` call inside is intentional dead code that cannot be simplified away.

The existing test case is extended to cover a `select_first` call on a declaration annotated with `#@ except: UnnecessaryFunctionCall`, confirming the warning is suppressed.