### PR TITLE
chore(ci): upgrade actions to Node 24

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
       # Disabling cache as the size is now consistently running out of disk for certain actions
-      # - uses: actions/cache@v4
+      # - uses: actions/cache@v5
       #   with:
       #     path: |
       #       ~/.cargo/bin/
@@ -118,7 +118,7 @@ jobs:
         run: rustup update stable && rustup default stable && rustup component add llvm-tools
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 env:
   RUST_BACKTRACE: full

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,7 +98,7 @@ jobs:
         run: cargo llvm-cov nextest --profile=ci --workspace --locked --all-targets --all-features --no-fail-fast --codecov --output-path codecov.json && cargo test --workspace --doc
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: codecov.json
@@ -154,7 +154,7 @@ jobs:
           cargo llvm-cov nextest --profile=ci --ignore-default-filter -E "not (kind(bench))" --locked -p wdl-engine -p sprocket --all-features --no-fail-fast --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: codecov.json

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,14 +17,14 @@ jobs:
   spelling:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Spell Check Repo
         uses: crate-ci/typos@v1.44.0
 
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update nightly && rustup default nightly
       - name: Install rustfmt
@@ -35,7 +35,7 @@ jobs:
   sort:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update stable
       - name: Install `cargo-sort`
@@ -50,7 +50,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - name: Install clippy
@@ -65,7 +65,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-shellcheck
       - name: Update Rust
         run: rustup update stable && rustup default stable && rustup component add llvm-tools
@@ -112,7 +112,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-shellcheck
       - name: Update Rust
         run: rustup update stable && rustup default stable && rustup component add llvm-tools
@@ -163,7 +163,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Update Rust
@@ -177,7 +177,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - run: git config --global core.autocrlf false
       - name: Update Rust
         run: rustup update stable && rustup default stable
@@ -190,7 +190,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/install-shellcheck
       - run: git config --global core.autocrlf false
       - name: Update Rust
@@ -200,7 +200,7 @@ jobs:
   workspace-lints-enabled:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - run: cargo --locked install cargo-workspace-lints
@@ -209,7 +209,7 @@ jobs:
   deny:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - run: cargo --locked install cargo-deny
@@ -218,7 +218,7 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - name: Install cargo-binstall
@@ -232,7 +232,7 @@ jobs:
   udeps:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update nightly && rustup default nightly
       - name: Install cargo-udeps

--- a/.github/workflows/pr_assign.yml
+++ b/.github/workflows/pr_assign.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.number }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: true
       - name: Add assignee

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   docker-x86:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Update Rust
@@ -53,7 +53,7 @@ jobs:
   docker-arm:
     runs-on: ubuntu-24.04-arm
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Update Rust
@@ -138,7 +138,7 @@ jobs:
           - rust-target: aarch64-pc-windows-msvc
             extension: zip
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Update Rust
@@ -163,7 +163,7 @@ jobs:
             os: macos-latest
             extension: tar.gz
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Update Rust
@@ -189,7 +189,7 @@ jobs:
             os: ubuntu-24.04-arm
             extension: tar.gz
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Update Rust

--- a/.github/workflows/spec-compliance.yml
+++ b/.github/workflows/spec-compliance.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/spec-compliance.yml
+++ b/.github/workflows/spec-compliance.yml
@@ -16,7 +16,7 @@ jobs:
     name: WDL 1.3
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Update Rust
         run: rustup update stable && rustup default stable

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
       - name: Close PRs


### PR DESCRIPTION
Sprocket's CI currently uses outdated versions of `actions/checkout`, `actions/cache`, and `codecov/codecov-action`. These actions all require Node.js 20, which [is deprecated](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and causes warnings to be emitted. For example, here are the warnings emitted from [this CI run](https://github.com/stjude-rust-labs/sprocket/actions/runs/25882121815):

<img width="2168" height="1222" src="https://github.com/user-attachments/assets/9718cf3b-86cb-4cd0-b381-fccb1c05344c" />

In this PR, I upgraded `actions/checkout`, `actions/cache`, and `codecov/codecov-action` to all use the latest version, which uses the recommended Node.js 24. I reviewed the changelogs for each action and do not believe we will be affected by any breaking changes:

- [`actions/checkout@v5`](https://github.com/actions/checkout/releases/tag/v5.0.0): updates to Node.js 24
- [`actions/checkout@v6`](https://github.com/actions/checkout/releases/tag/v6.0.0): changes `persist-credentials` behaviors, which we don't use
- [`actions/cache@v5`](https://github.com/actions/cache/releases/tag/v5.0.0): updates to Node.js 24
- [`codecov/codecov-action@v6`](https://github.com/codecov/codecov-action/releases/tag/v6.0.0): updates to Node.js 24

In addition to upgrading these actions, I also let the CI and spec-compliance workflows be [run manually](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow) for easier testing.

This is my first time contributing! Let me know if there's anything else you need me to do :)

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.