### PR TITLE
fix(sprocket): pre-validate inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* `sprocket run` will no longer create `out` directories for runs with invalid CLI inputs ([#861](https://github.com/stjude-rust-labs/sprocket/issues/861)).
+
 ## 0.25.0 - 2026-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* `sprocket run` will no longer create `out` directories for runs with invalid CLI inputs ([#861](https://github.com/stjude-rust-labs/sprocket/issues/861)).
+* `sprocket run` will no longer create `out` directories for runs with invalid CLI inputs ([#863](https://github.com/stjude-rust-labs/sprocket/pull/863)).
 
 ## 0.25.0 - 2026-05-14
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -29,6 +29,7 @@ use tracing::Level;
 use tracing::error;
 use tracing_indicatif::span_ext::IndicatifSpanExt as _;
 use tracing_subscriber::fmt::layer;
+use wdl::analysis::Document;
 use wdl::ast::AstNode as _;
 use wdl::ast::Severity;
 use wdl::diagnostics::Mode;
@@ -54,6 +55,7 @@ use crate::analysis::Source;
 use crate::commands::CommandError;
 use crate::commands::CommandResult;
 use crate::inputs::Invocation;
+use crate::system::v1::db::Database;
 use crate::system::v1::db::SprocketCommand;
 use crate::system::v1::exec::RunContext;
 use crate::system::v1::exec::Target;
@@ -65,6 +67,7 @@ use crate::system::v1::exec::open_database;
 use crate::system::v1::exec::select_target;
 use crate::system::v1::fs::FileSystemLock;
 use crate::system::v1::fs::OutputDirectory;
+use crate::system::v1::fs::RunDirectory;
 
 /// The delay in showing the progress bar.
 ///
@@ -302,6 +305,8 @@ struct State {
 /// Displays evaluation progress.
 async fn progress(
     progress_bar: tracing::Span,
+    colorize: bool,
+    target: Arc<Target>,
     mut crankshaft: Receiver<CrankshaftEvent>,
     mut engine: Receiver<EngineEvent>,
     token: CancellationToken,
@@ -344,6 +349,27 @@ async fn progress(
 
         message
     }
+
+    let run_kind = match &*target {
+        Target::Task(_) => "task",
+        Target::Workflow(_) => "workflow",
+    };
+
+    let template = if colorize {
+        format!(
+            "[{{elapsed_precise:.cyan/blue}}] {{spinner:.cyan/blue}} {running} {run_kind} \
+             {target}{{msg}}",
+            running = "running".cyan(),
+            target = target.name().magenta().bold()
+        )
+    } else {
+        format!(
+            "[{{elapsed_precise}}] {{spinner}} running {run_kind} {target}{{msg}}",
+            target = target.name()
+        )
+    };
+
+    progress_bar.pb_set_style(&ProgressStyle::with_template(&template).unwrap());
 
     let mut state = State::default();
     let mut lagged = false;
@@ -526,14 +552,6 @@ pub async fn run(
     let report_mode = args.report_mode.unwrap_or(config.common.report_mode);
     args.apply_engine_config(&mut config.run.engine);
 
-    let template = if colorize {
-        "[{elapsed_precise:.cyan/blue}] {bar:40.cyan/blue} {msg} {pos}/{len}"
-    } else {
-        "[{elapsed_precise}] {bar:40} {msg} {pos}/{len}"
-    };
-
-    let style = ProgressStyle::with_template(template).unwrap();
-
     let progress_bar = tracing::span!(Level::WARN, "progress");
     let start = std::time::Instant::now();
 
@@ -542,6 +560,14 @@ pub async fn run(
         .fallback_version(config.common.wdl.fallback_version.inner().cloned())
         .init({
             let progress_bar = progress_bar.clone();
+
+            let template = if colorize {
+                "[{elapsed_precise:.cyan/blue}] {bar:40.cyan/blue} {msg} {pos}/{len}"
+            } else {
+                "[{elapsed_precise}] {bar:40} {msg} {pos}/{len}"
+            };
+
+            let style = ProgressStyle::with_template(template).unwrap();
             Box::new(move || {
                 progress_bar.pb_set_style(&style);
             })
@@ -603,123 +629,9 @@ pub async fn run(
 
     let document = results.filter(&[&args.source]).next().unwrap().document();
 
-    // Parse and resolve inputs. The `into_resolved_json()` method resolves
-    // relative paths using per-input origins before serializing to JSON.
-    let (target, inputs) = match Invocation::coalesce(&args.inputs, args.target.clone())
-        .await
-        .with_context(|| {
-            format!(
-                "failed to parse inputs from `{sources}`",
-                sources = args.inputs.join("`, `")
-            )
-        })?
-        .into_engine_inputs(document)
-        .await?
-    {
-        Some((target, inputs)) => (
-            select_target(document, Some(&target)).map_err(|e| anyhow!(e))?,
-            inputs,
-        ),
-        None => {
-            let target = select_target(document, args.target.as_deref()).map_err(|e| anyhow!(e))?;
+    let (target, inputs) = resolve_inputs(&args, document).await?;
 
-            let inputs = match target {
-                Target::Task(_) => TaskInputs::default().into(),
-                Target::Workflow(_) => WorkflowInputs::default().into(),
-            };
-
-            (target, inputs)
-        }
-    };
-
-    // Set up output directory structure
-    let output_dir = OutputDirectory::new(
-        args.output_dir
-            .clone()
-            .unwrap_or_else(|| config.run.output_dir.clone()),
-    );
-
-    // Acquire an exclusive lock on the output directory to serialize setup
-    // operations across concurrent processes (e.g., database creation,
-    // directory structure initialization, and symlink management).
-    //
-    // NOTE: this lock covers setup only. Post-setup operations on shared
-    // state (e.g., index symlink creation in `set_run_success`) are not
-    // covered—concurrent processes indexing on the same name can still
-    // race on symlinks. This is acceptable because each parallel test
-    // uses a unique target name.
-    let lock = FileSystemLock::acquire(output_dir.root())
-        .context("failed to acquire lock on output directory")?;
-
-    // Create the run directory
-    let run_dir = create_run_directory(&output_dir, target.name(), args.suffix.as_deref())?;
-
-    // Now that the run directory is created, initialize file logging
-    initialize_file_logging(handle, run_dir.root())?;
-
-    tracing::info!(
-        "`{dir}` will be used as the execution directory",
-        dir = run_dir.root().display()
-    );
-
-    let run_kind = match &target {
-        Target::Task(_) => "task",
-        Target::Workflow(_) => "workflow",
-    };
-
-    let template = if colorize {
-        format!(
-            "[{{elapsed_precise:.cyan/blue}}] {{spinner:.cyan/blue}} {running} {run_kind} \
-             {target}{{msg}}",
-            running = "running".cyan(),
-            target = target.name().magenta().bold()
-        )
-    } else {
-        format!(
-            "[{{elapsed_precise}}] {{spinner}} running {run_kind} {target}{{msg}}",
-            target = target.name()
-        )
-    };
-
-    progress_bar.pb_set_style(&ProgressStyle::with_template(&template).unwrap());
-
-    // Open or create the database for provenance tracking
-    let db_path = config.server.database_url();
-    let db = open_database(&db_path).await?;
-
-    // Create session and run records
-    let session = create_session(db.as_ref(), SprocketCommand::Run)
-        .await
-        .context("failed to create session")?;
-
-    let (run_id, run_name, _run) = create_run_record(
-        db.as_ref(),
-        session.uuid,
-        &args.source,
-        Some(target.name()),
-        &inputs_to_json(target.name(), &inputs).context("failed to serialize inputs")?,
-    )
-    .await
-    .context("failed to create run record")?;
-
-    // Update the run directory in the database
-    let run_dir_str = run_dir
-        .root()
-        .to_str()
-        .context("run directory path is not valid UTF-8")?;
-    db.update_run_directory(run_id, run_dir_str)
-        .await
-        .context("failed to update run directory")?;
-
-    // Release the lock now that setup is complete—each process has its own
-    // timestamped run directory from this point forward.
-    drop(lock);
-
-    let ctx = RunContext {
-        run_id,
-        run_generated_name: run_name,
-        started_at: Utc::now(),
-    };
+    let (ctx, run_dir, db) = setup_run_context(handle, &args, &config, &target, &inputs).await?;
 
     let cancellation = CancellationContext::new(config.run.engine.failure_mode);
     let events = Events::new(config.run.events_capacity);
@@ -731,6 +643,8 @@ pub async fn run(
     ));
     let crankshaft_progress = tokio::spawn(progress(
         progress_bar,
+        colorize,
+        target.clone(),
         events
             .subscribe_crankshaft()
             .expect("should have Crankshaft events"),
@@ -753,7 +667,7 @@ pub async fn run(
         config.run.engine,
         cancellation.clone(),
         events,
-        target,
+        &target,
         inputs,
         &run_dir,
         &base_dir,
@@ -823,6 +737,143 @@ pub async fn run(
             },
         }
     }
+}
+
+/// Parse and resolve inputs.
+async fn resolve_inputs(args: &Args, document: &Document) -> Result<(Arc<Target>, Inputs)> {
+    // The `into_resolved_json()` method resolves
+    // relative paths using per-input origins before serializing to JSON.
+    let (target, inputs) = match Invocation::coalesce(&args.inputs, args.target.clone())
+        .await
+        .with_context(|| {
+            format!(
+                "failed to parse inputs from `{sources}`",
+                sources = args.inputs.join("`, `")
+            )
+        })?
+        .into_engine_inputs(document)
+        .await?
+    {
+        Some((target, inputs)) => {
+            let target = select_target(document, Some(&target)).map_err(|e| anyhow!(e))?;
+            (Arc::new(target), inputs)
+        }
+        None => {
+            let target = select_target(document, args.target.as_deref()).map_err(|e| anyhow!(e))?;
+
+            let inputs = match target {
+                Target::Task(_) => TaskInputs::default().into(),
+                Target::Workflow(_) => WorkflowInputs::default().into(),
+            };
+
+            (Arc::new(target), inputs)
+        }
+    };
+
+    match (&*target, &inputs) {
+        (Target::Task(task), Inputs::Task(inputs)) => {
+            let Some(task) = document.task_by_name(task) else {
+                bail!("task '{task}' not found in document");
+            };
+
+            inputs.validate(document, task, None).with_context(|| {
+                format!(
+                    "failed to validate the inputs to task `{task}`",
+                    task = task.name()
+                )
+            })?;
+        }
+        (Target::Workflow(workflow), Inputs::Workflow(inputs)) => {
+            let Some(workflow) = document.workflow() else {
+                bail!("workflow '{workflow}' not found in document");
+            };
+
+            inputs.validate(document, workflow, None).with_context(|| {
+                format!(
+                    "failed to validate the inputs to workflow `{workflow}`",
+                    workflow = workflow.name()
+                )
+            })?;
+        }
+        _ => unreachable!(),
+    }
+
+    Ok((target, inputs))
+}
+
+/// Setup the run output directory and database for a run.
+async fn setup_run_context(
+    log_handle: FileReloadHandle,
+    args: &Args,
+    config: &Config,
+    target: &Target,
+    inputs: &Inputs,
+) -> Result<(RunContext, RunDirectory, Arc<dyn Database>)> {
+    // Set up output directory structure
+    let output_dir = OutputDirectory::new(
+        args.output_dir
+            .clone()
+            .unwrap_or_else(|| config.run.output_dir.clone()),
+    );
+
+    // Acquire an exclusive lock on the output directory to serialize setup
+    // operations across concurrent processes (e.g., database creation,
+    // directory structure initialization, and symlink management).
+    //
+    // NOTE: this lock covers setup only. Post-setup operations on shared
+    // state (e.g., index symlink creation in `set_run_success`) are not
+    // covered—concurrent processes indexing on the same name can still
+    // race on symlinks. This is acceptable because each parallel test
+    // uses a unique target name.
+    let _lock = FileSystemLock::acquire(output_dir.root())
+        .context("failed to acquire lock on output directory")?;
+
+    // Create the run directory
+    let run_dir = create_run_directory(&output_dir, target.name(), args.suffix.as_deref())?;
+
+    // Now that the run directory is created, initialize file logging
+    initialize_file_logging(log_handle, run_dir.root())?;
+
+    tracing::info!(
+        "`{dir}` will be used as the execution directory",
+        dir = run_dir.root().display()
+    );
+
+    // Open or create the database for provenance tracking
+    let db_path = config.server.database_url();
+    let db = open_database(&db_path).await?;
+
+    // Create session and run records
+    let session = create_session(db.as_ref(), SprocketCommand::Run)
+        .await
+        .context("failed to create session")?;
+
+    let (run_id, run_name, _run) = create_run_record(
+        db.as_ref(),
+        session.uuid,
+        &args.source,
+        Some(target.name()),
+        &inputs_to_json(target.name(), inputs).context("failed to serialize inputs")?,
+    )
+    .await
+    .context("failed to create run record")?;
+
+    // Update the run directory in the database
+    let run_dir_str = run_dir
+        .root()
+        .to_str()
+        .context("run directory path is not valid UTF-8")?;
+    db.update_run_directory(run_id, run_dir_str)
+        .await
+        .context("failed to update run directory")?;
+
+    let ctx = RunContext {
+        run_id,
+        run_generated_name: run_name,
+        started_at: Utc::now(),
+    };
+
+    Ok((ctx, run_dir, db))
 }
 
 /// Initializes logging to `output.log` in the given run directory.

--- a/src/system/v1/exec.rs
+++ b/src/system/v1/exec.rs
@@ -512,7 +512,7 @@ impl RunnableExecutor {
             self.engine_config,
             self.cancellation,
             self.events,
-            resolved_target,
+            &resolved_target,
             inputs,
             &run_dir,
             &base_dir,
@@ -612,7 +612,7 @@ pub async fn analyze_wdl_document(
 async fn set_run_success(
     db: &dyn Database,
     ctx: &RunContext,
-    target: Target,
+    target: &Target,
     outputs: Outputs,
     run_dir: &RunDirectory,
     index_on: Option<&str>,
@@ -766,7 +766,7 @@ async fn execute_task_target(
         )
     })?;
 
-    // Ensure the inputs are for a tas
+    // Ensure the inputs are for a task
     if inputs.as_task_inputs().is_none() {
         let error = "inputs are for a workflow, not a task";
         db.fail_run(ctx.run_id, error, Utc::now())
@@ -831,7 +831,7 @@ pub async fn execute_target(
     config: WdlConfig,
     cancellation: CancellationContext,
     events: Events,
-    target: Target,
+    target: &Target,
     inputs: Inputs,
     run_dir: &RunDirectory,
     base_dir: &EvaluationPath,
@@ -843,7 +843,7 @@ pub async fn execute_target(
         .map_err(anyhow::Error::from)?;
 
     let result: Result<Option<Outputs>, EvaluationError> = async {
-        match &target {
+        match target {
             Target::Task(_) => {
                 execute_task_target(
                     db.as_ref(),
@@ -852,7 +852,7 @@ pub async fn execute_target(
                     config,
                     cancellation,
                     events,
-                    &target,
+                    target,
                     inputs,
                     run_dir,
                     base_dir,

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -110,12 +110,17 @@ struct CommandOutput {
 }
 
 /// Runs a test given the test root directory.
-fn run_test(test_path: &Path) -> Result<()> {
+fn run_test(test_path: &Path, test_name: String) -> Result<()> {
     let working_test_directory = setup_working_test_directory(test_path)
         .context("failed to setup working test directory")?;
     let command_output = run_sprocket(test_path, working_test_directory.path())
         .context("failed to run sprocket command")?;
-    compare_test_results(test_path, working_test_directory.path(), &command_output)
+    compare_test_results(
+        test_path,
+        &test_name,
+        working_test_directory.path(),
+        &command_output,
+    )
 }
 
 /// Sets up the working test directory by copying initial files.
@@ -532,6 +537,7 @@ __UNEXPECTED_FILES_FOUND__
 /// Compares the result of the command output with the expected baseline.
 fn compare_test_results(
     test_path: &Path,
+    test_name: &str,
     working_test_directory: &Path,
     command_output: &CommandOutput,
 ) -> Result<()> {
@@ -569,6 +575,13 @@ fn compare_test_results(
         recursive_compare(&expected_output_dir, working_test_directory)?;
     }
 
+    // https://github.com/stjude-rust-labs/sprocket/issues/861
+    if test_name == "run/missing-required-array-input"
+        && working_test_directory.join("out").exists()
+    {
+        bail!("invalid CLI inputs shouldn't produce an output directory")
+    }
+
     compare_results(
         &expected_exit_code_file,
         &command_output.exit_code.to_string(),
@@ -589,8 +602,9 @@ fn main() {
     let trials = tests
         .into_iter()
         .map(|test| {
-            Trial::test(get_test_name(&test, test_root), move || {
-                run_test(&test).map_err(Into::into)
+            let name = get_test_name(&test, test_root);
+            Trial::test(name.clone(), move || {
+                run_test(&test, name).map_err(Into::into)
             })
         })
         .collect();


### PR DESCRIPTION
Prevents a run directory from being created if inputs fail validation

closes #861

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
