### PR TITLE
chore(ci): add Renovate bot config for dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,73 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  extends: [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+  ],
+  timezone: "America/Chicago",
+  schedule: [
+    "before 6am",
+  ],
+  prHourlyLimit: 4,
+  prConcurrentLimit: 10,
+  minimumReleaseAge: "14 days",
+  rangeStrategy: "update-lockfile",
+  automerge: true,
+  automergeType: "pr",
+  automergeStrategy: "squash",
+  platformAutomerge: true,
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: [
+      "before 6am on monday",
+    ],
+    automerge: true,
+  },
+  packageRules: [
+    {
+      matchManagers: [
+        "cargo",
+      ],
+      matchUpdateTypes: [
+        "major",
+      ],
+      automerge: false,
+      addLabels: [
+        "dependencies",
+        "major-update",
+      ],
+    },
+    {
+      matchManagers: [
+        "cargo",
+      ],
+      matchUpdateTypes: [
+        "minor",
+        "patch",
+      ],
+      addLabels: [
+        "dependencies",
+      ],
+    },
+    {
+      matchManagers: [
+        "github-actions",
+      ],
+      addLabels: [
+        "github-actions",
+      ],
+    },
+  ],
+  vulnerabilityAlerts: {
+    enabled: true,
+    minimumReleaseAge: null,
+    schedule: [
+      "at any time",
+    ],
+    labels: [
+      "security",
+    ],
+  },
+  osvVulnerabilityAlerts: true,
+}


### PR DESCRIPTION
Adds a `.github/renovate.json5` so the [Mend Renovate](https://docs.renovatebot.com) bot can take over routine dependency updates for the workspace. The intent is to keep `Cargo.toml`, `Cargo.lock`, and GitHub Actions versions current without manual chores, while still leaving humans in the loop for anything risky.

The configuration was chosen for three properties.

- A 14-day `minimumReleaseAge` window so freshly published crates and actions get a small period before adoption, which catches yanked releases and the worst supply-chain surprises.
- Patch and minor updates auto-merge once required CI checks pass, via GitHub's native auto-merge using `platformAutomerge` with a squash strategy. Major updates open a labeled PR for human review instead of auto-merging.
- Vulnerability alerts (Dependabot + OSV) bypass the release-age window and run on any schedule so a CVE fix is not delayed by the delay rule.

Other notable choices: `rangeStrategy: "update-lockfile"` so `Cargo.toml` constraints are only rewritten when the new version falls outside the existing range, keeping PRs to lockfile-only churn most of the time; weekly `lockFileMaintenance` for `Cargo.lock` refresh; daily schedule of "before 6am" in `America/Chicago`.

Before submitting this PR, please make sure:

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).