### PR TITLE
fix: canonicalize allowed paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* `sprocket dev server` will canonicalize paths passed as CLI arguments ([#913](https://github.com/stjude-rust-labs/sprocket/pull/913))
+
 ## 0.26.0 - 2026-06-03
 
 ### Changed

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -2,6 +2,7 @@
 
 use std::path::PathBuf;
 
+use anyhow::Context;
 use clap::Parser;
 
 use crate::Config;

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -73,6 +73,9 @@ impl Args {
 /// The main function for the `server` subcommand.
 pub async fn server(args: Args, mut config: Config) -> CommandResult<()> {
     args.apply(&mut config);
+    config
+        .validate()
+        .context("validating server configuration")?;
 
     // Validate that at least one source type is allowed
     if config.server.allowed_file_paths.is_empty() && config.server.allowed_urls.is_empty() {


### PR DESCRIPTION
Fixes #907. Re-runs the `validate` function on config after applying commandline arguments.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
