### PR TITLE
chore(ci): use `taiki-e/install-action` for `cargo-workspace-lints` and `cargo-msrv`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -199,7 +199,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - run: cargo --locked install cargo-workspace-lints
+      - name: Install `cargo-workspace-lints`
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-workspace-lints@0.1
       - run: cargo --locked workspace-lints
 
   deny:
@@ -220,10 +223,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Update Rust
         run: rustup update stable && rustup default stable
-      - name: Install cargo-binstall
-        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
       - name: Install cargo-msrv
-        run: cargo --locked binstall -y --version 0.16.0-beta.23 cargo-msrv
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-msrv@0.19
       - name: Verify the MSRV
         working-directory: ./crates/wdl
         run: cargo --locked msrv verify --output-format minimal --all-features


### PR DESCRIPTION
This is an alternative to #865 that uses [`taiki-e/install-action`](https://github.com/taiki-e/install-action) for the installation of `cargo-workspace-lints` and `cargo-msrv`.

Note that I left the version constraints. We'll still get bug fix updates, but won't automatically start using new versions with potential breaking changes. This will mean that we will have to periodically update these version constraints manually, so I'm happy to remove them.

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

cc @claymcleod