### PR TITLE
feat(wdl-grammar): diagnostic brace tracking

### DIFF
--- a/crates/wdl-grammar/src/grammar/v1.rs
+++ b/crates/wdl-grammar/src/grammar/v1.rs
@@ -2209,6 +2209,7 @@ fn call_statement(
         // Given the optional `input:` that we need to parse after the open brace, we
         // unfortunately can't use `Parser::matching_delimited` here
         let open_span = parser.require(Token::OpenBrace);
+        parser.push_open_delimiter(open_span, Token::OpenBrace);
 
         if parser.next_if(Token::InputKeyword).is_some() {
             expected!(parser, marker, Token::Colon);
@@ -2223,6 +2224,7 @@ fn call_statement(
         );
 
         parser.consume_close_token(Token::OpenBrace, open_span, Token::CloseBrace);
+        parser.pop_open_delimiter();
     }
 
     marker.complete(parser, SyntaxKind::CallStatementNode);

--- a/crates/wdl-grammar/src/grammar/v1.rs
+++ b/crates/wdl-grammar/src/grammar/v1.rs
@@ -710,7 +710,7 @@ fn import_statement(
     // Form 1 suffix: optional `as <alias>` and zero-or-more `alias` clauses.
     // Forms 2 and 3 do not accept either.
     if !has_selection {
-        if parser.next_if(Token::AsKeyword) {
+        if parser.next_if(Token::AsKeyword).is_some() {
             ident!(parser, marker, "import namespace");
         }
 
@@ -749,7 +749,7 @@ fn import_member(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker,
     expected_in!(parser, marker, ANY_IDENT, "selected member");
     parser.update_last_token_kind(SyntaxKind::Ident);
 
-    if parser.next_if(Token::AsKeyword) {
+    if parser.next_if(Token::AsKeyword).is_some() {
         expected_in!(parser, marker, ANY_IDENT, "member alias");
         parser.update_last_token_kind(SyntaxKind::Ident);
     }
@@ -769,7 +769,7 @@ fn symbolic_module_path(
     expected_in!(parser, marker, ANY_IDENT, "symbolic module path");
     parser.update_last_token_kind(SyntaxKind::Ident);
 
-    while parser.next_if(Token::Slash) {
+    while parser.next_if(Token::Slash).is_some() {
         expected_in!(parser, marker, ANY_IDENT, "symbolic module path component");
         parser.update_last_token_kind(SyntaxKind::Ident);
     }
@@ -1109,7 +1109,7 @@ fn input_item(
     expected_fn!(parser, marker, ty);
     ident!(parser, marker, "input name");
 
-    let kind = if parser.next_if(Token::Assignment) {
+    let kind = if parser.next_if(Token::Assignment).is_some() {
         expected_fn!(parser, marker, expr);
         SyntaxKind::BoundDeclNode
     } else {
@@ -2136,7 +2136,7 @@ fn conditional_else_if_clause(
     marker: Marker,
 ) -> Result<(), (Marker, ParseDiagnostic)> {
     parser.require(Token::ElseKeyword);
-    if parser.next_if(Token::IfKeyword) {
+    if parser.next_if(Token::IfKeyword).is_some() {
         paren!(parser, marker, |parser, _| {
             expected_fn!(parser, expr);
             Ok(())
@@ -2210,7 +2210,7 @@ fn call_statement(
         // unfortunately can't use `Parser::matching_delimited` here
         let open_span = parser.require(Token::OpenBrace);
 
-        if parser.next_if(Token::InputKeyword) {
+        if parser.next_if(Token::InputKeyword).is_some() {
             expected!(parser, marker, Token::Colon);
         }
 
@@ -2233,7 +2233,7 @@ fn call_statement(
 fn call_target(parser: &mut Parser<'_>, marker: Marker) -> Result<(), (Marker, ParseDiagnostic)> {
     ident!(parser, marker, "call target name");
 
-    while parser.next_if(Token::Dot) {
+    while parser.next_if(Token::Dot).is_some() {
         ident!(parser, marker, "call target name");
     }
 
@@ -2268,7 +2268,7 @@ fn call_input_item(
     ident!(parser, marker, "call input key");
     parser.update_last_token_kind(SyntaxKind::Ident);
 
-    if parser.next_if(Token::Assignment) {
+    if parser.next_if(Token::Assignment).is_some() {
         expected_fn!(parser, marker, expr);
     }
 
@@ -2479,7 +2479,7 @@ fn pair_or_paren_expr(
 
     expected_fn!(parser, marker, expr);
 
-    if parser.next_if(Token::CloseParen) {
+    if parser.next_if(Token::CloseParen).is_some() {
         // This was actually a parenthesized expression.
         return Ok(marker.complete(parser, SyntaxKind::ParenthesizedExprNode));
     }
@@ -2637,7 +2637,7 @@ fn literal_input_item(
 ) -> Result<(), (Marker, ParseDiagnostic)> {
     ident!(parser, marker, "input key");
 
-    while parser.next_if(Token::Dot) {
+    while parser.next_if(Token::Dot).is_some() {
         ident!(parser, marker, "struct member name");
     }
 
@@ -2670,7 +2670,7 @@ fn literal_output_item(
 ) -> Result<(), (Marker, ParseDiagnostic)> {
     ident!(parser, marker, "output key");
 
-    while parser.next_if(Token::Dot) {
+    while parser.next_if(Token::Dot).is_some() {
         ident!(parser, marker, "struct member name");
     }
 

--- a/crates/wdl-grammar/src/parser.rs
+++ b/crates/wdl-grammar/src/parser.rs
@@ -425,6 +425,10 @@ struct DiagnosticContext {
     diagnostics: IndexSet<Diagnostic>,
     /// Whether the parser has reached the end of the input.
     eof: bool,
+    /// Stack of open delimiters and their spans.
+    open_delimiters: Vec<(Span, &'static str)>,
+    /// Spans of matching (Open, Close) braces.
+    matching_block_spans: Vec<(Span, Span)>,
     /// Whether the parser has encountered a fatal error.
     halt: bool,
 }
@@ -608,14 +612,14 @@ where
 
     /// Consumes the next token only if it matches the given token.
     ///
-    /// Returns `true` if the token was consumed, `false` if otherwise.
-    pub fn next_if(&mut self, token: T) -> bool {
+    /// Returns the span of the token if it was consumed, `None` if otherwise.
+    pub fn next_if(&mut self, token: T) -> Option<Span> {
         match self.peek() {
-            Some((t, _)) if t == token => {
+            Some((t, span)) if t == token => {
                 self.next();
-                true
+                Some(span)
             }
-            _ => false,
+            _ => None,
         }
     }
 
@@ -635,11 +639,19 @@ where
     {
         let open_span = self.expect(open)?;
 
+        self.diagnostic_context
+            .open_delimiters
+            .push((open_span, open.describe()));
+
         // Check to see if the close token is immediately following the opening
         if allow_empty {
             match self.peek() {
-                Some((t, _)) if t == close => {
+                Some((t, span)) if t == close => {
                     self.next();
+                    self.diagnostic_context
+                        .matching_block_spans
+                        .push((open_span, span));
+                    self.diagnostic_context.open_delimiters.pop();
                     return Ok(());
                 }
                 _ => {}
@@ -648,10 +660,20 @@ where
 
         cb(self, open_span)?;
 
-        match self.next() {
-            Some((token, _)) if token == close => Ok(()),
-            found => Err(self.unmatched(open.describe(), open_span, close.describe(), found)),
-        }
+        let res = match self.next() {
+            Some((token, span)) if token == close => {
+                self.diagnostic_context
+                    .matching_block_spans
+                    .push((open_span, span));
+                Ok(())
+            }
+            found => {
+                Err(self.mismatched_delim_err(open.describe(), open_span, close.describe(), found))
+            }
+        };
+
+        self.diagnostic_context.open_delimiters.pop();
+        res
     }
 
     /// Parses a matching token pair that surround a delimited list of items.
@@ -679,9 +701,151 @@ where
         F: FnMut(&mut Self, Marker) -> Result<(), (Marker, ParseDiagnostic)>,
     {
         let open_span = self.expect(open)?;
+        self.diagnostic_context
+            .open_delimiters
+            .push((open_span, open.describe()));
+
         self.delimited(close, termination, delimiter, recovery, cb);
         self.consume_close_token(open, open_span, close);
+
+        self.diagnostic_context.open_delimiters.pop();
         Ok(())
+    }
+
+    /// Create a new "unmatched opening delimiter" diagnostic.
+    fn mismatched_delim_err(
+        &mut self,
+        open: &str,
+        open_span: Span,
+        close: &str,
+        found: Option<(T, Span)>,
+    ) -> ParseDiagnostic {
+        let mut diagnostic = self.unexpected(close, found);
+        diagnostic.inner = diagnostic
+            .inner
+            .with_label(format!("this {open} is not matched"), open_span);
+        self.report_suspicious_mismatch_block(diagnostic)
+    }
+
+    /// Extend a [`Self::unexpected()`] diagnostic with information about the
+    /// closest closing brace.
+    fn report_suspicious_mismatch_block(&self, mut diagnostic: ParseDiagnostic) -> ParseDiagnostic {
+        /// Calculates the indentation level of the line containing the start of
+        /// the given span.
+        fn indentation_level<'a, T>(parser: &Parser<'a, T>, span: Span) -> usize
+        where
+            T: ParserToken<'a>,
+        {
+            let prefix = parser.source(Span::new(0, span.start()));
+            let line_start = prefix.rfind('\n').map(|i| i + 1).unwrap_or(0);
+
+            prefix[line_start..]
+                .chars()
+                .take_while(|c| c.is_whitespace())
+                .count()
+        }
+
+        let mut matched_spans: Vec<(Span, bool)> = self
+            .diagnostic_context
+            .matching_block_spans
+            .iter()
+            .map(|&(open, close)| {
+                let same_indent = indentation_level(self, open) == indentation_level(self, close);
+                (
+                    Span::new(open.start(), close.start() - open.start()),
+                    same_indent,
+                )
+            })
+            .collect();
+
+        // Sort by `start` position, working outside-in
+        matched_spans.sort_by_key(|(open, ..)| open.start());
+
+        for i in 0..matched_spans.len() {
+            let (outer_span, same_indent) = matched_spans[i];
+            if !same_indent {
+                continue;
+            }
+
+            for (inner_span, same_indent) in matched_spans.iter_mut().skip(i + 1) {
+                if outer_span.contains(inner_span.start()) && outer_span.contains(inner_span.end())
+                {
+                    *same_indent = true;
+                }
+            }
+        }
+
+        // Find the innermost span candidate that still has a mismatched indentation
+        let candidate_span = matched_spans
+            .into_iter()
+            .rev()
+            .find(|&(_, same_indent)| !same_indent);
+
+        if let Some((block_span, _)) = candidate_span {
+            diagnostic.inner = diagnostic
+                .inner
+                .with_label(
+                    "this delimiter might not be properly closed...",
+                    Span::new(block_span.start(), 1),
+                )
+                .with_label(
+                    "...as it matches this but it has different indentation",
+                    Span::new(block_span.end(), 1),
+                );
+        } else if let Some(&(parent_open, parent_close)) =
+            self.diagnostic_context.matching_block_spans.last()
+        {
+            // Optional fallback if we don't have a specific candidate
+            diagnostic.inner = diagnostic
+                .inner
+                .with_label("this opening brace...", parent_open)
+                .with_label("...matches this closing brace", parent_close);
+        }
+
+        diagnostic
+    }
+
+    /// Create a diagnostic reporting all unclosed delimiters up to EOF.
+    fn eof_err(&mut self, open: T) {
+        if self.diagnostic_context.eof {
+            return;
+        }
+
+        const UNCLOSED_DELIMITER_SHOW_LIMIT: usize = 3;
+        let mut diagnostic = self.unexpected_inner(open.describe(), None, false);
+
+        let delimiters_shown = usize::min(
+            UNCLOSED_DELIMITER_SHOW_LIMIT,
+            self.diagnostic_context.open_delimiters.len(),
+        );
+        for (span, _) in &self.diagnostic_context.open_delimiters[..delimiters_shown] {
+            diagnostic.inner = diagnostic.inner.with_label("unclosed delimiter", *span);
+        }
+
+        // Summarize the rest
+        if let Some((span, _)) = self
+            .diagnostic_context
+            .open_delimiters
+            .get(UNCLOSED_DELIMITER_SHOW_LIMIT)
+            && self.diagnostic_context.open_delimiters.len() >= UNCLOSED_DELIMITER_SHOW_LIMIT + 2
+        {
+            diagnostic.inner = diagnostic.inner.with_label(
+                format!(
+                    "another {} unclosed delimiters begin from here",
+                    self.diagnostic_context.open_delimiters.len() - UNCLOSED_DELIMITER_SHOW_LIMIT
+                ),
+                *span,
+            );
+        }
+
+        if self.diagnostic_context.open_delimiters.last().is_some() {
+            diagnostic = self.report_suspicious_mismatch_block(diagnostic);
+        }
+
+        self.diagnostic(diagnostic);
+
+        // Prevent duplicate EOF diagnostics
+        self.diagnostic_context.eof = true;
     }
 
     /// Consumes a close token if it is the next token to be parsed.
@@ -689,13 +853,21 @@ where
     /// Otherwise, emits an "unmatched" diagnostic and synthesizes the close
     /// token into the parser's list of events.
     pub fn consume_close_token(&mut self, open: T, open_span: Span, close: T) {
-        if self.next_if(close) {
+        if let Some(span) = self.next_if(close) {
+            self.diagnostic_context
+                .matching_block_spans
+                .push((open_span, span));
             return;
         }
 
         let found = self.peek();
-        let diagnostic = self.unmatched(open.describe(), open_span, close.describe(), found);
-        self.diagnostic(diagnostic);
+        if found.is_some() {
+            let diagnostic =
+                self.mismatched_delim_err(open.describe(), open_span, close.describe(), found);
+            self.diagnostic(diagnostic);
+        } else {
+            self.eof_err(open);
+        }
 
         // Synthesize a close token event of zero width
         let span = found.map(|(_, s)| s).unwrap_or_else(|| self.span());
@@ -968,15 +1140,26 @@ where
         expected: &str,
         found: Option<(T, Span)>,
     ) -> ParseDiagnostic {
+        self.unexpected_inner(expected, found, true)
+    }
+
+    /// [`Self::unexpected()`] with the ability to toggle the label on the
+    /// `found` token.
+    fn unexpected_inner(
+        &mut self,
+        expected: &str,
+        found: Option<(T, Span)>,
+        label_found: bool,
+    ) -> ParseDiagnostic {
         let (found, span, eof) = self.maybe_eof_diagnostic(found);
 
         let found = found.unwrap_or("end of input");
-        let diagnostic: ParseDiagnostic =
-            Diagnostic::error(format!("expected {expected}, but found {found}"))
-                .with_label(format!("unexpected {found}"), span)
-                .into();
+        let mut diagnostic = Diagnostic::error(format!("expected {expected}, but found {found}"));
+        if label_found {
+            diagnostic = diagnostic.with_label(format!("unexpected {found}"), span)
+        }
 
-        diagnostic.with_eof(eof)
+        Into::<ParseDiagnostic>::into(diagnostic).with_eof(eof)
     }
 
     /// Creates an "expected one of, but found" diagnostic error.

--- a/crates/wdl-grammar/src/parser.rs
+++ b/crates/wdl-grammar/src/parser.rs
@@ -637,43 +637,61 @@ where
     where
         F: FnOnce(&mut Self, Span) -> Result<(), ParseDiagnostic>,
     {
-        let open_span = self.expect(open)?;
+        fn inner<'a, T, F>(
+            parser: &mut Parser<'a, T>,
+            open: T,
+            open_span: Span,
+            close: T,
+            allow_empty: bool,
+            cb: F,
+        ) -> Result<(), ParseDiagnostic>
+        where
+            T: ParserToken<'a>,
+            F: FnOnce(&mut Parser<'a, T>, Span) -> Result<(), ParseDiagnostic>,
+        {
+            // Check to see if the close token is immediately following the opening
+            if allow_empty {
+                match parser.peek() {
+                    Some((t, span)) if t == close => {
+                        parser.next();
+                        parser
+                            .diagnostic_context
+                            .matching_block_spans
+                            .push((open_span, span));
+                        parser.diagnostic_context.open_delimiters.pop();
+                        return Ok(());
+                    }
+                    _ => {}
+                }
+            }
 
-        self.diagnostic_context
-            .open_delimiters
-            .push((open_span, open.describe()));
+            cb(parser, open_span)?;
 
-        // Check to see if the close token is immediately following the opening
-        if allow_empty {
-            match self.peek() {
-                Some((t, span)) if t == close => {
-                    self.next();
-                    self.diagnostic_context
+            match parser.next() {
+                Some((token, span)) if token == close => {
+                    parser
+                        .diagnostic_context
                         .matching_block_spans
                         .push((open_span, span));
-                    self.diagnostic_context.open_delimiters.pop();
-                    return Ok(());
+                    Ok(())
                 }
-                _ => {}
+                found => Err(parser.mismatched_delim_err(
+                    open.describe(),
+                    open_span,
+                    close.describe(),
+                    found,
+                )),
             }
         }
 
-        cb(self, open_span)?;
+        let open_span = self.expect(open)?;
 
-        let res = match self.next() {
-            Some((token, span)) if token == close => {
-                self.diagnostic_context
-                    .matching_block_spans
-                    .push((open_span, span));
-                Ok(())
-            }
-            found => {
-                Err(self.mismatched_delim_err(open.describe(), open_span, close.describe(), found))
-            }
-        };
+        self.push_open_delimiter(open_span, open);
 
-        self.diagnostic_context.open_delimiters.pop();
-        res
+        let ret = inner(self, open, open_span, close, allow_empty, cb);
+
+        self.pop_open_delimiter();
+        ret
     }
 
     /// Parses a matching token pair that surround a delimited list of items.
@@ -710,6 +728,18 @@ where
 
         self.diagnostic_context.open_delimiters.pop();
         Ok(())
+    }
+
+    /// Records an opening delimiter for EOF diagnostics.
+    pub fn push_open_delimiter(&mut self, open_span: Span, open: T) {
+        self.diagnostic_context
+            .open_delimiters
+            .push((open_span, open.describe()));
+    }
+
+    /// Removes the most recently-recorded opening delimiter.
+    pub fn pop_open_delimiter(&mut self) {
+        self.diagnostic_context.open_delimiters.pop();
     }
 
     /// Create a new "unmatched opening delimiter" diagnostic.
@@ -798,26 +828,30 @@ where
             // Optional fallback if we don't have a specific candidate
             diagnostic.inner = diagnostic
                 .inner
-                .with_label("this opening brace...", parent_open)
-                .with_label("...matches this closing brace", parent_close);
+                .with_label("this opening delimiter...", parent_open)
+                .with_label("...matches this closing delimiter", parent_close);
         }
 
         diagnostic
     }
 
     /// Create a diagnostic reporting all unclosed delimiters up to EOF.
-    fn eof_err(&mut self, open: T) {
+    fn eof_err(&mut self, close: T) {
         if self.diagnostic_context.eof {
             return;
         }
 
         const UNCLOSED_DELIMITER_SHOW_LIMIT: usize = 3;
-        let mut diagnostic = self.unexpected_inner(open.describe(), None, false);
+        let mut diagnostic = self.unexpected_inner(close.describe(), None, false);
 
-        let delimiters_shown = usize::min(
-            UNCLOSED_DELIMITER_SHOW_LIMIT,
-            self.diagnostic_context.open_delimiters.len(),
-        );
+        let unclosed_delimiter_count = self.diagnostic_context.open_delimiters.len();
+        let summarize_delimiters = unclosed_delimiter_count >= UNCLOSED_DELIMITER_SHOW_LIMIT + 2;
+        let delimiters_shown = if summarize_delimiters {
+            UNCLOSED_DELIMITER_SHOW_LIMIT
+        } else {
+            unclosed_delimiter_count
+        };
+
         for (span, _) in &self.diagnostic_context.open_delimiters[..delimiters_shown] {
             diagnostic.inner = diagnostic.inner.with_label("unclosed delimiter", *span);
         }
@@ -826,13 +860,13 @@ where
         if let Some((span, _)) = self
             .diagnostic_context
             .open_delimiters
-            .get(UNCLOSED_DELIMITER_SHOW_LIMIT)
-            && self.diagnostic_context.open_delimiters.len() >= UNCLOSED_DELIMITER_SHOW_LIMIT + 2
+            .get(delimiters_shown)
+            && summarize_delimiters
         {
             diagnostic.inner = diagnostic.inner.with_label(
                 format!(
                     "another {} unclosed delimiters begin from here",
-                    self.diagnostic_context.open_delimiters.len() - UNCLOSED_DELIMITER_SHOW_LIMIT
+                    unclosed_delimiter_count - delimiters_shown
                 ),
                 *span,
             );
@@ -866,7 +900,7 @@ where
                 self.mismatched_delim_err(open.describe(), open_span, close.describe(), found);
             self.diagnostic(diagnostic);
         } else {
-            self.eof_err(open);
+            self.eof_err(close);
         }
 
         // Synthesize a close token event of zero width

--- a/crates/wdl-grammar/tests/parsing/many-unclosed/source.errors
+++ b/crates/wdl-grammar/tests/parsing/many-unclosed/source.errors
@@ -10,7 +10,7 @@ error: expected import statement, struct definition, enum definition, task defin
 3 │ "${a(;b{{{{{{{{
   │ ^^^^^^^^^^^^^^^ unexpected string
 
-error: expected `{`, but found end of input
+error: expected `}`, but found end of input
   ┌─ tests/parsing/many-unclosed/source.wdl:3:5
   │
 3 │ "${a(;b{{{{{{{{

--- a/crates/wdl-grammar/tests/parsing/many-unclosed/source.errors
+++ b/crates/wdl-grammar/tests/parsing/many-unclosed/source.errors
@@ -10,6 +10,16 @@ error: expected import statement, struct definition, enum definition, task defin
 3 │ "${a(;b{{{{{{{{
   │ ^^^^^^^^^^^^^^^ unexpected string
 
+error: expected `{`, but found end of input
+  ┌─ tests/parsing/many-unclosed/source.wdl:3:5
+  │
+3 │ "${a(;b{{{{{{{{
+  │     ^   --- another 5 unclosed delimiters begin from here
+  │     │   ││ 
+  │     │   │unclosed delimiter
+  │     │   unclosed delimiter
+  │     unclosed delimiter
+
 error: an unknown token was encountered
   ┌─ tests/parsing/many-unclosed/source.wdl:3:6
   │
@@ -127,12 +137,4 @@ error: expected `}`, but found `{`
   │              -^ unexpected `{`
   │              │ 
   │              this `{` is not matched
-
-error: expected `}`, but found end of input
-  ┌─ tests/parsing/many-unclosed/source.wdl:3:16
-  │
-3 │ "${a(;b{{{{{{{{
-  │               -^ unexpected end of input
-  │               │
-  │               this `{` is not matched
 

--- a/crates/wdl-grammar/tests/parsing/mismatched-brace/source.errors
+++ b/crates/wdl-grammar/tests/parsing/mismatched-brace/source.errors
@@ -1,10 +1,10 @@
-error: expected `{`, but found end of input
+error: expected `}`, but found end of input
   ┌─ tests/parsing/mismatched-brace/source.wdl:5:11
   │
 5 │ task test {
   │           ^ unclosed delimiter
 6 │     meta {
-  │          - this opening brace...
+  │          - this opening delimiter...
 7 │     }
-  │     - ...matches this closing brace
+  │     - ...matches this closing delimiter
 

--- a/crates/wdl-grammar/tests/parsing/mismatched-brace/source.errors
+++ b/crates/wdl-grammar/tests/parsing/mismatched-brace/source.errors
@@ -1,9 +1,10 @@
-error: expected `}`, but found end of input
-  ┌─ tests/parsing/mismatched-brace/source.wdl:8:1
+error: expected `{`, but found end of input
+  ┌─ tests/parsing/mismatched-brace/source.wdl:5:11
   │
 5 │ task test {
-  │           - this `{` is not matched
-  ·
-8 │ 
-  │ ^ unexpected end of input
+  │           ^ unclosed delimiter
+6 │     meta {
+  │          - this opening brace...
+7 │     }
+  │     - ...matches this closing brace
 

--- a/crates/wdl-grammar/tests/parsing/mismatched-bracket/source.errors
+++ b/crates/wdl-grammar/tests/parsing/mismatched-bracket/source.errors
@@ -2,7 +2,9 @@ error: expected `]`, but found identifier
   ┌─ tests/parsing/mismatched-bracket/source.wdl:7:32
   │
 7 │     Map[Boolean, Array[String] y
-  │        -                       ^ unexpected identifier
-  │        │                        
+  │        -              -      - ^ unexpected identifier
+  │        │              │      │  
+  │        │              │      ...matches this closing brace
+  │        │              this opening brace...
   │        this `[` is not matched
 

--- a/crates/wdl-grammar/tests/parsing/mismatched-bracket/source.errors
+++ b/crates/wdl-grammar/tests/parsing/mismatched-bracket/source.errors
@@ -4,7 +4,7 @@ error: expected `]`, but found identifier
 7 │     Map[Boolean, Array[String] y
   │        -              -      - ^ unexpected identifier
   │        │              │      │  
-  │        │              │      ...matches this closing brace
-  │        │              this opening brace...
+  │        │              │      ...matches this closing delimiter
+  │        │              this opening delimiter...
   │        this `[` is not matched
 

--- a/crates/wdl-grammar/tests/parsing/missing-brace/source.errors
+++ b/crates/wdl-grammar/tests/parsing/missing-brace/source.errors
@@ -11,10 +11,10 @@ error: expected `}`, but found `output` keyword
    ┌─ tests/parsing/missing-brace/source.wdl:16:5
    │
  5 │ task foo {
-   │          - this opening brace...
+   │          - this opening delimiter...
    ·
 12 │ }
-   │ - ...matches this closing brace
+   │ - ...matches this closing delimiter
    ·
 15 │     input {
    │           - this `{` is not matched
@@ -35,7 +35,7 @@ error: expected `}`, but found `task` keyword
 19 │ task baz {
    │ ^^^^ unexpected `task` keyword
 
-error: expected `{`, but found end of input
+error: expected `}`, but found end of input
    ┌─ tests/parsing/missing-brace/source.wdl:19:10
    │
 19 │ task baz {

--- a/crates/wdl-grammar/tests/parsing/missing-brace/source.errors
+++ b/crates/wdl-grammar/tests/parsing/missing-brace/source.errors
@@ -10,17 +10,64 @@ error: expected `}`, but found `meta` keyword
 error: expected `}`, but found `output` keyword
    ┌─ tests/parsing/missing-brace/source.wdl:16:5
    │
+ 5 │ task foo {
+   │          - this opening brace...
+   ·
+12 │ }
+   │ - ...matches this closing brace
+   ·
 15 │     input {
    │           - this `{` is not matched
 16 │     output {
    │     ^^^^^^ unexpected `output` keyword
 
-error: expected `}`, but found end of input
-   ┌─ tests/parsing/missing-brace/source.wdl:18:1
+error: expected `}`, but found `task` keyword
+   ┌─ tests/parsing/missing-brace/source.wdl:19:1
    │
 14 │ task bar {
    │          - this `{` is not matched
-   ·
+15 │     input {
+16 │     output {
+   │            - this delimiter might not be properly closed...
+17 │ }
+   │ - ...as it matches this but it has different indentation
 18 │ 
-   │ ^ unexpected end of input
+19 │ task baz {
+   │ ^^^^ unexpected `task` keyword
+
+error: expected `{`, but found end of input
+   ┌─ tests/parsing/missing-brace/source.wdl:19:10
+   │
+19 │ task baz {
+   │          ^ unclosed delimiter
+20 │     meta {
+   │          - unclosed delimiter
+   ·
+27 │         inputs: {
+   │                 - unclosed delimiter
+28 │             foo: {
+   │                  - another 4 unclosed delimiters begin from here
+   ·
+32 │                             quux: {
+   │                                   - this delimiter might not be properly closed...
+33 │ }
+   │ - ...as it matches this but it has different indentation
+
+error: expected `:`, but found identifier
+   ┌─ tests/parsing/missing-brace/source.wdl:25:6
+   │
+25 │ task qux {
+   │      ^^^ unexpected identifier
+
+error: expected `:`, but found `{`
+   ┌─ tests/parsing/missing-brace/source.wdl:25:10
+   │
+25 │ task qux {
+   │          ^ unexpected `{`
+
+error: expected `:`, but found `{`
+   ┌─ tests/parsing/missing-brace/source.wdl:26:11
+   │
+26 │     hints {
+   │           ^ unexpected `{`
 

--- a/crates/wdl-grammar/tests/parsing/missing-brace/source.tree
+++ b/crates/wdl-grammar/tests/parsing/missing-brace/source.tree
@@ -1,4 +1,4 @@
-RootNode@0..181
+RootNode@0..420
   Comment@0..35 "## This is a test of  ..."
   Whitespace@35..37 "\n\n"
   VersionStatementNode@37..48
@@ -50,7 +50,7 @@ RootNode@0..181
     Whitespace@139..140 "\n"
     CloseBrace@140..141 "}"
   Whitespace@141..143 "\n\n"
-  TaskDefinitionNode@143..180
+  TaskDefinitionNode@143..182
     TaskKeyword@143..147 "task"
     Whitespace@147..148 " "
     Ident@148..151 "bar"
@@ -69,5 +69,94 @@ RootNode@0..181
       OpenBrace@177..178 "{"
       Whitespace@178..179 "\n"
       CloseBrace@179..180 "}"
-    CloseBrace@180..180 ""
-  Whitespace@180..181 "\n"
+    Whitespace@180..182 "\n\n"
+    CloseBrace@182..182 ""
+  TaskDefinitionNode@182..420
+    TaskKeyword@182..186 "task"
+    Whitespace@186..187 " "
+    Ident@187..190 "baz"
+    Whitespace@190..191 " "
+    OpenBrace@191..192 "{"
+    Whitespace@192..197 "\n    "
+    MetadataSectionNode@197..420
+      MetaKeyword@197..201 "meta"
+      Whitespace@201..202 " "
+      OpenBrace@202..203 "{"
+      Whitespace@203..212 "\n        "
+      MetadataObjectItemNode@212..240
+        Ident@212..215 "foo"
+        Colon@215..216 ":"
+        Whitespace@216..217 " "
+        MetadataObjectNode@217..240
+          OpenBrace@217..218 "{"
+          Whitespace@218..231 "\n            "
+          MetadataObjectItemNode@231..238
+            Ident@231..234 "bar"
+            Colon@234..235 ":"
+            Whitespace@235..236 " "
+            MetadataObjectNode@236..238
+              OpenBrace@236..237 "{"
+              CloseBrace@237..238 "}"
+          Whitespace@238..239 "\n"
+          CloseBrace@239..240 "}"
+      Whitespace@240..242 "\n\n"
+      Ident@242..246 "task"
+      Whitespace@246..247 " "
+      Ident@247..250 "qux"
+      Whitespace@250..251 " "
+      OpenBrace@251..252 "{"
+      Whitespace@252..257 "\n    "
+      Ident@257..262 "hints"
+      Whitespace@262..263 " "
+      OpenBrace@263..264 "{"
+      Whitespace@264..273 "\n        "
+      MetadataObjectItemNode@273..420
+        Ident@273..279 "inputs"
+        Colon@279..280 ":"
+        Whitespace@280..281 " "
+        MetadataObjectNode@281..420
+          OpenBrace@281..282 "{"
+          Whitespace@282..295 "\n            "
+          MetadataObjectItemNode@295..420
+            Ident@295..298 "foo"
+            Colon@298..299 ":"
+            Whitespace@299..300 " "
+            MetadataObjectNode@300..420
+              OpenBrace@300..301 "{"
+              Whitespace@301..318 "\n                "
+              MetadataObjectItemNode@318..420
+                Ident@318..321 "bar"
+                Colon@321..322 ":"
+                Whitespace@322..323 " "
+                MetadataObjectNode@323..420
+                  OpenBrace@323..324 "{"
+                  Whitespace@324..345 "\n                    "
+                  MetadataObjectItemNode@345..420
+                    Ident@345..348 "baz"
+                    Colon@348..349 ":"
+                    Whitespace@349..350 " "
+                    MetadataObjectNode@350..420
+                      OpenBrace@350..351 "{"
+                      Whitespace@351..376 "\n                     ..."
+                      MetadataObjectItemNode@376..420
+                        Ident@376..379 "qux"
+                        Colon@379..380 ":"
+                        Whitespace@380..381 " "
+                        MetadataObjectNode@381..420
+                          OpenBrace@381..382 "{"
+                          Whitespace@382..411 "\n                     ..."
+                          MetadataObjectItemNode@411..420
+                            Ident@411..415 "quux"
+                            Colon@415..416 ":"
+                            Whitespace@416..417 " "
+                            MetadataObjectNode@417..420
+                              OpenBrace@417..418 "{"
+                              Whitespace@418..419 "\n"
+                              CloseBrace@419..420 "}"
+                          CloseBrace@420..420 ""
+                      CloseBrace@420..420 ""
+                  CloseBrace@420..420 ""
+              CloseBrace@420..420 ""
+          CloseBrace@420..420 ""
+      CloseBrace@420..420 ""
+    CloseBrace@420..420 ""

--- a/crates/wdl-grammar/tests/parsing/missing-brace/source.wdl
+++ b/crates/wdl-grammar/tests/parsing/missing-brace/source.wdl
@@ -15,3 +15,19 @@ task bar {
     input {
     output {
 }
+
+task baz {
+    meta {
+        foo: {
+            bar: {}
+}
+
+task qux {
+    hints {
+        inputs: {
+            foo: {
+                bar: {
+                    baz: {
+                        qux: {
+                            quux: {
+}

--- a/crates/wdl-grammar/tests/parsing/unterminated-metadata-string/source.errors
+++ b/crates/wdl-grammar/tests/parsing/unterminated-metadata-string/source.errors
@@ -1,15 +1,14 @@
+error: expected `{`, but found end of input
+  ┌─ tests/parsing/unterminated-metadata-string/source.wdl:5:11
+  │
+5 │ task test {
+  │           ^ unclosed delimiter
+6 │     meta {
+  │          - unclosed delimiter
+
 error: an unterminated string was encountered
   ┌─ tests/parsing/unterminated-metadata-string/source.wdl:8:12
   │
 8 │         a: 'unterminated
   │            ^ this quote is not matched
-
-error: expected `}`, but found end of input
-   ┌─ tests/parsing/unterminated-metadata-string/source.wdl:11:1
-   │
- 6 │     meta {
-   │          - this `{` is not matched
-   ·
-11 │ 
-   │ ^ unexpected end of input
 

--- a/crates/wdl-grammar/tests/parsing/unterminated-metadata-string/source.errors
+++ b/crates/wdl-grammar/tests/parsing/unterminated-metadata-string/source.errors
@@ -1,4 +1,4 @@
-error: expected `{`, but found end of input
+error: expected `}`, but found end of input
   ┌─ tests/parsing/unterminated-metadata-string/source.wdl:5:11
   │
 5 │ task test {


### PR DESCRIPTION
This adds more context to unclosed brace diagnostics, pretty much doing the exact same thing as `rustc`.

For the following:

```wdl
version 1.3

task foo {
    input {
        Map[String, Array[Int] foo
}
```

Before we produced:

```wdl
error: expected `]`, but found identifier
  ┌─ tmp.wdl:5:32
  │
5 │         Map[String, Array[Int] foo
  │            -                   ^^^ unexpected identifier
  │            │                    
  │            this `[` is not matched

error: expected `}`, but found end of input
  ┌─ tmp.wdl:7:1
  │
3 │ task foo {
  │          - this `{` is not matched
  ·
7 │ 
  │ ^ unexpected end of input

error: failing due to 2 errors
```

With this, it now produces:

```wdl
error: expected `{`, but found end of input
  ┌─ tmp.wdl:3:10
  │
3 │ task foo {
  │          ^ unclosed delimiter
4 │     input {
  │           - this delimiter might not be properly closed...
5 │         Map[String, Array[Int] foo
6 │ }
  │ - ...as it matches this but it has different indentation

error: expected `]`, but found identifier
  ┌─ tmp.wdl:5:12
  │
5 │         Map[String, Array[Int] foo
  │            ^             -   - --- unexpected identifier
  │            │             │   │  
  │            │             │   ...matches this closing brace
  │            │             this opening brace...
  │            this `[` is not matched

error: failing due to 2 errors
```

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
