### PR TITLE
feat(wdl-lsp): call hierarchy support

### DIFF
--- a/crates/wdl-analysis/src/analyzer.rs
+++ b/crates/wdl-analysis/src/analyzer.rs
@@ -21,6 +21,9 @@ use line_index::LineCol;
 use line_index::LineIndex;
 use line_index::WideEncoding;
 use line_index::WideLineCol;
+use lsp_types::CallHierarchyIncomingCall;
+use lsp_types::CallHierarchyItem;
+use lsp_types::CallHierarchyOutgoingCall;
 use lsp_types::CompletionResponse;
 use lsp_types::DocumentSymbolResponse;
 use lsp_types::GotoDefinitionResponse;
@@ -44,15 +47,18 @@ use crate::graph::ParseState;
 use crate::queue::AddRequest;
 use crate::queue::AnalysisQueue;
 use crate::queue::AnalyzeRequest;
+use crate::queue::CallHierarchyRequest;
 use crate::queue::CompletionRequest;
 use crate::queue::DocumentSymbolRequest;
 use crate::queue::FindAllReferencesRequest;
 use crate::queue::FormatRequest;
 use crate::queue::GotoDefinitionRequest;
 use crate::queue::HoverRequest;
+use crate::queue::IncomingCallsRequest;
 use crate::queue::InlayHintsRequest;
 use crate::queue::NotifyChangeRequest;
 use crate::queue::NotifyIncrementalChangeRequest;
+use crate::queue::OutgoingCallsRequest;
 use crate::queue::RemoveRequest;
 use crate::queue::RenameRequest;
 use crate::queue::Request;
@@ -603,6 +609,36 @@ where
         })?
     }
 
+    /// Get the call hierarchy for the symbol at the current position.
+    pub async fn call_hierarchy(
+        &self,
+        document: Url,
+        position: SourcePosition,
+        encoding: SourcePositionEncoding,
+    ) -> Result<Option<Vec<CallHierarchyItem>>> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(Request::CallHierarchy(CallHierarchyRequest {
+                document,
+                position,
+                encoding,
+                completed: tx,
+            }))
+            .map_err(|_| {
+                anyhow!(
+                    "failed to send call hierarchy request to analysis queue because the channel \
+                     has closed"
+                )
+            })?;
+
+        rx.await.map_err(|_| {
+            anyhow!(
+                "failed to receive call hierarchy response from analysis queue because the \
+                 channel has closed"
+            )
+        })
+    }
+
     /// Formats a document.
     pub async fn format_document(&self, document: Url) -> Result<Option<(u32, u32, String)>> {
         let (tx, rx) = oneshot::channel();
@@ -836,6 +872,66 @@ where
         rx.await.map_err(|_| {
             anyhow!(
                 "failed to receive workspace symbol response from analysis queue because the \
+                 channel has closed"
+            )
+        })
+    }
+
+    /// Get the incoming calls for the symbol at the current position.
+    pub async fn incoming_calls(
+        &self,
+        document: Url,
+        position: SourcePosition,
+        encoding: SourcePositionEncoding,
+    ) -> Result<Option<Vec<CallHierarchyIncomingCall>>> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(Request::IncomingCalls(IncomingCallsRequest {
+                document,
+                position,
+                encoding,
+                completed: tx,
+            }))
+            .map_err(|_| {
+                anyhow!(
+                    "failed to send incoming calls request to analysis queue because the channel \
+                     has closed"
+                )
+            })?;
+
+        rx.await.map_err(|_| {
+            anyhow!(
+                "failed to receive incoming calls response from analysis queue because the \
+                 channel has closed"
+            )
+        })
+    }
+
+    /// Get the outgoing calls for the symbol at the current position.
+    pub async fn outgoing_calls(
+        &self,
+        document: Url,
+        position: SourcePosition,
+        encoding: SourcePositionEncoding,
+    ) -> Result<Option<Vec<CallHierarchyOutgoingCall>>> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(Request::OutgoingCalls(OutgoingCallsRequest {
+                document,
+                position,
+                encoding,
+                completed: tx,
+            }))
+            .map_err(|_| {
+                anyhow!(
+                    "failed to send outgoing calls request to analysis queue because the channel \
+                     has closed"
+                )
+            })?;
+
+        rx.await.map_err(|_| {
+            anyhow!(
+                "failed to receive outgoing calls response from analysis queue because the \
                  channel has closed"
             )
         })

--- a/crates/wdl-analysis/src/document.rs
+++ b/crates/wdl-analysis/src/document.rs
@@ -523,6 +523,8 @@ pub struct Task {
     name_span: Span,
     /// The name of the task.
     name: String,
+    /// The span of the task definition.
+    span: Span,
     /// The scopes contained in the task.
     ///
     /// The first scope will always be the task's scope.
@@ -544,6 +546,11 @@ impl Task {
     /// Gets the span of the name.
     pub fn name_span(&self) -> Span {
         self.name_span
+    }
+
+    /// Gets the span of the workflow definition.
+    pub fn span(&self) -> Span {
+        self.span
     }
 
     /// Gets the scope of the task.
@@ -569,6 +576,8 @@ pub struct Workflow {
     name_span: Span,
     /// The name of the workflow.
     name: String,
+    /// The span of the workflow definition.
+    span: Span,
     /// The scopes contained in the workflow.
     ///
     /// The first scope will always be the workflow's scope.
@@ -594,6 +603,11 @@ impl Workflow {
     /// Gets the span of the name.
     pub fn name_span(&self) -> Span {
         self.name_span
+    }
+
+    /// Gets the span of the workflow definition.
+    pub fn span(&self) -> Span {
+        self.span
     }
 
     /// Gets the scope of the workflow.

--- a/crates/wdl-analysis/src/document.rs
+++ b/crates/wdl-analysis/src/document.rs
@@ -636,6 +636,41 @@ impl Workflow {
     }
 }
 
+/// A callable item.
+#[derive(Debug)]
+pub enum Callable<'a> {
+    /// A workflow.
+    Workflow(&'a Workflow),
+    /// A task.
+    Task(&'a Task),
+}
+
+impl Callable<'_> {
+    /// Get the name of this callable.
+    pub fn name(&self) -> &str {
+        match self {
+            Callable::Workflow(w) => w.name(),
+            Callable::Task(t) => t.name(),
+        }
+    }
+
+    /// Get the [`Span`] of the callable's name.
+    pub fn name_span(&self) -> Span {
+        match self {
+            Callable::Workflow(w) => w.name_span(),
+            Callable::Task(t) => t.name_span(),
+        }
+    }
+
+    /// Get the [`Span`] of the callable's full definition.
+    pub fn span(&self) -> Span {
+        match self {
+            Callable::Workflow(w) => w.span(),
+            Callable::Task(t) => t.span(),
+        }
+    }
+}
+
 /// Represents analysis data about a WDL document.
 #[derive(Debug)]
 pub(crate) struct DocumentData {
@@ -925,6 +960,24 @@ impl Document {
     /// Returns `None` if the document did not contain a workflow.
     pub fn workflow(&self) -> Option<&Workflow> {
         self.data.workflow.as_ref()
+    }
+
+    /// Gets a [`Callable`] in the document by name.
+    ///
+    /// Returns `None` if the document did not contain a callable definition
+    /// with the given name.
+    pub fn callable_by_name(&self, name: &str) -> Option<Callable<'_>> {
+        if let Some(workflow) = self.workflow()
+            && workflow.name() == name
+        {
+            return Some(Callable::Workflow(workflow));
+        }
+
+        if let Some(task) = self.task_by_name(name) {
+            return Some(Callable::Task(task));
+        }
+
+        None
     }
 
     /// Gets the structs in the document.

--- a/crates/wdl-analysis/src/document/v1.rs
+++ b/crates/wdl-analysis/src/document/v1.rs
@@ -753,6 +753,7 @@ fn add_task(config: &Config, document: &mut DocumentData, definition: &TaskDefin
     let mut task = Task {
         name_span: name.span(),
         name: name.text().to_string(),
+        span: definition.span(),
         scopes: vec![Scope::new(
             None,
             definition
@@ -1045,6 +1046,7 @@ fn add_workflow(document: &mut DocumentData, workflow: &WorkflowDefinition) -> b
     document.workflow = Some(Workflow {
         name_span: name.span(),
         name: name.text().to_string(),
+        span: workflow.span(),
         scopes: Default::default(),
         inputs: Default::default(),
         outputs: Default::default(),

--- a/crates/wdl-analysis/src/handlers.rs
+++ b/crates/wdl-analysis/src/handlers.rs
@@ -8,6 +8,7 @@ use crate::diagnostics;
 use crate::document::ScopeRef;
 use crate::types::v1::EvaluationContext;
 
+mod call_hierarchy;
 mod common;
 mod completions;
 mod document_symbol;
@@ -21,6 +22,7 @@ mod signature_help;
 pub(crate) mod snippets;
 mod workspace_symbol;
 
+pub use call_hierarchy::*;
 pub use completions::*;
 pub use document_symbol::*;
 pub use find_all_references::*;

--- a/crates/wdl-analysis/src/handlers/call_hierarchy.rs
+++ b/crates/wdl-analysis/src/handlers/call_hierarchy.rs
@@ -344,20 +344,14 @@ pub fn outgoing_calls(
             &from_doc
         };
 
-        let source_index = graph.get_index(to_doc.uri()).ok_or_else(|| {
-            anyhow!(
-                "document `{uri}` not found in graph",
-                uri = to_doc.uri()
-            )
-        })?;
+        let source_index = graph
+            .get_index(to_doc.uri())
+            .ok_or_else(|| anyhow!("document `{uri}` not found in graph", uri = to_doc.uri()))?;
 
         let source_node = graph.get(source_index);
         let lines = match source_node.parse_state() {
             ParseState::Parsed { lines, .. } => lines.clone(),
-            _ => bail!(
-                "document `{uri}` has not been parsed",
-                uri = to_doc.uri()
-            ),
+            _ => bail!("document `{uri}` has not been parsed", uri = to_doc.uri()),
         };
 
         let Some(from_span) = scope.lookup(ident).map(|s| s.span()) else {

--- a/crates/wdl-analysis/src/handlers/call_hierarchy.rs
+++ b/crates/wdl-analysis/src/handlers/call_hierarchy.rs
@@ -1,0 +1,341 @@
+//! Handlers for `call hierarchy` requests.
+//!
+//! This module implements the LSP "textDocument/prepareCallHierarchy"
+//! functionality for WDL files.
+//!
+//! See: [LSP Specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareCallHierarchy)
+
+use std::collections::HashMap;
+use std::collections::hash_map::Entry;
+use std::sync::Arc;
+
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use line_index::LineIndex;
+use lsp_types::CallHierarchyIncomingCall;
+use lsp_types::CallHierarchyItem;
+use lsp_types::CallHierarchyOutgoingCall;
+use lsp_types::Range;
+use lsp_types::SymbolKind;
+use url::Url;
+use wdl_ast::AstNode;
+use wdl_ast::AstToken;
+use wdl_ast::v1::TaskDefinition;
+use wdl_ast::v1::WorkflowDefinition;
+use wdl_grammar::Span;
+use wdl_grammar::SyntaxNode;
+
+use crate::Document;
+use crate::SourcePosition;
+use crate::SourcePositionEncoding;
+use crate::document::Task;
+use crate::document::Workflow;
+use crate::graph::DocumentGraph;
+use crate::graph::ParseState;
+use crate::handlers::EnclosingScopeKind;
+use crate::handlers::common::find_identifier_token_at_offset;
+use crate::handlers::common::location_from_span;
+use crate::handlers::common::position_to_offset;
+use crate::handlers::find_all_references;
+use crate::types::CallKind;
+
+/// A callable item.
+enum Callable<'a> {
+    /// A workflow.
+    Workflow(&'a Workflow),
+    /// A task.
+    Task(&'a Task),
+}
+
+impl Callable<'_> {
+    /// Get the name of this callable.
+    fn name(&self) -> &str {
+        match self {
+            Callable::Workflow(w) => w.name(),
+            Callable::Task(t) => t.name(),
+        }
+    }
+
+    /// Get the [`Span`] of the callable's name.
+    fn name_span(&self) -> Span {
+        match self {
+            Callable::Workflow(w) => w.name_span(),
+            Callable::Task(t) => t.name_span(),
+        }
+    }
+
+    /// Get the [`SymbolKind`] for this callable.
+    fn symbol_kind(&self) -> SymbolKind {
+        match self {
+            Callable::Workflow(_) => SymbolKind::FUNCTION,
+            Callable::Task(_) => SymbolKind::METHOD,
+        }
+    }
+
+    /// Attempt to convert this callable to a [`CallHierarchyItem`].
+    fn as_call_hierarchy_item(
+        &self,
+        analysis_doc: &Document,
+        lines: &LineIndex,
+    ) -> Result<CallHierarchyItem> {
+        let name_range = location_from_span(analysis_doc.uri(), self.name_span(), lines)?.range;
+
+        Ok(CallHierarchyItem {
+            name: self.name().to_string(),
+            kind: self.symbol_kind(),
+            tags: None,
+            detail: None,
+            uri: (**analysis_doc.uri()).clone(),
+            range: name_range,
+            selection_range: name_range,
+            data: None,
+        })
+    }
+}
+
+/// Attempt to get a [`Callable`] from the specified position.
+fn find_callable_at_position<'a>(
+    graph: &'a DocumentGraph,
+    document_uri: &Url,
+    position: SourcePosition,
+    encoding: SourcePositionEncoding,
+) -> Result<Option<(Document, Arc<LineIndex>, Callable<'a>)>> {
+    let index = graph
+        .get_index(document_uri)
+        .ok_or_else(|| anyhow!("document `{uri}` not found in graph", uri = document_uri))?;
+
+    let node = graph.get(index);
+    let (root, lines) = match node.parse_state() {
+        ParseState::Parsed { lines, root, .. } => {
+            (SyntaxNode::new_root(root.clone()), lines.clone())
+        }
+        _ => bail!("document `{uri}` has not been parsed", uri = document_uri),
+    };
+
+    let Some(analysis_doc) = node.document() else {
+        bail!("document analysis data not available for {}", document_uri);
+    };
+
+    let offset = position_to_offset(&lines, position, encoding)?;
+    let Some(token) = find_identifier_token_at_offset(&root, offset) else {
+        return Ok(None);
+    };
+
+    if let Some(workflow) = analysis_doc.workflow()
+        && workflow.name() == token.text()
+    {
+        return Ok(Some((
+            analysis_doc.clone(),
+            lines,
+            Callable::Workflow(workflow),
+        )));
+    }
+
+    if let Some(task) = analysis_doc.task_by_name(token.text()) {
+        return Ok(Some((analysis_doc.clone(), lines, Callable::Task(task))));
+    }
+
+    Ok(None)
+}
+
+/// Creates a [`CallHierarchyItem`] for the given symbol, if applicable.
+///
+/// Implementation of [`textDocument/prepareCallHierarchy`]
+///
+/// [`textDocument/prepareCallHierarchy`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_prepareCallHierarchy
+pub fn call_hierarchy(
+    graph: &DocumentGraph,
+    document_uri: Url,
+    position: SourcePosition,
+    encoding: SourcePositionEncoding,
+) -> Result<Option<Vec<CallHierarchyItem>>> {
+    let Some((analysis_doc, lines, callable)) =
+        find_callable_at_position(graph, &document_uri, position, encoding)?
+    else {
+        return Ok(None);
+    };
+
+    Ok(Some(vec![
+        callable.as_call_hierarchy_item(&analysis_doc, &lines)?,
+    ]))
+}
+
+/// Determines all incoming calls for the given symbol.
+///
+/// Implementation of [`callHierarchy/incomingCalls`]
+///
+/// [`callHierarchy/incomingCalls`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchy_incomingCalls
+pub fn incoming_calls(
+    graph: &DocumentGraph,
+    document_uri: Url,
+    position: SourcePosition,
+    encoding: SourcePositionEncoding,
+) -> Result<Option<Vec<CallHierarchyIncomingCall>>> {
+    let Some((analysis_doc, _, callable)) =
+        find_callable_at_position(graph, &document_uri, position, encoding)?
+    else {
+        return Ok(None);
+    };
+
+    let target_name = match &callable {
+        Callable::Workflow(workflow) => workflow.name().to_string(),
+        Callable::Task(task) => task.name().to_string(),
+    };
+
+    let references = find_all_references(graph, document_uri, position, encoding, false)?;
+    if references.references.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+
+    let mut calls: HashMap<(Url, String), (CallHierarchyItem, Vec<Range>)> = HashMap::new();
+
+    for reference in references.references {
+        let Some(scope) = reference.enclosing_scope else {
+            continue;
+        };
+
+        if scope.name == target_name && scope.location.uri == **analysis_doc.uri() {
+            continue;
+        }
+
+        let kind = match scope.kind {
+            EnclosingScopeKind::Task => SymbolKind::METHOD,
+            EnclosingScopeKind::Workflow => SymbolKind::FUNCTION,
+        };
+
+        match calls.entry((scope.location.uri.clone(), scope.name.clone())) {
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().1.push(reference.location.range);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert((
+                    CallHierarchyItem {
+                        name: scope.name,
+                        kind,
+                        tags: None,
+                        detail: None,
+                        uri: scope.location.uri,
+                        range: scope.location.range,
+                        selection_range: scope.location.range,
+                        data: None,
+                    },
+                    vec![reference.location.range],
+                ));
+            }
+        }
+    }
+
+    Ok(Some(
+        calls
+            .into_values()
+            .map(|(from, from_ranges)| CallHierarchyIncomingCall { from, from_ranges })
+            .collect(),
+    ))
+}
+
+/// Determines all outgoing calls for the given symbol.
+///
+/// Implementation of [`callHierarchy/outgoingCalls`]
+///
+/// [`callHierarchy/outgoingCalls`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchy_outgoingCalls
+pub fn outgoing_calls(
+    graph: &DocumentGraph,
+    document_uri: Url,
+    position: SourcePosition,
+    encoding: SourcePositionEncoding,
+) -> Result<Option<Vec<CallHierarchyOutgoingCall>>> {
+    let Some((analysis_doc, lines, callable)) =
+        find_callable_at_position(graph, &document_uri, position, encoding)?
+    else {
+        return Ok(None);
+    };
+
+    let Callable::Workflow(workflow) = callable else {
+        return Ok(Some(Vec::new()));
+    };
+
+    let mut calls: HashMap<(Url, String), (CallHierarchyItem, Vec<Range>)> = HashMap::new();
+    let scope = workflow.scope();
+
+    for (ident, call) in workflow.calls() {
+        let source_doc = call
+            .namespace()
+            .map(|ns| {
+                analysis_doc
+                    .namespace(ns)
+                    .expect("namespace should be present")
+                    .document()
+            })
+            .unwrap_or(&analysis_doc);
+
+        let source_index = graph.get_index(source_doc.uri()).ok_or_else(|| {
+            anyhow!(
+                "document `{uri}` not found in graph",
+                uri = source_doc.uri()
+            )
+        })?;
+
+        let source_node = graph.get(source_index);
+        let source_lines = match source_node.parse_state() {
+            ParseState::Parsed { lines, .. } => lines.clone(),
+            _ => bail!(
+                "document `{uri}` has not been parsed",
+                uri = source_doc.uri()
+            ),
+        };
+
+        let from_span = scope.lookup(ident).expect("should be in scope").span();
+        let from_range = location_from_span(analysis_doc.uri(), from_span, &lines)?.range;
+
+        let (kind, def_name_span) = match call.kind() {
+            CallKind::Task => {
+                let task = source_doc
+                    .root()
+                    .children::<TaskDefinition>()
+                    .find(|task| task.name().text() == call.name())
+                    .expect("should exist");
+                (SymbolKind::METHOD, task.name().span())
+            }
+            CallKind::Workflow => {
+                let workflow = source_doc
+                    .root()
+                    .children::<WorkflowDefinition>()
+                    .find(|workflow| workflow.name().text() == call.name())
+                    .expect("should exist");
+                (SymbolKind::FUNCTION, workflow.name().span())
+            }
+        };
+
+        let to_selection_range =
+            location_from_span(source_doc.uri(), def_name_span, &source_lines)?.range;
+
+        match calls.entry(((**source_doc.uri()).clone(), call.name().to_string())) {
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().1.push(from_range);
+            }
+            Entry::Vacant(entry) => {
+                entry.insert((
+                    CallHierarchyItem {
+                        name: call.name().to_string(),
+                        kind,
+                        tags: None,
+                        detail: None,
+                        uri: (**source_doc.uri()).clone(),
+                        range: to_selection_range,
+                        selection_range: to_selection_range,
+                        data: None,
+                    },
+                    vec![from_range],
+                ));
+            }
+        }
+    }
+
+    Ok(Some(
+        calls
+            .into_values()
+            .map(|(to, from_ranges)| CallHierarchyOutgoingCall { to, from_ranges })
+            .collect(),
+    ))
+}

--- a/crates/wdl-analysis/src/handlers/call_hierarchy.rs
+++ b/crates/wdl-analysis/src/handlers/call_hierarchy.rs
@@ -16,13 +16,10 @@ use line_index::LineIndex;
 use lsp_types::CallHierarchyIncomingCall;
 use lsp_types::CallHierarchyItem;
 use lsp_types::CallHierarchyOutgoingCall;
+use lsp_types::Location;
 use lsp_types::Range;
 use lsp_types::SymbolKind;
 use url::Url;
-use wdl_ast::AstNode;
-use wdl_ast::AstToken;
-use wdl_ast::v1::TaskDefinition;
-use wdl_ast::v1::WorkflowDefinition;
 use wdl_grammar::Span;
 use wdl_grammar::SyntaxNode;
 
@@ -33,14 +30,15 @@ use crate::document::Task;
 use crate::document::Workflow;
 use crate::graph::DocumentGraph;
 use crate::graph::ParseState;
-use crate::handlers::EnclosingScopeKind;
 use crate::handlers::common::find_identifier_token_at_offset;
 use crate::handlers::common::location_from_span;
 use crate::handlers::common::position_to_offset;
 use crate::handlers::find_all_references;
+use crate::handlers::goto_definition;
 use crate::types::CallKind;
 
 /// A callable item.
+#[derive(Debug)]
 enum Callable<'a> {
     /// A workflow.
     Workflow(&'a Workflow),
@@ -65,6 +63,14 @@ impl Callable<'_> {
         }
     }
 
+    /// Get the [`Span`] of the callable's full definition.
+    fn span(&self) -> Span {
+        match self {
+            Callable::Workflow(w) => w.span(),
+            Callable::Task(t) => t.span(),
+        }
+    }
+
     /// Get the [`SymbolKind`] for this callable.
     fn symbol_kind(&self) -> SymbolKind {
         match self {
@@ -79,7 +85,9 @@ impl Callable<'_> {
         analysis_doc: &Document,
         lines: &LineIndex,
     ) -> Result<CallHierarchyItem> {
-        let name_range = location_from_span(analysis_doc.uri(), self.name_span(), lines)?.range;
+        let range = location_from_span(analysis_doc.uri(), self.span(), lines)?.range;
+        let selection_range =
+            location_from_span(analysis_doc.uri(), self.name_span(), lines)?.range;
 
         Ok(CallHierarchyItem {
             name: self.name().to_string(),
@@ -87,8 +95,8 @@ impl Callable<'_> {
             tags: None,
             detail: None,
             uri: (**analysis_doc.uri()).clone(),
-            range: name_range,
-            selection_range: name_range,
+            range,
+            selection_range,
             data: None,
         })
     }
@@ -114,7 +122,7 @@ fn find_callable_at_position<'a>(
     };
 
     let Some(analysis_doc) = node.document() else {
-        bail!("document analysis data not available for {}", document_uri);
+        bail!("document analysis data not available for {document_uri}");
     };
 
     let offset = position_to_offset(&lines, position, encoding)?;
@@ -122,8 +130,23 @@ fn find_callable_at_position<'a>(
         return Ok(None);
     };
 
+    let Some(definition) = goto_definition(graph, analysis_doc.uri(), position, encoding)? else {
+        return Ok(None);
+    };
+
+    let definition_offset: u32 = position_to_offset(
+        &lines,
+        SourcePosition::new(
+            definition.range.start.line,
+            definition.range.start.character,
+        ),
+        encoding,
+    )?
+    .into();
+
     if let Some(workflow) = analysis_doc.workflow()
         && workflow.name() == token.text()
+        && workflow.name_span().contains(definition_offset as usize)
     {
         return Ok(Some((
             analysis_doc.clone(),
@@ -132,7 +155,9 @@ fn find_callable_at_position<'a>(
         )));
     }
 
-    if let Some(task) = analysis_doc.task_by_name(token.text()) {
+    if let Some(task) = analysis_doc.task_by_name(token.text())
+        && task.name_span().contains(definition_offset as usize)
+    {
         return Ok(Some((analysis_doc.clone(), lines, Callable::Task(task))));
     }
 
@@ -161,6 +186,67 @@ pub fn call_hierarchy(
     ]))
 }
 
+/// The enclosing scope of a reference site.
+#[derive(Clone, Debug)]
+struct EnclosingScope {
+    /// The kind of the enclosing scope.
+    pub kind: EnclosingScopeKind,
+    /// The name of the enclosing task or workflow.
+    pub name: String,
+    /// The location of the enclosing scope's name declaration.
+    pub location: Location,
+    /// The full range of the enclosing scope.
+    pub range: Range,
+}
+
+/// Represents the kind of an enclosing scope.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum EnclosingScopeKind {
+    /// The reference is inside a task.
+    Task,
+    /// The reference is inside a workflow.
+    Workflow,
+}
+
+/// Resolves the enclosing task or workflow scope.
+fn resolve_enclosing_scope(
+    document: &Document,
+    offset: usize,
+    lines: &LineIndex,
+) -> Option<EnclosingScope> {
+    if let Some(workflow) = document.workflow()
+        && workflow.scope().span().contains(offset)
+    {
+        let location = location_from_span(document.uri(), workflow.name_span(), lines).ok()?;
+        let range = location_from_span(document.uri(), workflow.span(), lines)
+            .ok()?
+            .range;
+        return Some(EnclosingScope {
+            kind: EnclosingScopeKind::Workflow,
+            name: workflow.name().to_string(),
+            location,
+            range,
+        });
+    }
+
+    for task in document.tasks() {
+        if task.scope().span().contains(offset) {
+            let location = location_from_span(document.uri(), task.name_span(), lines).ok()?;
+            let range = location_from_span(document.uri(), task.span(), lines)
+                .ok()?
+                .range;
+            return Some(EnclosingScope {
+                kind: EnclosingScopeKind::Task,
+                name: task.name().to_string(),
+                location,
+                range,
+            });
+        }
+    }
+
+    None
+}
+
 /// Determines all incoming calls for the given symbol.
 ///
 /// Implementation of [`callHierarchy/incomingCalls`]
@@ -168,60 +254,86 @@ pub fn call_hierarchy(
 /// [`callHierarchy/incomingCalls`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchy_incomingCalls
 pub fn incoming_calls(
     graph: &DocumentGraph,
-    document_uri: Url,
+    document_uri: &Url,
     position: SourcePosition,
     encoding: SourcePositionEncoding,
 ) -> Result<Option<Vec<CallHierarchyIncomingCall>>> {
     let Some((analysis_doc, _, callable)) =
-        find_callable_at_position(graph, &document_uri, position, encoding)?
+        find_callable_at_position(graph, document_uri, position, encoding)?
     else {
         return Ok(None);
     };
 
-    let target_name = match &callable {
-        Callable::Workflow(workflow) => workflow.name().to_string(),
-        Callable::Task(task) => task.name().to_string(),
-    };
+    let target_name = callable.name().to_string();
 
-    let references = find_all_references(graph, document_uri, position, encoding, false)?;
-    if references.references.is_empty() {
+    let locations = find_all_references(graph, document_uri, position, encoding, false)?;
+    if locations.is_empty() {
         return Ok(Some(Vec::new()));
+    }
+
+    let mut locations_by_uri: HashMap<Url, Vec<Range>> = HashMap::new();
+    for location in locations {
+        locations_by_uri
+            .entry(location.uri)
+            .or_default()
+            .push(location.range);
     }
 
     let mut calls: HashMap<(Url, String), (CallHierarchyItem, Vec<Range>)> = HashMap::new();
 
-    for reference in references.references {
-        let Some(scope) = reference.enclosing_scope else {
+    for (uri, ranges) in locations_by_uri {
+        let Some(node) = graph.get_index(&uri).map(|index| graph.get(index)) else {
             continue;
         };
 
-        if scope.name == target_name && scope.location.uri == **analysis_doc.uri() {
-            continue;
-        }
-
-        let kind = match scope.kind {
-            EnclosingScopeKind::Task => SymbolKind::METHOD,
-            EnclosingScopeKind::Workflow => SymbolKind::FUNCTION,
+        let lines = match node.parse_state() {
+            ParseState::Parsed { lines, .. } => lines.clone(),
+            _ => bail!("document `{uri}` has not been parsed"),
         };
 
-        match calls.entry((scope.location.uri.clone(), scope.name.clone())) {
-            Entry::Occupied(mut entry) => {
-                entry.get_mut().1.push(reference.location.range);
+        let Some(doc) = node.document() else {
+            bail!("document analysis data not available for {uri}");
+        };
+
+        for range in ranges {
+            let token_offset: u32 = position_to_offset(
+                &lines,
+                SourcePosition::new(range.start.line, range.start.character),
+                encoding,
+            )?
+            .into();
+            let Some(scope) = resolve_enclosing_scope(doc, token_offset as usize, &lines) else {
+                continue;
+            };
+
+            if scope.name == target_name && scope.location.uri == **analysis_doc.uri() {
+                continue;
             }
-            Entry::Vacant(entry) => {
-                entry.insert((
-                    CallHierarchyItem {
-                        name: scope.name,
-                        kind,
-                        tags: None,
-                        detail: None,
-                        uri: scope.location.uri,
-                        range: scope.location.range,
-                        selection_range: scope.location.range,
-                        data: None,
-                    },
-                    vec![reference.location.range],
-                ));
+
+            let kind = match scope.kind {
+                EnclosingScopeKind::Task => SymbolKind::METHOD,
+                EnclosingScopeKind::Workflow => SymbolKind::FUNCTION,
+            };
+
+            match calls.entry((scope.location.uri.clone(), scope.name.clone())) {
+                Entry::Occupied(mut entry) => {
+                    entry.get_mut().1.push(range);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert((
+                        CallHierarchyItem {
+                            name: scope.name,
+                            kind,
+                            tags: None,
+                            detail: None,
+                            uri: scope.location.uri,
+                            range: scope.range,
+                            selection_range: scope.location.range,
+                            data: None,
+                        },
+                        vec![range],
+                    ));
+                }
             }
         }
     }
@@ -241,12 +353,12 @@ pub fn incoming_calls(
 /// [`callHierarchy/outgoingCalls`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#callHierarchy_outgoingCalls
 pub fn outgoing_calls(
     graph: &DocumentGraph,
-    document_uri: Url,
+    document_uri: &Url,
     position: SourcePosition,
     encoding: SourcePositionEncoding,
 ) -> Result<Option<Vec<CallHierarchyOutgoingCall>>> {
     let Some((analysis_doc, lines, callable)) =
-        find_callable_at_position(graph, &document_uri, position, encoding)?
+        find_callable_at_position(graph, document_uri, position, encoding)?
     else {
         return Ok(None);
     };
@@ -259,15 +371,14 @@ pub fn outgoing_calls(
     let scope = workflow.scope();
 
     for (ident, call) in workflow.calls() {
-        let source_doc = call
-            .namespace()
-            .map(|ns| {
-                analysis_doc
-                    .namespace(ns)
-                    .expect("namespace should be present")
-                    .document()
-            })
-            .unwrap_or(&analysis_doc);
+        let source_doc = if let Some(ns) = call.namespace() {
+            let Some(ns) = analysis_doc.namespace(ns) else {
+                continue;
+            };
+            ns.document()
+        } else {
+            &analysis_doc
+        };
 
         let source_index = graph.get_index(source_doc.uri()).ok_or_else(|| {
             anyhow!(
@@ -288,24 +399,18 @@ pub fn outgoing_calls(
         let from_span = scope.lookup(ident).expect("should be in scope").span();
         let from_range = location_from_span(analysis_doc.uri(), from_span, &lines)?.range;
 
-        let (kind, def_name_span) = match call.kind() {
+        let (kind, def_span, def_name_span) = match call.kind() {
             CallKind::Task => {
-                let task = source_doc
-                    .root()
-                    .children::<TaskDefinition>()
-                    .find(|task| task.name().text() == call.name())
-                    .expect("should exist");
-                (SymbolKind::METHOD, task.name().span())
+                let task = source_doc.task_by_name(call.name()).expect("should exist");
+                (SymbolKind::METHOD, task.span(), task.name_span())
             }
             CallKind::Workflow => {
-                let workflow = source_doc
-                    .root()
-                    .children::<WorkflowDefinition>()
-                    .find(|workflow| workflow.name().text() == call.name())
-                    .expect("should exist");
-                (SymbolKind::FUNCTION, workflow.name().span())
+                let workflow = source_doc.workflow().expect("should exist");
+                (SymbolKind::FUNCTION, workflow.span(), workflow.name_span())
             }
         };
+
+        let to_range = location_from_span(source_doc.uri(), def_span, &source_lines)?.range;
 
         let to_selection_range =
             location_from_span(source_doc.uri(), def_name_span, &source_lines)?.range;
@@ -322,7 +427,7 @@ pub fn outgoing_calls(
                         tags: None,
                         detail: None,
                         uri: (**source_doc.uri()).clone(),
-                        range: to_selection_range,
+                        range: to_range,
                         selection_range: to_selection_range,
                         data: None,
                     },

--- a/crates/wdl-analysis/src/handlers/call_hierarchy.rs
+++ b/crates/wdl-analysis/src/handlers/call_hierarchy.rs
@@ -20,14 +20,12 @@ use lsp_types::Location;
 use lsp_types::Range;
 use lsp_types::SymbolKind;
 use url::Url;
-use wdl_grammar::Span;
 use wdl_grammar::SyntaxNode;
 
 use crate::Document;
 use crate::SourcePosition;
 use crate::SourcePositionEncoding;
-use crate::document::Task;
-use crate::document::Workflow;
+use crate::document::Callable;
 use crate::graph::DocumentGraph;
 use crate::graph::ParseState;
 use crate::handlers::common::find_identifier_token_at_offset;
@@ -35,43 +33,21 @@ use crate::handlers::common::location_from_span;
 use crate::handlers::common::position_to_offset;
 use crate::handlers::find_all_references;
 use crate::handlers::goto_definition;
-use crate::types::CallKind;
 
-/// A callable item.
-#[derive(Debug)]
-enum Callable<'a> {
-    /// A workflow.
-    Workflow(&'a Workflow),
-    /// A task.
-    Task(&'a Task),
+/// Call hierarchy-specific extensions for [`Callable`].
+trait CallableExt {
+    /// Get the [`SymbolKind`] for this callable.
+    fn symbol_kind(&self) -> SymbolKind;
+
+    /// Attempt to convert this callable to a [`CallHierarchyItem`].
+    fn as_call_hierarchy_item(
+        &self,
+        analysis_doc: &Document,
+        lines: &LineIndex,
+    ) -> Result<CallHierarchyItem>;
 }
 
-impl Callable<'_> {
-    /// Get the name of this callable.
-    fn name(&self) -> &str {
-        match self {
-            Callable::Workflow(w) => w.name(),
-            Callable::Task(t) => t.name(),
-        }
-    }
-
-    /// Get the [`Span`] of the callable's name.
-    fn name_span(&self) -> Span {
-        match self {
-            Callable::Workflow(w) => w.name_span(),
-            Callable::Task(t) => t.name_span(),
-        }
-    }
-
-    /// Get the [`Span`] of the callable's full definition.
-    fn span(&self) -> Span {
-        match self {
-            Callable::Workflow(w) => w.span(),
-            Callable::Task(t) => t.span(),
-        }
-    }
-
-    /// Get the [`SymbolKind`] for this callable.
+impl CallableExt for Callable<'_> {
     fn symbol_kind(&self) -> SymbolKind {
         match self {
             Callable::Workflow(_) => SymbolKind::FUNCTION,
@@ -79,7 +55,6 @@ impl Callable<'_> {
         }
     }
 
-    /// Attempt to convert this callable to a [`CallHierarchyItem`].
     fn as_call_hierarchy_item(
         &self,
         analysis_doc: &Document,
@@ -144,21 +119,10 @@ fn find_callable_at_position<'a>(
     )?
     .into();
 
-    if let Some(workflow) = analysis_doc.workflow()
-        && workflow.name() == token.text()
-        && workflow.name_span().contains(definition_offset as usize)
+    if let Some(callable) = analysis_doc.callable_by_name(token.text())
+        && callable.name_span().contains(definition_offset as usize)
     {
-        return Ok(Some((
-            analysis_doc.clone(),
-            lines,
-            Callable::Workflow(workflow),
-        )));
-    }
-
-    if let Some(task) = analysis_doc.task_by_name(token.text())
-        && task.name_span().contains(definition_offset as usize)
-    {
-        return Ok(Some((analysis_doc.clone(), lines, Callable::Task(task))));
+        return Ok(Some((analysis_doc.clone(), lines, callable)));
     }
 
     Ok(None)
@@ -357,7 +321,7 @@ pub fn outgoing_calls(
     position: SourcePosition,
     encoding: SourcePositionEncoding,
 ) -> Result<Option<Vec<CallHierarchyOutgoingCall>>> {
-    let Some((analysis_doc, lines, callable)) =
+    let Some((from_doc, from_doc_lines, callable)) =
         find_callable_at_position(graph, document_uri, position, encoding)?
     else {
         return Ok(None);
@@ -371,72 +335,47 @@ pub fn outgoing_calls(
     let scope = workflow.scope();
 
     for (ident, call) in workflow.calls() {
-        let source_doc = if let Some(ns) = call.namespace() {
-            let Some(ns) = analysis_doc.namespace(ns) else {
+        let to_doc = if let Some(ns) = call.namespace() {
+            let Some(ns) = from_doc.namespace(ns) else {
                 continue;
             };
             ns.document()
         } else {
-            &analysis_doc
+            &from_doc
         };
 
-        let source_index = graph.get_index(source_doc.uri()).ok_or_else(|| {
+        let source_index = graph.get_index(to_doc.uri()).ok_or_else(|| {
             anyhow!(
                 "document `{uri}` not found in graph",
-                uri = source_doc.uri()
+                uri = to_doc.uri()
             )
         })?;
 
         let source_node = graph.get(source_index);
-        let source_lines = match source_node.parse_state() {
+        let lines = match source_node.parse_state() {
             ParseState::Parsed { lines, .. } => lines.clone(),
             _ => bail!(
                 "document `{uri}` has not been parsed",
-                uri = source_doc.uri()
+                uri = to_doc.uri()
             ),
         };
 
         let Some(from_span) = scope.lookup(ident).map(|s| s.span()) else {
             continue;
         };
-        let from_range = location_from_span(analysis_doc.uri(), from_span, &lines)?.range;
+        let from_range = location_from_span(from_doc.uri(), from_span, &from_doc_lines)?.range;
 
-        let (kind, def_span, def_name_span) = match call.kind() {
-            CallKind::Task => {
-                let Some(task) = source_doc.task_by_name(call.name()) else {
-                    continue;
-                };
-                (SymbolKind::METHOD, task.span(), task.name_span())
-            }
-            CallKind::Workflow => {
-                let Some(workflow) = source_doc.workflow() else {
-                    continue;
-                };
-                (SymbolKind::FUNCTION, workflow.span(), workflow.name_span())
-            }
+        let Some(callable) = to_doc.callable_by_name(call.name()) else {
+            continue;
         };
 
-        let to_range = location_from_span(source_doc.uri(), def_span, &source_lines)?.range;
-
-        let to_selection_range =
-            location_from_span(source_doc.uri(), def_name_span, &source_lines)?.range;
-
-        match calls.entry(((**source_doc.uri()).clone(), call.name().to_string())) {
+        match calls.entry(((**to_doc.uri()).clone(), call.name().to_string())) {
             Entry::Occupied(mut entry) => {
                 entry.get_mut().1.push(from_range);
             }
             Entry::Vacant(entry) => {
                 entry.insert((
-                    CallHierarchyItem {
-                        name: call.name().to_string(),
-                        kind,
-                        tags: None,
-                        detail: None,
-                        uri: (**source_doc.uri()).clone(),
-                        range: to_range,
-                        selection_range: to_selection_range,
-                        data: None,
-                    },
+                    callable.as_call_hierarchy_item(to_doc, &lines)?,
                     vec![from_range],
                 ));
             }

--- a/crates/wdl-analysis/src/handlers/call_hierarchy.rs
+++ b/crates/wdl-analysis/src/handlers/call_hierarchy.rs
@@ -396,16 +396,22 @@ pub fn outgoing_calls(
             ),
         };
 
-        let from_span = scope.lookup(ident).expect("should be in scope").span();
+        let Some(from_span) = scope.lookup(ident).map(|s| s.span()) else {
+            continue;
+        };
         let from_range = location_from_span(analysis_doc.uri(), from_span, &lines)?.range;
 
         let (kind, def_span, def_name_span) = match call.kind() {
             CallKind::Task => {
-                let task = source_doc.task_by_name(call.name()).expect("should exist");
+                let Some(task) = source_doc.task_by_name(call.name()) else {
+                    continue;
+                };
                 (SymbolKind::METHOD, task.span(), task.name_span())
             }
             CallKind::Workflow => {
-                let workflow = source_doc.workflow().expect("should exist");
+                let Some(workflow) = source_doc.workflow() else {
+                    continue;
+                };
                 (SymbolKind::FUNCTION, workflow.span(), workflow.name_span())
             }
         };

--- a/crates/wdl-analysis/src/handlers/call_hierarchy.rs
+++ b/crates/wdl-analysis/src/handlers/call_hierarchy.rs
@@ -97,7 +97,7 @@ fn find_callable_at_position<'a>(
     };
 
     let Some(analysis_doc) = node.document() else {
-        bail!("document analysis data not available for {document_uri}");
+        bail!("document analysis data not available for `{document_uri}`");
     };
 
     let offset = position_to_offset(&lines, position, encoding)?;
@@ -256,7 +256,7 @@ pub fn incoming_calls(
         };
 
         let Some(doc) = node.document() else {
-            bail!("document analysis data not available for {uri}");
+            bail!("document analysis data not available for `{uri}`");
         };
 
         for range in ranges {

--- a/crates/wdl-analysis/src/handlers/common/position.rs
+++ b/crates/wdl-analysis/src/handlers/common/position.rs
@@ -1,7 +1,5 @@
 //! Utilities for working with positions and ranges.
 
-use std::sync::Arc;
-
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
@@ -36,7 +34,7 @@ pub fn position(index: &LineIndex, offset: TextSize) -> Result<Position> {
 }
 
 /// Converts a `Span` to an LSP location.
-pub fn location_from_span(uri: &Url, span: Span, lines: &Arc<LineIndex>) -> Result<Location> {
+pub fn location_from_span(uri: &Url, span: Span, lines: &LineIndex) -> Result<Location> {
     let start_offset = TextSize::from(span.start() as u32);
     let end_offset = TextSize::from(span.end() as u32);
     let range = lsp_types::Range {
@@ -49,7 +47,7 @@ pub fn location_from_span(uri: &Url, span: Span, lines: &Arc<LineIndex>) -> Resu
 
 /// Converts a source position to a text offset based on the specified encoding.
 pub fn position_to_offset(
-    lines: &Arc<LineIndex>,
+    lines: &LineIndex,
     position: SourcePosition,
     encoding: SourcePositionEncoding,
 ) -> Result<TextSize> {

--- a/crates/wdl-analysis/src/handlers/find_all_references.rs
+++ b/crates/wdl-analysis/src/handlers/find_all_references.rs
@@ -9,6 +9,7 @@
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use line_index::LineIndex;
 use lsp_types::Location;
 use url::Url;
 use wdl_ast::AstNode;
@@ -17,6 +18,7 @@ use wdl_ast::TreeToken;
 
 use crate::SourcePosition;
 use crate::SourcePositionEncoding;
+use crate::document::Document;
 use crate::graph::DocumentGraph;
 use crate::handlers;
 use crate::handlers::common::location_from_span;
@@ -32,6 +34,59 @@ struct TargetDefinition {
     location: Location,
 }
 
+/// The enclosing scope of a reference site.
+#[derive(Clone, Debug)]
+pub struct EnclosingScope {
+    /// The kind of the enclosing scope.
+    pub kind: EnclosingScopeKind,
+    /// The name of the enclosing task or workflow.
+    pub name: String,
+    /// The location of the enclosing scope's name declaration.
+    pub location: Location,
+}
+
+/// Represents the kind of an enclosing scope.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EnclosingScopeKind {
+    /// The reference is inside a task.
+    Task,
+    /// The reference is inside a workflow.
+    Workflow,
+}
+
+/// A reference location paired with its enclosing scope, if any.
+#[derive(Clone, Debug)]
+pub struct ReferenceWithScope {
+    /// The location of the reference.
+    pub location: Location,
+    /// The enclosing task or workflow scope that contains this reference.
+    ///
+    /// This is `None` for references at the document top-level (e.g., struct
+    /// definitions or import statements).
+    pub enclosing_scope: Option<EnclosingScope>,
+}
+
+/// The result of a find-all-references query.
+#[derive(Clone, Debug)]
+pub struct ScopedReferences {
+    /// The name of the target symbol.
+    pub target: String,
+    /// All references, each paired with their enclosing scope.
+    pub references: Vec<ReferenceWithScope>,
+}
+
+impl ScopedReferences {
+    /// Returns just the locations, discarding scope information.
+    pub fn locations(&self) -> Vec<Location> {
+        self.references.iter().map(|r| r.location.clone()).collect()
+    }
+
+    /// Whether this contains any references.
+    pub fn is_empty(&self) -> bool {
+        self.references.is_empty()
+    }
+}
+
 /// Finds all references to the identifier at the given position.
 ///
 /// It first resolves the definition of the identifier at the specified
@@ -43,7 +98,7 @@ pub fn find_all_references(
     position: SourcePosition,
     encoding: SourcePositionEncoding,
     include_declaration: bool,
-) -> Result<Vec<Location>> {
+) -> Result<ScopedReferences> {
     let definition_location = handlers::goto_definition(graph, document_uri, position, encoding)
         .context("failed to resolve symbol definition")?
         .ok_or_else(|| {
@@ -93,33 +148,69 @@ pub fn find_all_references(
     // TODO: better search scope for performance.
     let search_scope: Vec<_> = graph.transitive_dependents(doc_index).collect();
 
-    let mut locations = Vec::new();
+    let mut references = Vec::new();
     for doc_index in search_scope {
-        collect_references_from_document(graph, doc_index, &target, encoding, &mut locations)
+        collect_references_from_document(graph, doc_index, &target, encoding, &mut references)
             .with_context(|| {
                 format!("failed to collect references from document at index {doc_index:?}")
             })?;
     }
 
     if !include_declaration {
-        locations.retain(|loc| *loc != target.location);
+        references.retain(|r| r.location != target.location);
     }
 
-    Ok(locations)
+    Ok(ScopedReferences {
+        target: target.name,
+        references,
+    })
 }
 
-/// Collects references to the target symbol form a single document.
+/// Resolves the enclosing task or workflow scope.
+fn resolve_enclosing_scope(
+    document: &Document,
+    document_uri: &Url,
+    offset: usize,
+    lines: &LineIndex,
+) -> Option<EnclosingScope> {
+    if let Some(workflow) = document.workflow()
+        && workflow.scope().span().contains(offset)
+    {
+        let location = location_from_span(document_uri, workflow.name_span(), lines).ok()?;
+        return Some(EnclosingScope {
+            kind: EnclosingScopeKind::Workflow,
+            name: workflow.name().to_string(),
+            location,
+        });
+    }
+
+    for task in document.tasks() {
+        if task.scope().span().contains(offset) {
+            let location = location_from_span(document_uri, task.name_span(), lines).ok()?;
+            return Some(EnclosingScope {
+                kind: EnclosingScopeKind::Task,
+                name: task.name().to_string(),
+                location,
+            });
+        }
+    }
+
+    None
+}
+
+/// Collects references to the target symbol from a single document.
 ///
 /// 1. Traverse all tokens in the document's CST
 /// 2. Filter for identifier tokens matching the target name
 /// 3. For each match, resolve its definition using goto definition
 /// 4. If the resolved definition matches the target, add the reference location
+///    together with its enclosing scope
 fn collect_references_from_document(
     graph: &DocumentGraph,
     doc_index: petgraph::graph::NodeIndex,
     target: &TargetDefinition,
     encoding: SourcePositionEncoding,
-    locations: &mut Vec<Location>,
+    references: &mut Vec<ReferenceWithScope>,
 ) -> Result<()> {
     let node = graph.get(doc_index);
     let document = match node.document() {
@@ -133,6 +224,7 @@ fn collect_references_from_document(
     };
 
     let root = document.root().inner().clone();
+    let document_uri = document.uri().as_ref().clone();
 
     for token in root
         .descendants_with_tokens()
@@ -154,13 +246,9 @@ fn collect_references_from_document(
                 .context("failed to convert token position")?;
             let source_pos = SourcePosition::new(token_pos.line, token_pos.character);
 
-            let resolved_location = handlers::goto_definition(
-                graph,
-                document.uri().as_ref().clone(),
-                source_pos,
-                encoding,
-            )
-            .context("failed to resolve token definition")?;
+            let resolved_location =
+                handlers::goto_definition(graph, document_uri.clone(), source_pos, encoding)
+                    .context("failed to resolve token definition")?;
 
             if let Some(location) = resolved_location
                 && location == target.location
@@ -168,7 +256,14 @@ fn collect_references_from_document(
                 let reference_location = location_from_span(document.uri(), token.span(), lines)
                     .context("failed to create reference location")?;
 
-                locations.push(reference_location);
+                let token_offset = usize::from(token.text_range().start());
+                let enclosing_scope =
+                    resolve_enclosing_scope(document, &document_uri, token_offset, lines);
+
+                references.push(ReferenceWithScope {
+                    location: reference_location,
+                    enclosing_scope,
+                });
             }
         }
     }

--- a/crates/wdl-analysis/src/handlers/find_all_references.rs
+++ b/crates/wdl-analysis/src/handlers/find_all_references.rs
@@ -9,7 +9,6 @@
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
-use line_index::LineIndex;
 use lsp_types::Location;
 use url::Url;
 use wdl_ast::AstNode;
@@ -18,7 +17,6 @@ use wdl_ast::TreeToken;
 
 use crate::SourcePosition;
 use crate::SourcePositionEncoding;
-use crate::document::Document;
 use crate::graph::DocumentGraph;
 use crate::handlers;
 use crate::handlers::common::location_from_span;
@@ -34,59 +32,6 @@ struct TargetDefinition {
     location: Location,
 }
 
-/// The enclosing scope of a reference site.
-#[derive(Clone, Debug)]
-pub struct EnclosingScope {
-    /// The kind of the enclosing scope.
-    pub kind: EnclosingScopeKind,
-    /// The name of the enclosing task or workflow.
-    pub name: String,
-    /// The location of the enclosing scope's name declaration.
-    pub location: Location,
-}
-
-/// Represents the kind of an enclosing scope.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum EnclosingScopeKind {
-    /// The reference is inside a task.
-    Task,
-    /// The reference is inside a workflow.
-    Workflow,
-}
-
-/// A reference location paired with its enclosing scope, if any.
-#[derive(Clone, Debug)]
-pub struct ReferenceWithScope {
-    /// The location of the reference.
-    pub location: Location,
-    /// The enclosing task or workflow scope that contains this reference.
-    ///
-    /// This is `None` for references at the document top-level (e.g., struct
-    /// definitions or import statements).
-    pub enclosing_scope: Option<EnclosingScope>,
-}
-
-/// The result of a find-all-references query.
-#[derive(Clone, Debug)]
-pub struct ScopedReferences {
-    /// The name of the target symbol.
-    pub target: String,
-    /// All references, each paired with their enclosing scope.
-    pub references: Vec<ReferenceWithScope>,
-}
-
-impl ScopedReferences {
-    /// Returns just the locations, discarding scope information.
-    pub fn locations(&self) -> Vec<Location> {
-        self.references.iter().map(|r| r.location.clone()).collect()
-    }
-
-    /// Whether this contains any references.
-    pub fn is_empty(&self) -> bool {
-        self.references.is_empty()
-    }
-}
-
 /// Finds all references to the identifier at the given position.
 ///
 /// It first resolves the definition of the identifier at the specified
@@ -94,11 +39,11 @@ impl ScopedReferences {
 /// documents to find all references to that definition.
 pub fn find_all_references(
     graph: &DocumentGraph,
-    document_uri: Url,
+    document_uri: &Url,
     position: SourcePosition,
     encoding: SourcePositionEncoding,
     include_declaration: bool,
-) -> Result<ScopedReferences> {
+) -> Result<Vec<Location>> {
     let definition_location = handlers::goto_definition(graph, document_uri, position, encoding)
         .context("failed to resolve symbol definition")?
         .ok_or_else(|| {
@@ -148,54 +93,19 @@ pub fn find_all_references(
     // TODO: better search scope for performance.
     let search_scope: Vec<_> = graph.transitive_dependents(doc_index).collect();
 
-    let mut references = Vec::new();
+    let mut locations = Vec::new();
     for doc_index in search_scope {
-        collect_references_from_document(graph, doc_index, &target, encoding, &mut references)
+        collect_references_from_document(graph, doc_index, &target, encoding, &mut locations)
             .with_context(|| {
                 format!("failed to collect references from document at index {doc_index:?}")
             })?;
     }
 
     if !include_declaration {
-        references.retain(|r| r.location != target.location);
+        locations.retain(|loc| *loc != target.location);
     }
 
-    Ok(ScopedReferences {
-        target: target.name,
-        references,
-    })
-}
-
-/// Resolves the enclosing task or workflow scope.
-fn resolve_enclosing_scope(
-    document: &Document,
-    document_uri: &Url,
-    offset: usize,
-    lines: &LineIndex,
-) -> Option<EnclosingScope> {
-    if let Some(workflow) = document.workflow()
-        && workflow.scope().span().contains(offset)
-    {
-        let location = location_from_span(document_uri, workflow.name_span(), lines).ok()?;
-        return Some(EnclosingScope {
-            kind: EnclosingScopeKind::Workflow,
-            name: workflow.name().to_string(),
-            location,
-        });
-    }
-
-    for task in document.tasks() {
-        if task.scope().span().contains(offset) {
-            let location = location_from_span(document_uri, task.name_span(), lines).ok()?;
-            return Some(EnclosingScope {
-                kind: EnclosingScopeKind::Task,
-                name: task.name().to_string(),
-                location,
-            });
-        }
-    }
-
-    None
+    Ok(locations)
 }
 
 /// Collects references to the target symbol from a single document.
@@ -204,13 +114,12 @@ fn resolve_enclosing_scope(
 /// 2. Filter for identifier tokens matching the target name
 /// 3. For each match, resolve its definition using goto definition
 /// 4. If the resolved definition matches the target, add the reference location
-///    together with its enclosing scope
 fn collect_references_from_document(
     graph: &DocumentGraph,
     doc_index: petgraph::graph::NodeIndex,
     target: &TargetDefinition,
     encoding: SourcePositionEncoding,
-    references: &mut Vec<ReferenceWithScope>,
+    locations: &mut Vec<Location>,
 ) -> Result<()> {
     let node = graph.get(doc_index);
     let document = match node.document() {
@@ -224,7 +133,6 @@ fn collect_references_from_document(
     };
 
     let root = document.root().inner().clone();
-    let document_uri = document.uri().as_ref().clone();
 
     for token in root
         .descendants_with_tokens()
@@ -247,7 +155,7 @@ fn collect_references_from_document(
             let source_pos = SourcePosition::new(token_pos.line, token_pos.character);
 
             let resolved_location =
-                handlers::goto_definition(graph, document_uri.clone(), source_pos, encoding)
+                handlers::goto_definition(graph, document.uri(), source_pos, encoding)
                     .context("failed to resolve token definition")?;
 
             if let Some(location) = resolved_location
@@ -256,14 +164,7 @@ fn collect_references_from_document(
                 let reference_location = location_from_span(document.uri(), token.span(), lines)
                     .context("failed to create reference location")?;
 
-                let token_offset = usize::from(token.text_range().start());
-                let enclosing_scope =
-                    resolve_enclosing_scope(document, &document_uri, token_offset, lines);
-
-                references.push(ReferenceWithScope {
-                    location: reference_location,
-                    enclosing_scope,
-                });
+                locations.push(reference_location);
             }
         }
     }

--- a/crates/wdl-analysis/src/handlers/goto_definition.rs
+++ b/crates/wdl-analysis/src/handlers/goto_definition.rs
@@ -57,24 +57,24 @@ use crate::types::v1::ExprTypeEvaluator;
 /// * Else, [`None`] is returned.
 pub fn goto_definition(
     graph: &DocumentGraph,
-    document_uri: Url,
+    document_uri: &Url,
     position: SourcePosition,
     encoding: SourcePositionEncoding,
 ) -> Result<Option<Location>> {
     let index = graph
-        .get_index(&document_uri)
-        .ok_or_else(|| anyhow!("document `{uri}` not found in graph", uri = document_uri))?;
+        .get_index(document_uri)
+        .ok_or_else(|| anyhow!("document `{document_uri}` not found in graph"))?;
 
     let node = graph.get(index);
     let (root, lines) = match node.parse_state() {
         ParseState::Parsed { lines, root, .. } => {
             (SyntaxNode::new_root(root.clone()), lines.clone())
         }
-        _ => bail!("document `{uri}` has not been parsed", uri = document_uri),
+        _ => bail!("document `{document_uri}` has not been parsed"),
     };
 
     let Some(analysis_doc) = node.document() else {
-        bail!("document analysis data not available for {}", document_uri);
+        bail!("document analysis data not available for {document_uri}");
     };
 
     let offset = position_to_offset(&lines, position, encoding)?;
@@ -90,7 +90,7 @@ pub fn goto_definition(
         &parent_node,
         &token,
         analysis_doc,
-        &document_uri,
+        document_uri,
         &lines,
         graph,
     )? {
@@ -121,7 +121,7 @@ pub fn goto_definition(
                     target.inner(),
                     callee_name.inner(),
                     analysis_doc,
-                    &document_uri,
+                    document_uri,
                     &lines,
                     graph,
                 );
@@ -129,14 +129,14 @@ pub fn goto_definition(
         }
 
         return Ok(Some(location_from_span(
-            &document_uri,
+            document_uri,
             name_def.span(),
             &lines,
         )?));
     }
 
     // Global resolution
-    resolve_global_identifier(analysis_doc, ident_text, &document_uri, &lines, graph)
+    resolve_global_identifier(analysis_doc, ident_text, document_uri, &lines, graph)
 }
 
 /// Resolves identifier definition based on their parent node's syntax kind.

--- a/crates/wdl-analysis/src/handlers/rename.rs
+++ b/crates/wdl-analysis/src/handlers/rename.rs
@@ -37,13 +37,13 @@ pub fn rename(
         bail!("name `{new_name}` is not a valid WDL identifier");
     }
 
-    let locations = handlers::find_all_references(graph, document_uri, position, encoding, true)?;
-    if locations.is_empty() {
+    let references = handlers::find_all_references(graph, document_uri, position, encoding, true)?;
+    if references.is_empty() {
         return Ok(None);
     }
 
     let mut changes: HashMap<Url, Vec<TextEdit>> = HashMap::new();
-    for location in locations {
+    for location in references.locations() {
         let text_edit = TextEdit {
             range: location.range,
             new_text: new_name.clone(),

--- a/crates/wdl-analysis/src/handlers/rename.rs
+++ b/crates/wdl-analysis/src/handlers/rename.rs
@@ -28,7 +28,7 @@ use crate::handlers;
 /// The rename is rejected if the new name is not a valid WDL identifier.
 pub fn rename(
     graph: &DocumentGraph,
-    document_uri: Url,
+    document_uri: &Url,
     position: SourcePosition,
     encoding: SourcePositionEncoding,
     new_name: String,
@@ -43,7 +43,7 @@ pub fn rename(
     }
 
     let mut changes: HashMap<Url, Vec<TextEdit>> = HashMap::new();
-    for location in references.locations() {
+    for location in references {
         let text_edit = TextEdit {
             range: location.range,
             new_text: new_name.clone(),

--- a/crates/wdl-analysis/src/handlers/signature_help.rs
+++ b/crates/wdl-analysis/src/handlers/signature_help.rs
@@ -146,7 +146,12 @@ pub fn signature_help(
 
             SignatureInformation {
                 label,
-                documentation: None,
+                documentation: s.definition().map(|def| {
+                    Documentation::MarkupContent(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: def.to_string(),
+                    })
+                }),
                 parameters: Some(parameters),
                 active_parameter: Some(active_parameter),
             }

--- a/crates/wdl-analysis/src/queue.rs
+++ b/crates/wdl-analysis/src/queue.rs
@@ -14,6 +14,9 @@ use futures::Future;
 use futures::StreamExt;
 use futures::stream::FuturesUnordered;
 use indexmap::IndexSet;
+use lsp_types::CallHierarchyIncomingCall;
+use lsp_types::CallHierarchyItem;
+use lsp_types::CallHierarchyOutgoingCall;
 use lsp_types::CompletionResponse;
 use lsp_types::DocumentSymbolResponse;
 use lsp_types::GotoDefinitionResponse;
@@ -64,6 +67,8 @@ pub enum Request<Context> {
     Add(AddRequest),
     /// A request to analyze documents.
     Analyze(AnalyzeRequest<Context>),
+    /// A request to get all callers of a symbol.
+    CallHierarchy(CallHierarchyRequest),
     /// A request to remove documents from the graph.
     Remove(RemoveRequest),
     /// A request to process a document's incremental change.
@@ -88,6 +93,10 @@ pub enum Request<Context> {
     DocumentSymbol(DocumentSymbolRequest),
     /// A request to get symbols for the workspace.
     WorkspaceSymbol(WorkspaceSymbolRequest),
+    /// A request to get all incoming calls from a symbol.
+    IncomingCalls(IncomingCallsRequest),
+    /// A request to get all outgoing calls from a symbol.
+    OutgoingCalls(OutgoingCallsRequest),
     /// A request to get signature help.
     SignatureHelp(SignatureHelpRequest),
     /// A request to get inlay hints for a document.
@@ -112,6 +121,18 @@ pub struct AnalyzeRequest<Context> {
     pub context: Context,
     /// The sender for completing the request.
     pub completed: oneshot::Sender<Result<Vec<AnalysisResult>>>,
+}
+
+/// Represents a request to get the call hierarchy for a symbol.
+pub struct CallHierarchyRequest {
+    /// The document to search for the symbol definition.
+    pub document: Url,
+    /// The position of the symbol in the document.
+    pub position: SourcePosition,
+    /// The encoding used for the position.
+    pub encoding: SourcePositionEncoding,
+    /// The sender for completing the request.
+    pub completed: oneshot::Sender<Option<Vec<CallHierarchyItem>>>,
 }
 
 /// Represents a request to remove documents from the document graph.
@@ -242,6 +263,30 @@ pub struct WorkspaceSymbolRequest {
     pub completed: oneshot::Sender<Option<Vec<SymbolInformation>>>,
 }
 
+/// Represents a request to get the incoming calls for a symbol.
+pub struct IncomingCallsRequest {
+    /// The document to search for the symbol definition.
+    pub document: Url,
+    /// The position of the symbol in the document.
+    pub position: SourcePosition,
+    /// The encoding used for the position.
+    pub encoding: SourcePositionEncoding,
+    /// The sender for completing the request.
+    pub completed: oneshot::Sender<Option<Vec<CallHierarchyIncomingCall>>>,
+}
+
+/// Represents a request to get the outgoing calls for a symbol.
+pub struct OutgoingCallsRequest {
+    /// The document to search for the symbol definition.
+    pub document: Url,
+    /// The position of the symbol in the document.
+    pub position: SourcePosition,
+    /// The encoding used for the position.
+    pub encoding: SourcePositionEncoding,
+    /// The sender for completing the request.
+    pub completed: oneshot::Sender<Option<Vec<CallHierarchyOutgoingCall>>>,
+}
+
 /// Represents a request for signature help.
 pub struct SignatureHelpRequest {
     /// The document where the request was initiated.
@@ -361,6 +406,38 @@ where
                                 "request to analyze documents was canceled after {elapsed:?}",
                                 elapsed = start.elapsed()
                             );
+                        }
+                    }
+                }
+                Request::CallHierarchy(CallHierarchyRequest {
+                    document,
+                    position,
+                    encoding,
+                    completed,
+                }) => {
+                    let start = Instant::now();
+                    debug!(
+                        "received request for call hierarchy at {document}: {line}:{char}",
+                        line = position.line,
+                        char = position.character
+                    );
+
+                    let graph = self.graph.read();
+                    match handlers::call_hierarchy(&graph, document, position, encoding) {
+                        Ok(result) => {
+                            debug!(
+                                "call hierarchy request completed in {elapsed:?}",
+                                elapsed = start.elapsed()
+                            );
+
+                            completed.send(result).ok();
+                        }
+                        Err(err) => {
+                            error!(
+                                "error occurred while completing the call hierarchy request: \
+                                 {err:?}"
+                            );
+                            completed.send(None).ok();
                         }
                     }
                 }
@@ -514,7 +591,7 @@ where
                                 elapsed = start.elapsed()
                             );
 
-                            completed.send(result).ok();
+                            completed.send(result.locations()).ok();
                         }
                         Err(err) => {
                             error!("find all references request failed: {err:?}");
@@ -719,6 +796,70 @@ where
                         }
                         Err(err) => {
                             error!("workspace symbol request failed: {err:?}");
+                            completed.send(None).ok();
+                        }
+                    }
+                }
+                Request::IncomingCalls(IncomingCallsRequest {
+                    document,
+                    position,
+                    encoding,
+                    completed,
+                }) => {
+                    let start = Instant::now();
+                    debug!(
+                        "received request for incoming calls at {document}: {line}:{char}",
+                        line = position.line,
+                        char = position.character
+                    );
+
+                    let graph = self.graph.read();
+                    match handlers::incoming_calls(&graph, document, position, encoding) {
+                        Ok(result) => {
+                            debug!(
+                                "incoming calls request completed in {elapsed:?}",
+                                elapsed = start.elapsed()
+                            );
+
+                            completed.send(result).ok();
+                        }
+                        Err(err) => {
+                            error!(
+                                "error occurred while completing the incoming calls request: \
+                                 {err:?}"
+                            );
+                            completed.send(None).ok();
+                        }
+                    }
+                }
+                Request::OutgoingCalls(OutgoingCallsRequest {
+                    document,
+                    position,
+                    encoding,
+                    completed,
+                }) => {
+                    let start = Instant::now();
+                    debug!(
+                        "received request for outgoing calls at {document}: {line}:{char}",
+                        line = position.line,
+                        char = position.character
+                    );
+
+                    let graph = self.graph.read();
+                    match handlers::outgoing_calls(&graph, document, position, encoding) {
+                        Ok(result) => {
+                            debug!(
+                                "outgoing calls request completed in {elapsed:?}",
+                                elapsed = start.elapsed()
+                            );
+
+                            completed.send(result).ok();
+                        }
+                        Err(err) => {
+                            error!(
+                                "error occurred while completing the outgoing calls request: \
+                                 {err:?}"
+                            );
                             completed.send(None).ok();
                         }
                     }

--- a/crates/wdl-analysis/src/queue.rs
+++ b/crates/wdl-analysis/src/queue.rs
@@ -544,7 +544,7 @@ where
                     );
 
                     let graph = self.graph.read();
-                    match handlers::goto_definition(&graph, document, position, encoding) {
+                    match handlers::goto_definition(&graph, &document, position, encoding) {
                         Ok(result) => {
                             debug!(
                                 "goto definition request completed in {elapsed:?}",
@@ -580,7 +580,7 @@ where
                     let graph = self.graph.read();
                     match handlers::find_all_references(
                         &graph,
-                        document,
+                        &document,
                         position,
                         encoding,
                         include_declaration,
@@ -591,7 +591,7 @@ where
                                 elapsed = start.elapsed()
                             );
 
-                            completed.send(result.locations()).ok();
+                            completed.send(result).ok();
                         }
                         Err(err) => {
                             error!("find all references request failed: {err:?}");
@@ -685,7 +685,7 @@ where
                     );
 
                     let graph = self.graph.read();
-                    match handlers::rename(&graph, document, position, encoding, new_name) {
+                    match handlers::rename(&graph, &document, position, encoding, new_name) {
                         Ok(result) => {
                             debug!(
                                 "rename request completed in {elapsed:?}",
@@ -814,7 +814,7 @@ where
                     );
 
                     let graph = self.graph.read();
-                    match handlers::incoming_calls(&graph, document, position, encoding) {
+                    match handlers::incoming_calls(&graph, &document, position, encoding) {
                         Ok(result) => {
                             debug!(
                                 "incoming calls request completed in {elapsed:?}",
@@ -846,7 +846,7 @@ where
                     );
 
                     let graph = self.graph.read();
-                    match handlers::outgoing_calls(&graph, document, position, encoding) {
+                    match handlers::outgoing_calls(&graph, &document, position, encoding) {
                         Ok(result) => {
                             debug!(
                                 "outgoing calls request completed in {elapsed:?}",

--- a/crates/wdl-lsp/CHANGELOG.md
+++ b/crates/wdl-lsp/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added support for the `textDocument/prepareCallHierarchy`, `callHierarchy/incomingCalls`, and
+  `callHierarchy/outgoingCalls` requests ([#874](https://github.com/stjude-rust-labs/sprocket/pull/874)).
+
 ## 0.19.1 - 2026-05-14
 
 ## 0.19.0 - 2026-04-22

--- a/crates/wdl-lsp/src/server.rs
+++ b/crates/wdl-lsp/src/server.rs
@@ -631,6 +631,7 @@ impl<S: 'static> LanguageServer for Server<S> {
                     },
                 }),
                 inlay_hint_provider: Some(OneOf::Left(true)),
+                call_hierarchy_provider: Some(CallHierarchyServerCapability::Simple(true)),
                 ..Default::default()
             },
             server_info: Some(self.info().await),
@@ -979,6 +980,94 @@ impl<S: 'static> LanguageServer for Server<S> {
                     new_text: formatted,
                 }]
             });
+
+        Ok(result)
+    }
+
+    async fn prepare_call_hierarchy(
+        &self,
+        mut params: CallHierarchyPrepareParams,
+    ) -> RpcResult<Option<Vec<CallHierarchyItem>>> {
+        let config = self.config.read().await;
+
+        normalize_uri_path(&mut params.text_document_position_params.text_document.uri);
+
+        debug!("received `textDocument/prepareCallHierarchy` request: {params:#?}");
+
+        let position = SourcePosition::new(
+            params.text_document_position_params.position.line,
+            params.text_document_position_params.position.character,
+        );
+
+        let result = config
+            .analyzer
+            .call_hierarchy(
+                params.text_document_position_params.text_document.uri,
+                position,
+                SourcePositionEncoding::UTF16,
+            )
+            .await
+            .map_err(|e| RpcError {
+                code: ErrorCode::InternalError,
+                message: e.to_string().into(),
+                data: None,
+            })?;
+
+        Ok(result)
+    }
+
+    async fn incoming_calls(
+        &self,
+        mut params: CallHierarchyIncomingCallsParams,
+    ) -> RpcResult<Option<Vec<CallHierarchyIncomingCall>>> {
+        let config = self.config.read().await;
+
+        normalize_uri_path(&mut params.item.uri);
+
+        debug!("received `callHierarchy/incomingCalls` request: {params:#?}");
+
+        let position = SourcePosition::new(
+            params.item.selection_range.start.line,
+            params.item.selection_range.start.character,
+        );
+
+        let result = config
+            .analyzer
+            .incoming_calls(params.item.uri, position, SourcePositionEncoding::UTF16)
+            .await
+            .map_err(|e| RpcError {
+                code: ErrorCode::InternalError,
+                message: e.to_string().into(),
+                data: None,
+            })?;
+
+        Ok(result)
+    }
+
+    async fn outgoing_calls(
+        &self,
+        mut params: CallHierarchyOutgoingCallsParams,
+    ) -> RpcResult<Option<Vec<CallHierarchyOutgoingCall>>> {
+        let config = self.config.read().await;
+
+        normalize_uri_path(&mut params.item.uri);
+
+        debug!("received `callHierarchy/outgoingCalls` request: {params:#?}");
+
+        let position = SourcePosition::new(
+            params.item.selection_range.start.line,
+            params.item.selection_range.start.character,
+        );
+
+        let result = config
+            .analyzer
+            .outgoing_calls(params.item.uri, position, SourcePositionEncoding::UTF16)
+            .await
+            .map_err(|e| RpcError {
+                code: ErrorCode::InternalError,
+                message: e.to_string().into(),
+                data: None,
+            })?;
 
         Ok(result)
     }

--- a/crates/wdl-lsp/tests/call_hierarchy.rs
+++ b/crates/wdl-lsp/tests/call_hierarchy.rs
@@ -121,13 +121,13 @@ fn verify_call_hierarchy(
         if let Some(index) = matched {
             expected.remove(index);
         } else {
-            panic!("Unexpected call hierarchy item returned: {item:?}");
+            panic!("unexpected call hierarchy item returned: {item:?}");
         }
     }
 
     assert!(
         expected.is_empty(),
-        "Some expected items were not returned: {expected:?}"
+        "some expected items were not returned: {expected:?}"
     );
 }
 
@@ -154,13 +154,13 @@ fn verify_outgoing_calls(
         if let Some(index) = matched {
             expected.remove(index);
         } else {
-            panic!("Unexpected outgoing call returned: {call:?}");
+            panic!("unexpected outgoing call returned: {call:?}");
         }
     }
 
     assert!(
         expected.is_empty(),
-        "Some expected items were not returned: {expected:?}"
+        "some expected items were not returned: {expected:?}"
     );
 }
 
@@ -182,13 +182,13 @@ fn verify_incoming_calls(
         if let Some(index) = matched {
             expected.remove(index);
         } else {
-            panic!("Unexpected incoming call returned: {call:?}");
+            panic!("unexpected incoming call returned: {call:?}");
         }
     }
 
     assert!(
         expected.is_empty(),
-        "Some expected items were not returned: {expected:?}"
+        "some expected items were not returned: {expected:?}"
     );
 }
 
@@ -307,7 +307,7 @@ async fn should_determine_incoming_calls() {
     let item = hierarchy.remove(0);
     let incoming_calls = incoming_calls_request(&mut ctx, item)
         .await
-        .expect("should return outgoing calls");
+        .expect("should return incoming calls");
 
     verify_incoming_calls(
         vec![

--- a/crates/wdl-lsp/tests/call_hierarchy.rs
+++ b/crates/wdl-lsp/tests/call_hierarchy.rs
@@ -1,0 +1,331 @@
+//! Integration tests for call hierarchy requests.
+
+use tower_lsp::lsp_types::CallHierarchyIncomingCall;
+use tower_lsp::lsp_types::CallHierarchyIncomingCallsParams;
+use tower_lsp::lsp_types::CallHierarchyItem;
+use tower_lsp::lsp_types::CallHierarchyOutgoingCall;
+use tower_lsp::lsp_types::CallHierarchyOutgoingCallsParams;
+use tower_lsp::lsp_types::CallHierarchyPrepareParams;
+use tower_lsp::lsp_types::Position;
+use tower_lsp::lsp_types::Range;
+use tower_lsp::lsp_types::SymbolKind;
+use tower_lsp::lsp_types::TextDocumentIdentifier;
+use tower_lsp::lsp_types::TextDocumentPositionParams;
+use tower_lsp::lsp_types::request::CallHierarchyIncomingCalls;
+use tower_lsp::lsp_types::request::CallHierarchyOutgoingCalls;
+use tower_lsp::lsp_types::request::CallHierarchyPrepare;
+
+use crate::common::TestContext;
+
+mod common;
+
+// textDocument/prepareCallHierarchy
+async fn call_hierarchy_request(
+    ctx: &mut TestContext,
+    path: &str,
+    position: Position,
+) -> Option<Vec<CallHierarchyItem>> {
+    ctx.request::<CallHierarchyPrepare>(CallHierarchyPrepareParams {
+        text_document_position_params: TextDocumentPositionParams {
+            text_document: TextDocumentIdentifier {
+                uri: ctx.doc_uri(path),
+            },
+            position,
+        },
+        work_done_progress_params: Default::default(),
+    })
+    .await
+}
+
+// callHierarchy/incomingCalls
+async fn incoming_calls_request(
+    ctx: &mut TestContext,
+    item: CallHierarchyItem,
+) -> Option<Vec<CallHierarchyIncomingCall>> {
+    ctx.request::<CallHierarchyIncomingCalls>(CallHierarchyIncomingCallsParams {
+        item,
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    })
+    .await
+}
+
+// callHierarchy/outgoingCalls
+async fn outgoing_calls_request(
+    ctx: &mut TestContext,
+    item: CallHierarchyItem,
+) -> Option<Vec<CallHierarchyOutgoingCall>> {
+    ctx.request::<CallHierarchyOutgoingCalls>(CallHierarchyOutgoingCallsParams {
+        item,
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    })
+    .await
+}
+
+async fn setup() -> TestContext {
+    let mut ctx = TestContext::new("call_hierarchy");
+    ctx.initialize().await;
+    ctx
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ExpectedCallHierarchyItem {
+    name: String,
+    kind: SymbolKind,
+}
+
+impl ExpectedCallHierarchyItem {
+    fn first() -> Self {
+        ExpectedCallHierarchyItem {
+            name: String::from("first"),
+            kind: SymbolKind::METHOD,
+        }
+    }
+
+    fn second() -> Self {
+        ExpectedCallHierarchyItem {
+            name: String::from("second"),
+            kind: SymbolKind::FUNCTION,
+        }
+    }
+
+    fn third() -> Self {
+        ExpectedCallHierarchyItem {
+            name: String::from("third"),
+            kind: SymbolKind::FUNCTION,
+        }
+    }
+
+    fn all_together() -> Self {
+        ExpectedCallHierarchyItem {
+            name: String::from("all_together"),
+            kind: SymbolKind::FUNCTION,
+        }
+    }
+}
+
+impl PartialEq<CallHierarchyItem> for ExpectedCallHierarchyItem {
+    fn eq(&self, other: &CallHierarchyItem) -> bool {
+        self.name == other.name && self.kind == other.kind
+    }
+}
+
+fn verify_call_hierarchy(
+    mut expected: Vec<ExpectedCallHierarchyItem>,
+    received: &[CallHierarchyItem],
+) {
+    for item in received {
+        let matched = expected.iter().position(|expected| expected == item);
+
+        if let Some(index) = matched {
+            expected.remove(index);
+        } else {
+            panic!("Unexpected call hierarchy item returned: {item:?}");
+        }
+    }
+
+    assert!(
+        expected.is_empty(),
+        "Some expected items were not returned: {expected:?}"
+    );
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ExpectedCallHierarchyOutgoingCall {
+    to: ExpectedCallHierarchyItem,
+    from_ranges: Vec<Range>,
+}
+
+fn verify_outgoing_calls(
+    mut expected: Vec<ExpectedCallHierarchyOutgoingCall>,
+    received: &[CallHierarchyOutgoingCall],
+) {
+    for call in received {
+        let matched = expected.iter().position(|expected| {
+            expected.to == call.to
+                && expected.from_ranges.len() == call.from_ranges.len()
+                && expected
+                    .from_ranges
+                    .iter()
+                    .all(|expected_range| call.from_ranges.contains(expected_range))
+        });
+
+        if let Some(index) = matched {
+            expected.remove(index);
+        } else {
+            panic!("Unexpected outgoing call returned: {call:?}");
+        }
+    }
+
+    assert!(
+        expected.is_empty(),
+        "Some expected items were not returned: {expected:?}"
+    );
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct ExpectedCallHierarchyIncomingCall {
+    from: ExpectedCallHierarchyItem,
+    from_ranges: Vec<Range>,
+}
+
+fn verify_incoming_calls(
+    mut expected: Vec<ExpectedCallHierarchyIncomingCall>,
+    received: &[CallHierarchyIncomingCall],
+) {
+    for call in received {
+        let matched = expected.iter().position(|expected| {
+            expected.from == call.from && expected.from_ranges == call.from_ranges
+        });
+
+        if let Some(index) = matched {
+            expected.remove(index);
+        } else {
+            panic!("Unexpected incoming call returned: {call:?}");
+        }
+    }
+
+    assert!(
+        expected.is_empty(),
+        "Some expected items were not returned: {expected:?}"
+    );
+}
+
+#[tokio::test]
+async fn should_prepare_call_hierarchy() {
+    let mut ctx = setup().await;
+
+    for (file, item, pos) in [
+        (
+            "first.wdl",
+            ExpectedCallHierarchyItem::first(),
+            Position::new(2, 6),
+        ),
+        (
+            "second.wdl",
+            ExpectedCallHierarchyItem::second(),
+            Position::new(4, 10),
+        ),
+        (
+            "third.wdl",
+            ExpectedCallHierarchyItem::third(),
+            Position::new(4, 10),
+        ),
+        (
+            "source.wdl",
+            ExpectedCallHierarchyItem::all_together(),
+            Position::new(6, 10),
+        ),
+    ] {
+        let Some(hierarchy) = call_hierarchy_request(&mut ctx, file, pos).await else {
+            panic!("expected call hierarchy in {file}")
+        };
+
+        verify_call_hierarchy(vec![item], &hierarchy);
+    }
+}
+
+#[tokio::test]
+async fn should_not_prepare_call_hierarchy() {
+    let mut ctx = setup().await;
+
+    assert!(
+        call_hierarchy_request(
+            &mut ctx,
+            "second.wdl",
+            // Some random position
+            Position::new(5, 0)
+        )
+        .await
+        .is_none()
+    );
+}
+
+#[tokio::test]
+async fn should_determine_outgoing_calls() {
+    let mut ctx = setup().await;
+    let Some(mut hierarchy) =
+        call_hierarchy_request(&mut ctx, "source.wdl", Position::new(6, 10)).await
+    else {
+        panic!("expected call hierarchy")
+    };
+
+    verify_call_hierarchy(vec![ExpectedCallHierarchyItem::all_together()], &hierarchy);
+
+    let item = hierarchy.remove(0);
+    let outgoing_calls = outgoing_calls_request(&mut ctx, item)
+        .await
+        .expect("should return outgoing calls");
+
+    verify_outgoing_calls(
+        vec![
+            ExpectedCallHierarchyOutgoingCall {
+                to: ExpectedCallHierarchyItem::first(),
+                from_ranges: vec![Range {
+                    start: Position::new(7, 15),
+                    end: Position::new(7, 20),
+                }],
+            },
+            ExpectedCallHierarchyOutgoingCall {
+                to: ExpectedCallHierarchyItem::second(),
+                from_ranges: vec![Range {
+                    start: Position::new(8, 16),
+                    end: Position::new(8, 22),
+                }],
+            },
+            ExpectedCallHierarchyOutgoingCall {
+                to: ExpectedCallHierarchyItem::third(),
+                // Aliased calls are consolidated
+                from_ranges: vec![
+                    Range {
+                        start: Position::new(9, 15),
+                        end: Position::new(9, 20),
+                    },
+                    Range {
+                        start: Position::new(10, 24),
+                        end: Position::new(10, 30),
+                    },
+                ],
+            },
+        ],
+        &outgoing_calls,
+    );
+}
+
+#[tokio::test]
+async fn should_determine_incoming_calls() {
+    let mut ctx = setup().await;
+    let Some(mut hierarchy) =
+        call_hierarchy_request(&mut ctx, "first.wdl", Position::new(2, 6)).await
+    else {
+        panic!("expected call hierarchy")
+    };
+
+    verify_call_hierarchy(vec![ExpectedCallHierarchyItem::first()], &hierarchy);
+
+    let item = hierarchy.remove(0);
+    let incoming_calls = incoming_calls_request(&mut ctx, item)
+        .await
+        .expect("should return outgoing calls");
+
+    verify_incoming_calls(
+        vec![
+            ExpectedCallHierarchyIncomingCall {
+                from: ExpectedCallHierarchyItem::second(),
+                from_ranges: vec![Range {
+                    start: Position::new(5, 15),
+                    end: Position::new(5, 20),
+                }],
+            },
+            ExpectedCallHierarchyIncomingCall {
+                from: ExpectedCallHierarchyItem::all_together(),
+                from_ranges: vec![Range {
+                    start: Position::new(7, 15),
+                    end: Position::new(7, 20),
+                }],
+            },
+        ],
+        &incoming_calls,
+    );
+}

--- a/crates/wdl-lsp/tests/workspace/call_hierarchy/first.wdl
+++ b/crates/wdl-lsp/tests/workspace/call_hierarchy/first.wdl
@@ -1,0 +1,5 @@
+version 1.3
+
+task first {
+    command <<<>>>
+}

--- a/crates/wdl-lsp/tests/workspace/call_hierarchy/second.wdl
+++ b/crates/wdl-lsp/tests/workspace/call_hierarchy/second.wdl
@@ -1,0 +1,7 @@
+version 1.3
+
+import "first.wdl"
+
+workflow second {
+    call first.first
+}

--- a/crates/wdl-lsp/tests/workspace/call_hierarchy/source.wdl
+++ b/crates/wdl-lsp/tests/workspace/call_hierarchy/source.wdl
@@ -1,0 +1,12 @@
+version 1.3
+
+import "first.wdl"
+import "second.wdl"
+import "third.wdl"
+
+workflow all_together {
+    call first.first {}
+    call second.second {}
+    call third.third {}
+    call third.third as third2 {}
+}

--- a/crates/wdl-lsp/tests/workspace/call_hierarchy/third.wdl
+++ b/crates/wdl-lsp/tests/workspace/call_hierarchy/third.wdl
@@ -1,0 +1,7 @@
+version 1.3
+
+import "second.wdl"
+
+workflow third {
+    call second.second
+}


### PR DESCRIPTION
Adds support for the `textDocument/prepareCallHierarchy`, `callHierarchy/incomingCalls`, and `callHierarchy/outgoingCalls` requests

For editors that support it, you can use it to visualize workflows:

```wdl
task first {
    command <<<>>>
}

workflow second {
    call first
}

workflow third {
    call second
}

workflow all_together {
    call first
    call second
    call third
}
```

<img width="331" height="174" alt="image" src="https://github.com/user-attachments/assets/d56b69f7-33a4-4993-ae5a-447594411c4e" />

Or reverse it to find the callers of a task/workflow:

<img width="463" height="247" alt="image" src="https://github.com/user-attachments/assets/fca4bfe7-10bf-45d7-b5ba-5f0e228fd9d8" />

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
