### PR TITLE
feat(renovate): enhance grouping rules for cargo and npm updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -45,27 +45,15 @@
       ]
     },
     {
-      "description": "Group all cargo patch updates into one PR",
+      "description": "Group all cargo minor and patch updates into one PR",
       "matchManagers": [
         "cargo"
       ],
       "matchUpdateTypes": [
+        "minor",
         "patch"
       ],
-      "groupName": "cargo patch updates",
-      "addLabels": [
-        "cargo"
-      ]
-    },
-    {
-      "description": "Group all cargo minor updates into one PR",
-      "matchManagers": [
-        "cargo"
-      ],
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "groupName": "cargo minor updates",
+      "groupName": "cargo updates",
       "addLabels": [
         "cargo"
       ]

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,9 @@
     ":semanticCommits",
     ":semanticCommitTypeAll(build)"
   ],
+  "ignorePresets": [
+    "group:monorepos"
+  ],
   "labels": [
     "dependencies"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,7 @@
   "platformAutomerge": true,
   "enabledManagers": [
     "cargo",
+    "npm",
     "github-actions"
   ],
   "lockFileMaintenance": {
@@ -44,16 +45,43 @@
       ]
     },
     {
-      "description": "Label cargo minor/patch updates",
+      "description": "Group all cargo patch updates into one PR",
       "matchManagers": [
         "cargo"
       ],
       "matchUpdateTypes": [
-        "minor",
         "patch"
       ],
+      "groupName": "cargo patch updates",
       "addLabels": [
         "cargo"
+      ]
+    },
+    {
+      "description": "Group all cargo minor updates into one PR",
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "groupName": "cargo minor updates",
+      "addLabels": [
+        "cargo"
+      ]
+    },
+    {
+      "description": "Group all npm updates into one PR",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
+      "groupName": "npm updates",
+      "addLabels": [
+        "npm"
       ]
     },
     {

--- a/renovate.json
+++ b/renovate.json
@@ -13,8 +13,8 @@
   "schedule": [
     "at any time"
   ],
-  "prHourlyLimit": 4,
-  "prConcurrentLimit": 5,
+  "prHourlyLimit": 5,
+  "prConcurrentLimit": 10,
   "minimumReleaseAge": "14 days",
   "rangeStrategy": "update-lockfile",
   "automerge": true,
@@ -35,11 +35,12 @@
   },
   "packageRules": [
     {
-      "description": "Major updates require manual review",
+      "description": "Major updates require manual approval via Dependency Dashboard",
       "matchUpdateTypes": [
         "major"
       ],
       "automerge": false,
+      "dependencyDashboardApproval": true,
       "addLabels": [
         "major-update"
       ]

--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,7 @@
     "at any time"
   ],
   "prHourlyLimit": 4,
-  "prConcurrentLimit": 10,
+  "prConcurrentLimit": 5,
   "minimumReleaseAge": "14 days",
   "rangeStrategy": "update-lockfile",
   "automerge": true,

--- a/renovate.json
+++ b/renovate.json
@@ -13,8 +13,8 @@
   "schedule": [
     "at any time"
   ],
-  "prHourlyLimit": 5,
-  "prConcurrentLimit": 10,
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
   "minimumReleaseAge": "14 days",
   "rangeStrategy": "update-lockfile",
   "automerge": true,
@@ -35,28 +35,15 @@
   },
   "packageRules": [
     {
-      "description": "Major updates require manual approval via Dependency Dashboard",
+      "description": "Major updates require manual approval via Dependency Dashboard and are capped at 3 concurrent PRs",
       "matchUpdateTypes": [
         "major"
       ],
       "automerge": false,
       "dependencyDashboardApproval": true,
+      "prConcurrentLimit": 3,
       "addLabels": [
         "major-update"
-      ]
-    },
-    {
-      "description": "Group all cargo minor and patch updates into one PR",
-      "matchManagers": [
-        "cargo"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
-      ],
-      "groupName": "cargo updates",
-      "addLabels": [
-        "cargo"
       ]
     },
     {
@@ -82,6 +69,20 @@
       "addLabels": [
         "github-actions"
       ]
+    },
+    {
+      "description": "Group all cargo minor and patch updates into one PR, overriding monorepo presets",
+      "matchManagers": [
+        "cargo"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "cargo updates",
+      "addLabels": [
+        "cargo"
+      ]
     }
   ],
   "vulnerabilityAlerts": {
@@ -96,3 +97,4 @@
   },
   "osvVulnerabilityAlerts": true
 }
+


### PR DESCRIPTION
Updates the Renovate configuration to reduce PR noise by grouping dependency updates and adding npm support. When multiple packages match the same packageRule, Renovate puts them all into a single branch/PR named after the groupName.

**Changes:**
- Add `npm` as an enabled manager so JavaScript dependencies are kept up to date
- Group all Cargo minor and patch updates into a single PR (auto-merges if CI passes), overriding built-in monorepo presets so packages like `strum` and `utoipa` do not get their own separate PRs
- Group all npm patch/minor updates into a single PR
- Major updates require manual opt-in via the Renovate Dependency Dashboard issue — Renovate will not open a PR for a major upgrade until someone checks its checkbox in that issue. Additionally capped at 3 concurrent major PRs open at once.
- Minor/patch PRs have no concurrent or hourly limit — they flow freely and automerge when CI passes
- `prHourlyLimit` and `prConcurrentLimit` set to `0` (unlimited) at the top level

**What the dry run shows this would open:**
- `renovate/cargo-updates` — all cargo minor + patch grouped into one PR
- `renovate/github-actions` — all GitHub Actions version updates grouped into one PR
- `renovate/lock-file-maintenance` — bumps in-range npm dependencies in lock files only

All major upgrades are held in the Dependency Dashboard until manually opted in.

---

Before submitting this PR, please make sure:

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every possible diagnostic emitted for the rule within the file where the rule is implemented.