### PR TITLE
chore(py): rename python package to `sprocket_bio`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ software are difficult, it may be easiest to wrap an `apptainer` invocation of
 apptainer -s run docker://koalaman/shellcheck:stable $@
 ```
 
-If you are developing the Python bindings, please see [`sprocket_py`'s `README.md`](./python/README.md).
+If you are developing the Python bindings, please see [the Python-specific `README.md`](./python/README.md).
 
 ## 🚧️ Tests
 

--- a/crates/sprocket-py/src/lib.rs
+++ b/crates/sprocket-py/src/lib.rs
@@ -2,7 +2,7 @@
 //! using [`pyo3`].
 //!
 //! This crate is not meant to be imported directly. Instead, import the
-//! `sprocket_py` Python package (located at `python/sprocket_py`), which
+//! `sprocket_bio` Python package (located at `python/sprocket_bio`), which
 //! bundles this extension.
 
 use pyo3::prelude::*;
@@ -10,4 +10,4 @@ use pyo3::prelude::*;
 /// Python bindings to [Sprocket](https://sprocket.bio), a bioinformatics toolkit for Workflow
 /// Description Language (WDL).
 #[pymodule]
-mod sprocket_py {}
+mod sprocket_bio {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=1.13,<2.0"]
 build-backend = "maturin"
 
 [project]
-name = "sprocket_py"
+name = "sprocket_bio"
 readme = "python/README.md"
 requires-python = ">=3.9"
 classifiers = [

--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <h1 align="center">
-    <code>sprocket_py</code>
+    <code>sprocket_bio</code>
   </h1>
 
   <p align="center">
@@ -8,12 +8,12 @@
       <img alt="CI: Status" src="https://github.com/stjude-rust-labs/sprocket/actions/workflows/CI.yml/badge.svg" />
     </a>
     <a href="https://pypi.org/project/sprocket-py/" target="_blank">
-      <img alt="PyPI: Version" src="https://img.shields.io/pypi/v/sprocket_py">
+      <img alt="PyPI: Version" src="https://img.shields.io/pypi/v/sprocket_bio">
     </a>
     <a href="https://rustseq.zulipchat.com/join/coxb7c7b3bbahlfx7poeqqrd/" target="_blank">
       <img alt="Chat: Zulip" src="https://img.shields.io/badge/chat-%23workflows--lib--wdl-blue?logo=zulip&logoColor=f6f6f6" />
     </a>
-    <img alt="PyPI: Downloads" src="https://img.shields.io/pypi/dm/sprocket_py">
+    <img alt="PyPI: Downloads" src="https://img.shields.io/pypi/dm/sprocket_bio">
   </p>
 
   <p align="center">
@@ -31,7 +31,7 @@
 
 ## 🖥️ Development
 
-`sprocket_py` requires Python 3.9, which you can [install from python.org](https://www.python.org/downloads/) or from your favorite package manager. Once you have Python installed, you can set up your development environment with the following commands:
+`sprocket_bio` requires Python 3.9 or greater, which you can [install from python.org](https://www.python.org/downloads/) or from your favorite package manager. Once you have Python installed, you can set up your development environment with the following commands:
 
 ```bash
 # Create the Python virtual environment, installing the latest version of pip and setuptools.
@@ -43,8 +43,8 @@ source .venv/bin/activate
 # Install the build system, Maturin.
 pip install maturin
 
-# Compile and install `sprocket_py` in the virtual environment.
+# Compile and install `sprocket_bio` in the virtual environment.
 maturin develop
 ```
 
-The Python package is located at `python/sprocket_py` (in this folder), and the Python extension that it bundles is compiled from `crates/sprocket_py`. Dependencies and additional metadata are specified in `pyproject.toml` and `crates/sprocket_py/Cargo.toml`.
+The Python package is located at `python/sprocket_bio` (in this folder), and the Python extension that it bundles is compiled from `crates/sprocket_py`. Dependencies and additional metadata are specified in `pyproject.toml` and `crates/sprocket_py/Cargo.toml`.

--- a/python/sprocket_bio/__init__.py
+++ b/python/sprocket_bio/__init__.py
@@ -1,0 +1,5 @@
+# Re-export all items from the Python extension.
+from .sprocket_bio import *
+
+__doc__ = sprocket_bio.__doc__
+# __all__ = sprocket_bio.__all__

--- a/python/sprocket_py/__init__.py
+++ b/python/sprocket_py/__init__.py
@@ -1,5 +1,0 @@
-# Re-export all items from the Python extension.
-from .sprocket_py import *
-
-__doc__ = sprocket_py.__doc__
-# __all__ = sprocket_py.__all__


### PR DESCRIPTION
@claymcleod requested that the Python package be renamed from `sprocket_py` to `sprocket_bio`. Note that the Rust crate is still `sprocket_py`, as it is not user-facing and would be confusing if named `sprocket_bio`.

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.
