### PR TITLE
fix(wdl-engine): reopen the call cache lock file read-only before locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-
-* Fixed shared lock acquisition to reopen new lock files read-only before locking.
-
 ## 0.25.0 - 2026-05-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Fixed shared lock acquisition to reopen new lock files read-only before locking.
+
 ## 0.25.0 - 2026-05-14
 
 ### Added
@@ -108,7 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Increased SQLite `busy_timeout` from 5s to 30s and added retry with
   exponential backoff when opening the database
   ([#734](https://github.com/stjude-rust-labs/sprocket/pull/734)).
-* Fixed a bug where the `format`, `run`, `lock` and `inputs` commands would not 
+* Fixed a bug where the `format`, `run`, `lock` and `inputs` commands would not
   utilize the configured `fallback_version`
   ([#784](https://github.com/stjude-rust-labs/sprocket/pull/784)).
 
@@ -270,7 +274,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Apptainer-based backends now store converted container images within each run directory, rather than in a user-specified directory ([#463](https://github.com/stjude-rust-labs/sprocket/pull/463)).
 * `sprocket run` now writes a `.sprocketignore` file directly to the `runs/` directory instead of the `runs/<entrypoint>/` directory ([#481](https://github.com/stjude-rust-labs/sprocket/pull/481)).
 
-
 ### Fixed
 
 * Fixed a bug in `sprocket config init` where `sprocket.toml` was unnecessarily loaded and would fail if malformed ([#473](https://github.com/stjude-rust-labs/sprocket/pull/473)).
@@ -346,9 +349,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * Added support for `.sprocketignore` files ([#158](https://github.com/stjude-rust-labs/sprocket/pull/158)).
-    * the semantics of these new "ignorefiles" are similar to `.gitignore` files
-    * the commands `analyzer`, `check`/`lint`, and `doc` all respect these files
-    * both parent and child directories of the current working directory are searched for `.sprocketignore` files
+  * the semantics of these new "ignorefiles" are similar to `.gitignore` files
+  * the commands `analyzer`, `check`/`lint`, and `doc` all respect these files
+  * both parent and child directories of the current working directory are searched for `.sprocketignore` files
 * Added support for custom logos in `sprocket dev doc` ([#156](https://github.com/stjude-rust-labs/sprocket/pull/156)).
 
 ## 0.15.0 - 07-31-2025
@@ -361,15 +364,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added new default output directory logic ([#149](https://github.com/stjude-rust-labs/sprocket/pull/149)).
 * Individual analysis and lint rules can now be excepted when running the `
   analyzer` command ([#150](https://github.com/stjude-rust-labs/sprocket/pull/150)).
-    * both command line flags and TOML config are supported
+  * both command line flags and TOML config are supported
 
 ### Changed
 
 * The `UnusedCall` analysis rule no longer emits a diagnostic for tasks and
   workflows if they have an empty or missing `output` section ([wdl:#532](https://github.com/stjude-rust-labs/wdl/pull/532)).
 * `--name` option renamed to `--entrypoint` for `validate` and `run` ([#147](https://github.com/stjude-rust-labs/sprocket/pull/147)).
-    * `--entrypoint` is now required if no inputs are provided.
-    * `--entrypoint` will be prefixed to the key of any key-value pairs
+  * `--entrypoint` is now required if no inputs are provided.
+  * `--entrypoint` will be prefixed to the key of any key-value pairs
       supplied on the command line.
 
 ### Removed
@@ -472,10 +475,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Updated WDL crates to latest ([#79](https://github.com/stjude-rust-labs/sprocket/pull/79)). This added many features and fixes. Some highlights:
-    * Fixed certain misplaced highlights from the `ShellCheck` lint.
-    * Relaxed the `CommentWhitespace` lint rule so it doesn't trigger for as
+  * Fixed certain misplaced highlights from the `ShellCheck` lint.
+  * Relaxed the `CommentWhitespace` lint rule so it doesn't trigger for as
       many comments.
-    * The `ImportSort` lint rule now supplies the correct order of imports in
+  * The `ImportSort` lint rule now supplies the correct order of imports in
       the `fix` message.
 * By default, when checking a local file, suppress diagnostics from remote
   files. Added a `--show-remote-diagnostics` flag to recreate the older

--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-* Fixed shared lock acquisition to reopen new lock files read-only before locking.
+* Fixed shared lock acquisition to reopen new lock files read-only before locking ([#869](https://github.com/stjude-rust-labs/sprocket/pull/869)).
 
 ## 0.14.0 - 2026-05-14
 

--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* Fixed shared lock acquisition to reopen new lock files read-only before locking.
+
 ## 0.14.0 - 2026-05-14
 
 ## 0.13.2 - 2026-04-22
@@ -197,7 +201,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Removed
 
 * Removed the `codespan` cargo feature in favor of enabling codespan reporting always ([#462](https://github.com/stjude-rust-labs/sprocket/pull/462)).
-
 
 ## 0.9.0 - 10-14-2025
 

--- a/crates/wdl-engine/src/cache/lock.rs
+++ b/crates/wdl-engine/src/cache/lock.rs
@@ -28,15 +28,41 @@ impl LockedFile {
     pub async fn acquire_shared(path: impl AsRef<Path>, create: bool) -> Result<Option<Self>> {
         let path = path.as_ref();
         let file = if create {
-            // Create or open the file, but do not truncate it if it exists
-            let mut options = fs::OpenOptions::new();
-            options.create(true).write(true);
-            options.open(path).with_context(|| {
-                format!(
-                    "failed to create call cache entry file `{path}`",
-                    path = path.display()
-                )
-            })?
+            match fs::File::open(path) {
+                Ok(file) => file,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                    let mut options = fs::OpenOptions::new();
+                    options.create_new(true).write(true);
+
+                    match options.open(path) {
+                        Ok(file) => drop(file),
+                        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
+                        Err(e) => {
+                            return Err(e).with_context(|| {
+                                format!(
+                                    "failed to create call cache entry file `{path}`",
+                                    path = path.display()
+                                )
+                            });
+                        }
+                    }
+
+                    fs::File::open(path).with_context(|| {
+                        format!(
+                            "failed to open call cache entry file `{path}`",
+                            path = path.display()
+                        )
+                    })?
+                }
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!(
+                            "failed to open call cache entry file `{path}`",
+                            path = path.display()
+                        )
+                    });
+                }
+            }
         } else {
             match fs::File::open(path)
                 .map(Some)
@@ -194,7 +220,7 @@ mod test {
     }
 
     #[tokio::test]
-    async fn acquire_shared() {
+    async fn acquire_shared_existing_file() {
         let file = NamedTempFile::new().unwrap();
         let _first = LockedFile::acquire_shared(file.path(), true)
             .await
@@ -204,6 +230,23 @@ mod test {
             .await
             .unwrap()
             .expect("should have locked file");
+    }
+
+    #[tokio::test]
+    async fn acquire_shared_creates_file_returns_readable_lock() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("needs_to_be_created");
+
+        let mut file = LockedFile::acquire_shared(&path, true)
+            .await
+            .unwrap()
+            .expect("should create and lock file");
+
+        assert!(path.is_file());
+
+        let mut buf = String::new();
+        file.read_to_string(&mut buf)
+            .expect("shared lock file should be readable");
     }
 
     #[tokio::test]

--- a/crates/wdl-engine/src/cache/lock.rs
+++ b/crates/wdl-engine/src/cache/lock.rs
@@ -27,60 +27,39 @@ impl LockedFile {
     /// returned.
     pub async fn acquire_shared(path: impl AsRef<Path>, create: bool) -> Result<Option<Self>> {
         let path = path.as_ref();
-        let file = if create {
-            match fs::File::open(path) {
-                Ok(file) => file,
-                Err(e) if e.kind() == io::ErrorKind::NotFound => {
-                    let mut options = fs::OpenOptions::new();
-                    options.create_new(true).write(true);
+        let file = match fs::File::open(path) {
+            Ok(file) => file,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                if !create {
+                    return Ok(None);
+                }
 
-                    match options.open(path) {
-                        Ok(file) => drop(file),
-                        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {}
-                        Err(e) => {
-                            return Err(e).with_context(|| {
-                                format!(
-                                    "failed to create call cache entry file `{path}`",
-                                    path = path.display()
-                                )
-                            });
-                        }
+                // Create the file, which requires writable access
+                let mut options = fs::OpenOptions::new();
+                options.create_new(true).write(true);
+
+                match options.open(path) {
+                    Ok(file) => drop(file),
+                    Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+                        // Another process created the file after our initial open failed
                     }
+                    Err(e) => {
+                        return Err(e).with_context(|| {
+                            format!("failed to create file `{path}`", path = path.display())
+                        });
+                    }
+                }
 
-                    fs::File::open(path).with_context(|| {
-                        format!(
-                            "failed to open call cache entry file `{path}`",
-                            path = path.display()
-                        )
-                    })?
-                }
-                Err(e) => {
-                    return Err(e).with_context(|| {
-                        format!(
-                            "failed to open call cache entry file `{path}`",
-                            path = path.display()
-                        )
-                    });
-                }
+                // Re-open the file as readable as the lock is shared and we don't want the file
+                // to be writable
+                fs::File::open(path).with_context(|| {
+                    format!("failed to open file `{path}`", path = path.display())
+                })?
             }
-        } else {
-            match fs::File::open(path)
-                .map(Some)
-                .or_else(|e| {
-                    if e.kind() == io::ErrorKind::NotFound {
-                        Ok(None)
-                    } else {
-                        Err(e)
-                    }
-                })
-                .with_context(|| {
-                    format!(
-                        "failed to open call cache entry file `{path}`",
-                        path = path.display()
-                    )
-                })? {
-                Some(file) => file,
-                None => return Ok(None),
+            Err(e) => {
+                return Err(e).with_context(|| {
+                    format!("failed to open file `{path}`", path = path.display())
+                });
             }
         };
 

--- a/crates/wdl-engine/src/cache/lock.rs
+++ b/crates/wdl-engine/src/cache/lock.rs
@@ -36,19 +36,10 @@ impl LockedFile {
 
                 // Create the file, which requires writable access
                 let mut options = fs::OpenOptions::new();
-                options.create_new(true).write(true);
-
-                match options.open(path) {
-                    Ok(file) => drop(file),
-                    Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
-                        // Another process created the file after our initial open failed
-                    }
-                    Err(e) => {
-                        return Err(e).with_context(|| {
-                            format!("failed to create file `{path}`", path = path.display())
-                        });
-                    }
-                }
+                options.create(true).write(true);
+                options.open(path).with_context(|| {
+                    format!("failed to create file `{path}`", path = path.display())
+                })?;
 
                 // Re-open the file as readable as the lock is shared and we don't want the file
                 // to be writable


### PR DESCRIPTION
Fix #862

With `[run.task] cache = "on"`, `sprocket run` fails before workflow evaluation starts on NFS-backed filesystems:

```bash
error: failed to create workflow evaluator
Caused by:
    0: failed to acquire shared lock on cache entry file `sprocket_call_cache/.lock`
    1: Bad file descriptor (os error 9)
```

`acquire_shared(..., create: true)` created the global call-cache lock file with a write-only handle and then attempted to acquire a shared lock on that same handle. Apparently this works on some local filesystems, but can fail on NFS.

Fix:
When the lock file is missing, create it with `create_new(true)` using a temporary write handle and also deal with `AlreadyExists` in case of concurrent creators. The write handle is then explicitly dropped and the file is reopened read-only before acquiring the shared lock.

The `acquire_shared` test was renamed to `acquire_shared_existing_file ` to make it more explicit that an existing file is used, where the missing-file code-path is not followed. Added the `acquire_shared_creates_file_returns_readable_lock ` test to actually test the missing-file code-path.

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.