### PR TITLE
feat(wdl-lsp): hover support on doc comments

### DIFF
--- a/crates/wdl-analysis/src/handlers/hover.rs
+++ b/crates/wdl-analysis/src/handlers/hover.rs
@@ -19,17 +19,16 @@ use wdl_ast::AstNode;
 use wdl_ast::AstToken;
 use wdl_ast::Comment;
 use wdl_ast::Documented;
+use wdl_ast::Ident;
 use wdl_ast::SyntaxKind;
 use wdl_ast::SyntaxNode;
 use wdl_ast::SyntaxToken;
 use wdl_ast::TreeNode;
 use wdl_ast::TreeToken;
 use wdl_ast::v1::AccessExpr;
-use wdl_ast::v1::BoundDecl;
 use wdl_ast::v1::CallExpr;
 use wdl_ast::v1::CallTarget;
 use wdl_ast::v1::Decl;
-use wdl_ast::v1::EnumDefinition;
 use wdl_ast::v1::EnumVariant;
 use wdl_ast::v1::LiteralStruct;
 use wdl_ast::v1::LiteralStructItem;
@@ -37,9 +36,6 @@ use wdl_ast::v1::MetadataObject;
 use wdl_ast::v1::MetadataValue;
 use wdl_ast::v1::ParameterMetadataSection;
 use wdl_ast::v1::StructDefinition;
-use wdl_ast::v1::TaskDefinition;
-use wdl_ast::v1::UnboundDecl;
-use wdl_ast::v1::WorkflowDefinition;
 use wdl_grammar::SyntaxElement;
 
 use crate::Document;
@@ -98,7 +94,7 @@ pub fn hover(
     let hovered_token = root
         .token_at_offset(offset)
         .find(|t| t.kind() == SyntaxKind::Ident || t.kind() == SyntaxKind::Comment)
-        .ok_or_else(|| anyhow!("no token found at offset"))?;
+        .ok_or_else(|| anyhow!("no hoverable token found at offset"))?;
 
     let parent_node = hovered_token.parent().expect("token has no parent");
 
@@ -180,7 +176,7 @@ fn resolve_hover_by_context(
     document: &Document,
     graph: &DocumentGraph,
 ) -> Result<Option<String>> {
-    // Hovering doc comments of an item produces the same content as hoving the
+    // Hovering doc comments of an item produces the same content as hovering the
     // identifier of the item
     if token.kind() == SyntaxKind::Comment {
         let comment = Comment::cast(token.clone()).expect("should cast");
@@ -201,35 +197,22 @@ fn resolve_hover_by_context(
                 _ => break,
             };
 
-            let item_name = match target.kind() {
-                SyntaxKind::VersionStatementNode => {
-                    return match document.root().doc_comments() {
-                        Some(comments) if !comments.is_empty() => Ok(comments_to_string(comments)),
-                        _ => Ok(None),
-                    };
+            if target.kind() == SyntaxKind::VersionStatementNode {
+                return match document.root().doc_comments() {
+                    Some(comments) if !comments.is_empty() => Ok(comments_to_string(comments)),
+                    _ => Ok(None),
+                };
+            }
+
+            let Some(item_name) = target.descendants_with_tokens().find_map(|element| {
+                if let SyntaxElement::Token(token) = element
+                    && let Some(ident) = Ident::cast(token)
+                {
+                    return Some(ident);
                 }
-                SyntaxKind::StructDefinitionNode => StructDefinition::cast(target.clone())
-                    .expect("should cast")
-                    .name(),
-                SyntaxKind::EnumDefinitionNode => EnumDefinition::cast(target.clone())
-                    .expect("should cast")
-                    .name(),
-                SyntaxKind::EnumVariantNode => EnumVariant::cast(target.clone())
-                    .expect("should cast")
-                    .name(),
-                SyntaxKind::TaskDefinitionNode => TaskDefinition::cast(target.clone())
-                    .expect("should cast")
-                    .name(),
-                SyntaxKind::WorkflowDefinitionNode => WorkflowDefinition::cast(target.clone())
-                    .expect("should cast")
-                    .name(),
-                SyntaxKind::UnboundDeclNode => UnboundDecl::cast(target.clone())
-                    .expect("should cast")
-                    .name(),
-                SyntaxKind::BoundDeclNode => {
-                    BoundDecl::cast(target.clone()).expect("should cast").name()
-                }
-                _ => break,
+                None
+            }) else {
+                break;
             };
 
             return resolve_hover_content(&target, item_name.inner(), document, graph);

--- a/crates/wdl-analysis/src/handlers/hover.rs
+++ b/crates/wdl-analysis/src/handlers/hover.rs
@@ -6,15 +6,18 @@
 //! See: [LSP Specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover)
 
 use anyhow::Result;
+use anyhow::anyhow;
 use anyhow::bail;
 use lsp_types::Hover;
 use lsp_types::HoverContents;
 use lsp_types::MarkupContent;
 use lsp_types::MarkupKind;
+use rowan::Direction;
 use tracing::debug;
 use url::Url;
 use wdl_ast::AstNode;
 use wdl_ast::AstToken;
+use wdl_ast::Comment;
 use wdl_ast::Documented;
 use wdl_ast::SyntaxKind;
 use wdl_ast::SyntaxNode;
@@ -22,9 +25,11 @@ use wdl_ast::SyntaxToken;
 use wdl_ast::TreeNode;
 use wdl_ast::TreeToken;
 use wdl_ast::v1::AccessExpr;
+use wdl_ast::v1::BoundDecl;
 use wdl_ast::v1::CallExpr;
 use wdl_ast::v1::CallTarget;
 use wdl_ast::v1::Decl;
+use wdl_ast::v1::EnumDefinition;
 use wdl_ast::v1::EnumVariant;
 use wdl_ast::v1::LiteralStruct;
 use wdl_ast::v1::LiteralStructItem;
@@ -32,6 +37,10 @@ use wdl_ast::v1::MetadataObject;
 use wdl_ast::v1::MetadataValue;
 use wdl_ast::v1::ParameterMetadataSection;
 use wdl_ast::v1::StructDefinition;
+use wdl_ast::v1::TaskDefinition;
+use wdl_ast::v1::UnboundDecl;
+use wdl_ast::v1::WorkflowDefinition;
+use wdl_grammar::SyntaxElement;
 
 use crate::Document;
 use crate::SourcePosition;
@@ -39,7 +48,7 @@ use crate::SourcePositionEncoding;
 use crate::graph::DocumentGraph;
 use crate::graph::ParseState;
 use crate::handlers::TypeEvalContext;
-use crate::handlers::common::find_identifier_token_at_offset;
+use crate::handlers::common::comments_to_string;
 use crate::handlers::common::location_from_span;
 use crate::handlers::common::position_to_offset;
 use crate::handlers::common::provide_enum_documentation;
@@ -86,14 +95,15 @@ pub fn hover(
     };
 
     let offset = position_to_offset(&lines, position, encoding)?;
-    let Some(token) = find_identifier_token_at_offset(&root, offset) else {
-        bail!("no identifier found at position");
-    };
+    let hovered_token = root
+        .token_at_offset(offset)
+        .find(|t| t.kind() == SyntaxKind::Ident || t.kind() == SyntaxKind::Comment)
+        .ok_or_else(|| anyhow!("no token found at offset"))?;
 
-    let parent_node = token.parent().expect("token has no parent");
+    let parent_node = hovered_token.parent().expect("token has no parent");
 
-    if let Ok(Some(value)) = resolve_hover_content(&parent_node, &token, document, graph) {
-        let range = location_from_span(document_uri, token.span(), &lines)?.range;
+    if let Ok(Some(value)) = resolve_hover_content(&parent_node, &hovered_token, document, graph) {
+        let range = location_from_span(document_uri, hovered_token.span(), &lines)?.range;
         Ok(Some(Hover {
             contents: HoverContents::Markup(MarkupContent {
                 kind: MarkupKind::Markdown,
@@ -170,6 +180,62 @@ fn resolve_hover_by_context(
     document: &Document,
     graph: &DocumentGraph,
 ) -> Result<Option<String>> {
+    // Hovering doc comments of an item produces the same content as hoving the
+    // identifier of the item
+    if token.kind() == SyntaxKind::Comment {
+        let comment = Comment::cast(token.clone()).expect("should cast");
+        if !comment.is_doc_comment() {
+            return Ok(None);
+        }
+
+        for sibling in token.siblings_with_tokens(Direction::Next) {
+            let target = match sibling {
+                SyntaxElement::Node(target) => target,
+                // Also lets line comments and directives through, like `wdl-doc`
+                SyntaxElement::Token(token)
+                    if token.kind() == SyntaxKind::Comment
+                        || token.kind() == SyntaxKind::Whitespace =>
+                {
+                    continue;
+                }
+                _ => break,
+            };
+
+            let item_name = match target.kind() {
+                SyntaxKind::VersionStatementNode => {
+                    return match document.root().doc_comments() {
+                        Some(comments) if !comments.is_empty() => Ok(comments_to_string(comments)),
+                        _ => Ok(None),
+                    };
+                }
+                SyntaxKind::StructDefinitionNode => StructDefinition::cast(target.clone())
+                    .expect("should cast")
+                    .name(),
+                SyntaxKind::EnumDefinitionNode => EnumDefinition::cast(target.clone())
+                    .expect("should cast")
+                    .name(),
+                SyntaxKind::EnumVariantNode => EnumVariant::cast(target.clone())
+                    .expect("should cast")
+                    .name(),
+                SyntaxKind::TaskDefinitionNode => TaskDefinition::cast(target.clone())
+                    .expect("should cast")
+                    .name(),
+                SyntaxKind::WorkflowDefinitionNode => WorkflowDefinition::cast(target.clone())
+                    .expect("should cast")
+                    .name(),
+                SyntaxKind::UnboundDeclNode => UnboundDecl::cast(target.clone())
+                    .expect("should cast")
+                    .name(),
+                SyntaxKind::BoundDeclNode => {
+                    BoundDecl::cast(target.clone()).expect("should cast").name()
+                }
+                _ => break,
+            };
+
+            return resolve_hover_content(&target, item_name.inner(), document, graph);
+        }
+    }
+
     match parent_node.kind() {
         SyntaxKind::TypeRefNode | SyntaxKind::LiteralStructNode => {
             if let Some(s) = document.struct_by_name(token.text()) {

--- a/crates/wdl-ast/src/lib.rs
+++ b/crates/wdl-ast/src/lib.rs
@@ -477,6 +477,14 @@ impl<N: TreeNode> AstNode<N> for Document<N> {
     }
 }
 
+impl Documented<SyntaxNode> for Document<SyntaxNode> {
+    fn doc_comments(&self) -> Option<Vec<Comment<<SyntaxNode as TreeNode>::Token>>> {
+        let version_statement = self.child::<VersionStatement>()?;
+        let version_keyword = version_statement.keyword();
+        Some(doc_comments::<SyntaxNode>(version_keyword.inner().preceding_trivia()).collect())
+    }
+}
+
 impl Document {
     /// Parses a document from the given source.
     ///

--- a/crates/wdl-lsp/CHANGELOG.md
+++ b/crates/wdl-lsp/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Added hover support for doc comments, allowing editors to render preamble comments and give more surface area
+  to render item docs ([#873](https://github.com/stjude-rust-labs/sprocket/pull/873)).
+
 ## 0.19.1 - 2026-05-14
 
 ## 0.19.0 - 2026-04-22

--- a/crates/wdl-lsp/CHANGELOG.md
+++ b/crates/wdl-lsp/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-* Added hover support for doc comments, allowing editors to render preamble comments and give more surface area
-  to render item docs ([#873](https://github.com/stjude-rust-labs/sprocket/pull/873)).
+* Extended hover to render docs when the cursor is over a doc comment or the file preamble ([#873](https://github.com/stjude-rust-labs/sprocket/pull/873)).
 
 ## 0.19.1 - 2026-05-14
 

--- a/crates/wdl-lsp/tests/hover.rs
+++ b/crates/wdl-lsp/tests/hover.rs
@@ -344,6 +344,7 @@ async fn should_render_docs_on_comment_hover() {
     // Hovering over doc comments should produce the same content as hovering
     // over the item name.
     let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(5, 4)).await;
+    assert_hover_content(&response, "task doc_only");
     assert_hover_content(&response, "Greets someone by name.");
     assert_hover_content(&response, "Used for hover doc tests.");
 }
@@ -354,4 +355,19 @@ async fn should_render_preamble_on_hover() {
     // Hovering over preamble should render like hovering over an item
     let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(0, 4)).await;
     assert_hover_content(&response, "This is a preamble comment");
+}
+
+#[tokio::test]
+async fn should_not_render_standalone_docs_on_hover() {
+    let mut ctx = setup().await;
+    // Only ever render doc comments when they're attached to a node
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(95, 4)).await;
+    assert!(response.is_none());
+}
+
+#[tokio::test]
+async fn should_not_render_line_comments_on_hover() {
+    let mut ctx = setup().await;
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(97, 4)).await;
+    assert!(response.is_none());
 }

--- a/crates/wdl-lsp/tests/hover.rs
+++ b/crates/wdl-lsp/tests/hover.rs
@@ -237,7 +237,7 @@ async fn should_hover_enum_variant() {
 async fn should_hover_task_doc_comment_only() {
     let mut ctx = setup().await;
     // Position of `doc_only` in `task doc_only`
-    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(4, 7)).await;
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(6, 7)).await;
     assert_hover_content(&response, "task doc_only");
     assert_hover_content(
         &response,
@@ -249,7 +249,7 @@ async fn should_hover_task_doc_comment_only() {
 async fn should_hover_task_doc_comment_over_meta() {
     let mut ctx = setup().await;
     // Position of `doc_and_meta` in `task doc_and_meta`
-    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(20, 7)).await;
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(22, 7)).await;
     assert_hover_content(&response, "task doc_and_meta");
     assert_hover_content(&response, "This doc comment should win over meta.");
 }
@@ -272,7 +272,7 @@ fn assert_hover_not_content(hover: &Option<Hover>, unexpected: &str) {
 #[tokio::test]
 async fn should_hover_task_doc_comment_not_meta() {
     let mut ctx = setup().await;
-    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(20, 7)).await;
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(22, 7)).await;
     assert_hover_not_content(&response, "This meta description should NOT appear");
 }
 
@@ -280,7 +280,7 @@ async fn should_hover_task_doc_comment_not_meta() {
 async fn should_hover_task_meta_fallback() {
     let mut ctx = setup().await;
     // Position of `meta_only` in `task meta_only`
-    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(38, 7)).await;
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(40, 7)).await;
     assert_hover_content(&response, "task meta_only");
     assert_hover_content(&response, "A simple greeting task");
 }
@@ -289,7 +289,7 @@ async fn should_hover_task_meta_fallback() {
 async fn should_hover_input_doc_comment() {
     let mut ctx = setup().await;
     // Position of `name` in `String name` inside doc_only task input
-    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(7, 15)).await;
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(9, 15)).await;
     assert_hover_content(&response, "(variable) name: String");
     assert_hover_content(&response, "The person's name to greet");
 }
@@ -297,7 +297,7 @@ async fn should_hover_input_doc_comment() {
 async fn should_hover_workflow_doc_comment() {
     let mut ctx = setup().await;
     // Position of `doc_workflow` in `workflow doc_workflow`
-    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(58, 9)).await;
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(60, 9)).await;
     assert_hover_content(&response, "workflow doc_workflow");
     assert_hover_content(
         &response,
@@ -309,7 +309,7 @@ async fn should_hover_workflow_doc_comment() {
 async fn should_hover_struct_doc_comment() {
     let mut ctx = setup().await;
     // Position of `DocPerson` in `struct DocPerson`
-    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(73, 7)).await;
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(75, 7)).await;
     assert_hover_content(&response, "struct DocPerson");
     assert_hover_content(
         &response,
@@ -321,7 +321,7 @@ async fn should_hover_struct_doc_comment() {
 async fn should_hover_enum_doc_comment() {
     let mut ctx = setup().await;
     // Position of `DocStatus` in `enum DocStatus`
-    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(81, 5)).await;
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(83, 5)).await;
     assert_hover_content(&response, "enum DocStatus");
     assert_hover_content(&response, "A status indicator enum.");
 }
@@ -332,8 +332,26 @@ async fn should_hover_blank_line_doc_merges_paragraphs() {
     // Position of `blank_line_doc` in `task blank_line_doc`
     // Doc comments separated by a blank `##` line are all collected.
     // This documents the current behavior: blank separator lines are included.
-    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(89, 5)).await;
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(91, 5)).await;
     assert_hover_content(&response, "task blank_line_doc");
     assert_hover_content(&response, "First paragraph of doc.");
     assert_hover_content(&response, "Second paragraph after blank line.");
+}
+
+#[tokio::test]
+async fn should_render_docs_on_comment_hover() {
+    let mut ctx = setup().await;
+    // Hovering over doc comments should produce the same content as hovering
+    // over the item name.
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(5, 4)).await;
+    assert_hover_content(&response, "Greets someone by name.");
+    assert_hover_content(&response, "Used for hover doc tests.");
+}
+
+#[tokio::test]
+async fn should_render_preamble_on_hover() {
+    let mut ctx = setup().await;
+    // Hovering over preamble should render like hovering over an item
+    let response = hover_request(&mut ctx, "doc_comments.wdl", Position::new(0, 4)).await;
+    assert_hover_content(&response, "This is a preamble comment");
 }

--- a/crates/wdl-lsp/tests/workspace/hover/doc_comments.wdl
+++ b/crates/wdl-lsp/tests/workspace/hover/doc_comments.wdl
@@ -92,3 +92,7 @@ enum DocStatus {
 task blank_line_doc {
     command <<<>>>
 }
+
+## I'm not attached to anything...
+
+# And I'm a plain line comment

--- a/crates/wdl-lsp/tests/workspace/hover/doc_comments.wdl
+++ b/crates/wdl-lsp/tests/workspace/hover/doc_comments.wdl
@@ -1,3 +1,5 @@
+## This is a preamble comment
+
 version 1.3
 
 ## Greets someone by name.


### PR DESCRIPTION
Adds the ability to hover doc comments to get a rendered preview. Not sure if other editors typically do this, but I really like this feature in RustRover

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
