### PR TITLE
chore: install CI tools via official `cargo-binstall` action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,10 +42,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update stable
+      - name: Install `cargo-binstall`
+        uses: cargo-bins/cargo-binstall@main
       - name: Install `cargo-sort`
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-sort@2
+        run: cargo binstall -y cargo-sort
       - name: Check for sorted `Cargo.toml`
         run: cargo --locked sort -w --check
 
@@ -85,12 +85,10 @@ jobs:
           # Do not cache bins, as we already install pre-built binaries.
           cache-bin: false
 
-      - name: Install cargo-llvm-cov and cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: |
-            cargo-llvm-cov@0.8
-            nextest@0.9
+      - name: Install `cargo-binstall`
+        uses: cargo-bins/cargo-binstall@main
+      - name: Install `cargo-llvm-cov` and `cargo-nextest`
+        run: cargo binstall -y cargo-llvm-cov cargo-nextest
 
       # Pre-warm the npx cache so parallel tests don't race to install it.
       - name: Install Pagefind
@@ -122,12 +120,10 @@ jobs:
       - name: Update Rust
         run: rustup update stable && rustup default stable && rustup component add llvm-tools
 
-      - name: Install cargo-llvm-cov and cargo-nextest
-        uses: taiki-e/install-action@v2
-        with:
-          tool: |
-            cargo-llvm-cov@0.8
-            nextest@0.9
+      - name: Install `cargo-binstall`
+        uses: cargo-bins/cargo-binstall@main
+      - name: Install `cargo-llvm-cov` and `cargo-nextest`
+        run: cargo binstall -y cargo-llvm-cov cargo-nextest
 
       # See the `test` job
       - name: Install Pagefind
@@ -199,7 +195,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - run: cargo --locked install cargo-workspace-lints
+      - name: Install `cargo-binstall`
+        uses: cargo-bins/cargo-binstall@main
+      - name: Install `cargo-workspace-lints`
+        run: cargo binstall -y cargo-workspace-lints
       - run: cargo --locked workspace-lints
 
   deny:
@@ -208,10 +207,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - name: Install cargo-deny
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-deny@0.19
+      - name: Install `cargo-binstall`
+        uses: cargo-bins/cargo-binstall@main
+      - name: Install `cargo-deny`
+        run: cargo binstall -y cargo-deny
       - run: cargo --locked deny check
 
   msrv:
@@ -220,10 +219,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - name: Install cargo-binstall
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
-      - name: Install cargo-msrv
-        run: cargo --locked binstall -y --version 0.16.0-beta.23 cargo-msrv
+      - name: Install `cargo-binstall`
+        uses: cargo-bins/cargo-binstall@main
+      - name: Install `cargo-msrv`
+        run: cargo binstall -y cargo-msrv
       - name: Verify the MSRV
         working-directory: ./crates/wdl
         run: cargo --locked msrv verify --output-format minimal --all-features
@@ -234,9 +233,9 @@ jobs:
       - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update nightly && rustup default nightly
-      - name: Install cargo-udeps
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-udeps@0.1
+      - name: Install `cargo-binstall`
+        uses: cargo-bins/cargo-binstall@main
+      - name: Install `cargo-udeps`
+        run: cargo binstall -y cargo-udeps
       - name: Ensure no unused dependencies
         run: cargo --locked udeps


### PR DESCRIPTION
Experimental — opening as draft to see how the official `cargo-bins/cargo-binstall@main` action performs against `taiki-e/install-action` and the remaining `cargo install` source build.

This PR builds on #864 by:

- Swapping `taiki-e/install-action` for `cargo-bins/cargo-binstall@main` across the `sort`, `test`, `engine-test`, `deny`, and `udeps` jobs.
- Replacing the slow `cargo install cargo-workspace-lints` source build in the `workspace-lints-enabled` job with `cargo binstall`.
- Collapsing the hand-rolled `curl | bash` bootstrap in the `msrv` job into the official action.
- Dropping all tool version pins so each job picks up the latest release of `cargo-sort`, `cargo-llvm-cov`, `cargo-nextest`, `cargo-deny`, `cargo-udeps`, `cargo-workspace-lints`, and `cargo-msrv`.

Things to watch on this run:

- Whether `cargo binstall` finds prebuilt binaries for every tool — `cargo-workspace-lints` in particular may fall back to a source build if no release artifacts exist.
- Whether unpinning versions introduces any compatibility surprises in `cargo-sort` or `cargo-msrv`.

For external contributors:

- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the \`next\` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).