### PR TITLE
feat(renovate): update schedule and group updates for cargo and npm

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,7 @@
   "platformAutomerge": true,
   "enabledManagers": [
     "cargo",
+    "npm",
     "github-actions"
   ],
   "lockFileMaintenance": {
@@ -44,16 +45,43 @@
       ]
     },
     {
-      "description": "Label cargo minor/patch updates",
+      "description": "Group all cargo patch updates into one PR",
       "matchManagers": [
         "cargo"
       ],
       "matchUpdateTypes": [
-        "minor",
         "patch"
       ],
+      "groupName": "cargo patch updates",
       "addLabels": [
         "cargo"
+      ]
+    },
+    {
+      "description": "Group all cargo minor updates into one PR",
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "groupName": "cargo minor updates",
+      "addLabels": [
+        "cargo"
+      ]
+    },
+    {
+      "description": "Group all npm updates into one PR",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "npm updates",
+      "addLabels": [
+        "npm"
       ]
     },
     {


### PR DESCRIPTION
Updates the Renovate configuration to reduce PR noise by grouping dependency updates and adding npm support.

**Changes:**
- Add `npm` as an enabled manager so JavaScript dependencies are kept up to date
- Group all Cargo patch updates into a single weekly PR (auto-merges if CI passes)
- Group all Cargo minor updates into a single weekly PR (auto-merges if CI passes)
- Group all npm patch/minor updates into a single weekly PR
- Major updates for all managers remain as individual PRs requiring manual review

Before submitting this PR, please make sure:

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.