### PR TITLE
feat: add Renovate configuration files for dependency management

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,49 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 13 * * 1' # 8 AM CDT / 7 AM CST Monday (1 PM UTC)
+  pull_request:
+    paths:
+      - 'renovate.json'
+      - '.github/workflows/renovate.yaml'
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: 'Dry run (no PRs created)'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.1.13
+        with:
+          configurationFile: renovate.json
+          token: ${{ steps.generate-token.outputs.token }}
+        env:
+          LOG_LEVEL: info
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          RENOVATE_DRY_RUN: ${{ github.event_name == 'pull_request' && 'full' || (inputs.dryRun == 'true' && 'full' || '') }}

--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
   ],
   "timezone": "America/Chicago",
   "schedule": [
-    "before 6am"
+    "at any time"
   ],
   "prHourlyLimit": 4,
   "prConcurrentLimit": 10,
@@ -28,7 +28,7 @@
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": [
-      "before 6am on monday"
+      "at any time"
     ],
     "automerge": true
   },

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(build)"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "timezone": "America/Chicago",
+  "schedule": [
+    "before 6am"
+  ],
+  "prHourlyLimit": 4,
+  "prConcurrentLimit": 10,
+  "minimumReleaseAge": "14 days",
+  "rangeStrategy": "update-lockfile",
+  "automerge": true,
+  "automergeType": "pr",
+  "automergeStrategy": "squash",
+  "platformAutomerge": true,
+  "enabledManagers": [
+    "cargo",
+    "github-actions"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 6am on monday"
+    ],
+    "automerge": true
+  },
+  "packageRules": [
+    {
+      "description": "Major updates require manual review",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false,
+      "addLabels": [
+        "major-update"
+      ]
+    },
+    {
+      "description": "Label cargo minor/patch updates",
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "addLabels": [
+        "cargo"
+      ]
+    },
+    {
+      "description": "Group GitHub Actions together",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github actions",
+      "addLabels": [
+        "github-actions"
+      ]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "minimumReleaseAge": null,
+    "schedule": [
+      "at any time"
+    ],
+    "labels": [
+      "security"
+    ]
+  },
+  "osvVulnerabilityAlerts": true
+}


### PR DESCRIPTION
Adds self-managed [Renovate](https://docs.renovatebot.com) via a GitHub Actions workflow and config file to automate dependency updates for `Cargo.toml`, `Cargo.lock`, and GitHub Actions versions. It keeps things current without manual chores while leaving humans in the loop for anything risky.

**How it runs:** A scheduled GitHub Action (weekly, Monday 8 AM CT) runs Renovate using the existing GitHub App token (`APP_ID`/`APP_PRIVATE_KEY`). Supports manual dispatch and dry-run mode. Changes to the config or workflow trigger a dry-run on PR to validate before merge.

**Key configuration choices:**

- **14-day `minimumReleaseAge`** — freshly published crates and actions get a buffer before adoption, catching yanked releases and supply-chain issues.
- **Minor/patch automerge** — auto-merges via GitHub's native `platformAutomerge` with a squash strategy once CI passes. Major updates open a labeled PR for human review.
- **Vulnerability alerts** (Dependabot + OSV) bypass the release-age window and run on any schedule so CVE fixes are not delayed.
- **`rangeStrategy: "update-lockfile"`** — `Cargo.toml` constraints are only rewritten when the new version falls outside the existing range, keeping PRs to lockfile-only churn most of the time.
- **Weekly `lockFileMaintenance`** for `Cargo.lock` refresh.
- **Semantic commits** — PRs use `build(deps):` commit convention.

Before submitting this PR, please make sure:

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).