### PR TITLE
Feat(metrics): Bringing OTEL to Sprocket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,11 +324,38 @@ dependencies = [
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower 0.5.3",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -316,7 +365,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -327,10 +376,30 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2383,6 +2452,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,7 +2481,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3056,6 +3138,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -3381,6 +3469,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-otlp"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91cf61a1868dacc576bf2b2a1c3e9ab150af7272909e80085c3173384fe11f76"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
 name = "opentelemetry-prometheus"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3392,6 +3498,18 @@ dependencies = [
  "prometheus",
  "protobuf",
  "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e05acbfada5ec79023c85368af14abd0b307c015e9064d249b2a950ef459a6"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -3871,6 +3989,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "protobuf"
 version = "2.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3986,7 +4127,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4024,7 +4165,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4252,7 +4393,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -4296,7 +4437,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -5059,6 +5200,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -5101,7 +5252,7 @@ version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "bon",
  "chrono",
  "clap",
@@ -5123,6 +5274,7 @@ dependencies = [
  "nonempty",
  "opener",
  "opentelemetry",
+ "opentelemetry-otlp",
  "opentelemetry-prometheus",
  "opentelemetry_sdk",
  "path-clean",
@@ -5148,7 +5300,7 @@ dependencies = [
  "tokio-retry2 0.9.1",
  "tokio-util",
  "toml-spanner",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tracing",
  "tracing-indicatif",
@@ -5846,7 +5998,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -6032,6 +6184,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d282ade6016312faf3e41e57ebbba0c073e4056dab1232ab1cb624199648f8ed"
 
 [[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.7.9",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6069,7 +6271,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6343,7 +6545,7 @@ version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
- "axum",
+ "axum 0.8.9",
  "base64",
  "mime_guess",
  "regex",
@@ -6686,7 +6888,7 @@ dependencies = [
  "ammonia",
  "anyhow",
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "colored",
  "libtest-mimic",
  "maud",
@@ -6838,7 +7040,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,6 +2029,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "globset"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,6 +3367,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b834e966ea5e2d03dfe5f2253f03d22cce21403ee940265070eeee96cee0bcc"
+dependencies = [
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prometheus",
+ "protobuf",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.5",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "opool"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3799,6 +3854,27 @@ dependencies = [
  "syn 2.0.117",
  "version_check",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "ptr_meta"
@@ -5046,11 +5122,15 @@ dependencies = [
  "libtest-mimic",
  "nonempty",
  "opener",
+ "opentelemetry",
+ "opentelemetry-prometheus",
+ "opentelemetry_sdk",
  "path-clean",
  "pathdiff",
  "peak_alloc",
  "petname",
  "pretty_assertions",
+ "prometheus",
  "rand 0.9.4",
  "regex",
  "reqwest 0.13.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,6 +190,7 @@ itertools.workspace = true
 nonempty.workspace = true
 opener.workspace = true
 opentelemetry = { version = "0.27", features = ["metrics"], optional = true }
+opentelemetry-otlp = { version = "0.27", default-features = false, features = ["metrics", "grpc-tonic"], optional = true }
 opentelemetry-prometheus = { version = "0.27", optional = true }
 opentelemetry_sdk = { version = "0.27", features = ["metrics", "rt-tokio"], optional = true }
 path-clean.workspace = true
@@ -233,6 +234,7 @@ metrics = [
     "dep:opentelemetry",
     "dep:opentelemetry_sdk",
     "dep:opentelemetry-prometheus",
+    "dep:opentelemetry-otlp",
     "dep:prometheus",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,11 +189,15 @@ indicatif.workspace = true
 itertools.workspace = true
 nonempty.workspace = true
 opener.workspace = true
+opentelemetry = { version = "0.27", features = ["metrics"], optional = true }
+opentelemetry-prometheus = { version = "0.27", optional = true }
+opentelemetry_sdk = { version = "0.27", features = ["metrics", "rt-tokio"], optional = true }
 path-clean.workspace = true
 pathdiff.workspace = true
 peak_alloc.workspace = true
 petname.workspace = true
 pretty_assertions.workspace = true
+prometheus = { version = "0.13", optional = true }
 rand.workspace = true
 regex.workspace = true
 reqwest.workspace = true
@@ -222,6 +226,15 @@ walkdir.workspace = true
 wdl.workspace = true
 wdl-modules.workspace = true
 whoami.workspace = true
+
+[features]
+# OpenTelemetry metrics for WDL execution (off by default; pulls the OTEL stack).
+metrics = [
+    "dep:opentelemetry",
+    "dep:opentelemetry_sdk",
+    "dep:opentelemetry-prometheus",
+    "dep:prometheus",
+]
 
 [dev-dependencies]
 criterion = { workspace = true, features = ["async_tokio"] }

--- a/crates/wdl-engine/src/eval.rs
+++ b/crates/wdl-engine/src/eval.rs
@@ -330,6 +330,8 @@ pub enum EngineEvent {
     ReusedCachedExecutionResult {
         /// The id of the task that reused a cached execution result.
         id: String,
+        /// The WDL task name (un-mangled, e.g. `align`).
+        name: String,
     },
     /// A locally running task has been parked by the engine due to insufficient
     /// resources.
@@ -337,6 +339,27 @@ pub enum EngineEvent {
     /// A locally running task has been unparked by the engine.
     TaskUnparked {
         /// Whether or not the task was unparked due to being canceled.
+        canceled: bool,
+    },
+    /// A WDL task execution attempt has started (one per attempt).
+    ///
+    /// Carries structured identity directly from the engine, so consumers need
+    /// not parse the backend's mangled task id.
+    WdlTaskStarted {
+        /// The full task id for this attempt (e.g. `align-0`).
+        id: String,
+        /// The WDL task name (un-mangled, e.g. `align`).
+        name: String,
+    },
+    /// A WDL task execution attempt has finished (one per attempt).
+    WdlTaskCompleted {
+        /// The full task id for this attempt (e.g. `align-0`).
+        id: String,
+        /// The WDL task name (un-mangled, e.g. `align`).
+        name: String,
+        /// The process exit code, if the attempt produced one.
+        exit_code: Option<i32>,
+        /// Whether the attempt was canceled rather than run to completion.
         canceled: bool,
     },
 }

--- a/crates/wdl-engine/src/eval.rs
+++ b/crates/wdl-engine/src/eval.rs
@@ -362,6 +362,18 @@ pub enum EngineEvent {
         /// Whether the attempt was canceled rather than run to completion.
         canceled: bool,
     },
+    /// A workflow has started evaluating.
+    WorkflowStarted {
+        /// The workflow name.
+        name: String,
+    },
+    /// A workflow has finished evaluating.
+    WorkflowCompleted {
+        /// The workflow name.
+        name: String,
+        /// The terminal status: `completed`, `failed`, or `canceled`.
+        status: String,
+    },
 }
 
 /// Represents events that may be sent during WDL evaluation.

--- a/crates/wdl-engine/src/eval/v1/task.rs
+++ b/crates/wdl-engine/src/eval/v1/task.rs
@@ -852,6 +852,7 @@ impl Evaluator {
                         if let Some(sender) = &self.events {
                             let _ = sender.send(EngineEvent::ReusedCachedExecutionResult {
                                 id: id.to_string(),
+                                name: state.task.name().to_string(),
                             });
                         }
 
@@ -890,6 +891,16 @@ impl Evaluator {
                     attempt_dir.push("attempts");
                     attempt_dir.push(attempt.to_string());
 
+                    // Emit a structured task-started event (one per attempt) so
+                    // consumers get the un-mangled task name without parsing the
+                    // backend's mangled id.
+                    if let Some(sender) = &self.events {
+                        let _ = sender.send(EngineEvent::WdlTaskStarted {
+                            id: id.to_string(),
+                            name: state.task.name().to_string(),
+                        });
+                    }
+
                     match self
                         .backend
                         .execute(
@@ -909,9 +920,37 @@ impl Evaluator {
                         )
                         .await
                     {
-                        Ok(None) => return Err(EvaluationError::Canceled),
-                        Ok(Some(result)) => result,
+                        Ok(None) => {
+                            if let Some(sender) = &self.events {
+                                let _ = sender.send(EngineEvent::WdlTaskCompleted {
+                                    id: id.to_string(),
+                                    name: state.task.name().to_string(),
+                                    exit_code: None,
+                                    canceled: true,
+                                });
+                            }
+                            return Err(EvaluationError::Canceled);
+                        }
+                        Ok(Some(result)) => {
+                            if let Some(sender) = &self.events {
+                                let _ = sender.send(EngineEvent::WdlTaskCompleted {
+                                    id: id.to_string(),
+                                    name: state.task.name().to_string(),
+                                    exit_code: Some(result.exit_code),
+                                    canceled: false,
+                                });
+                            }
+                            result
+                        }
                         Err(e) => {
+                            if let Some(sender) = &self.events {
+                                let _ = sender.send(EngineEvent::WdlTaskCompleted {
+                                    id: id.to_string(),
+                                    name: state.task.name().to_string(),
+                                    exit_code: None,
+                                    canceled: false,
+                                });
+                            }
                             return Err(EvaluationError::new(
                                 state.document.clone(),
                                 task_execution_failed(&e, task.name(), id, task.name_span()),

--- a/crates/wdl-engine/src/eval/v1/workflow.rs
+++ b/crates/wdl-engine/src/eval/v1/workflow.rs
@@ -62,6 +62,7 @@ use crate::CallLocation;
 use crate::CallValue;
 use crate::CancellationContextState;
 use crate::Coercible;
+use crate::EngineEvent;
 use crate::EvaluationContext;
 use crate::EvaluationError;
 use crate::EvaluationPath;
@@ -621,13 +622,36 @@ impl Evaluator {
             return Err(anyhow!("cannot evaluate a document with errors").into());
         }
 
+        // Announce the workflow boundary so observers (metrics, traces) can time
+        // it without a CLI-side stopwatch.
+        if let Some(sender) = &self.events {
+            let _ = sender.send(EngineEvent::WorkflowStarted {
+                name: workflow.name().to_string(),
+            });
+        }
+
         let result = self
             .perform_workflow_evaluation(document, inputs, eval_root_dir.as_ref(), workflow.name())
             .await;
 
-        if self.cancellation.user_canceled()
-            && self.cancellation.state() == CancellationContextState::Canceling
-        {
+        let canceled = self.cancellation.user_canceled()
+            && self.cancellation.state() == CancellationContextState::Canceling;
+
+        if let Some(sender) = &self.events {
+            let status = if canceled {
+                "canceled"
+            } else if result.is_ok() {
+                "completed"
+            } else {
+                "failed"
+            };
+            let _ = sender.send(EngineEvent::WorkflowCompleted {
+                name: workflow.name().to_string(),
+                status: status.to_string(),
+            });
+        }
+
+        if canceled {
             return Err(EvaluationError::Canceled);
         }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -211,6 +211,15 @@ pub struct Args {
     #[cfg(feature = "metrics")]
     #[clap(long, value_name = "ADDR")]
     pub metrics_addr: Option<String>,
+
+    /// Push OpenTelemetry metrics for this run to an OTLP endpoint, e.g.
+    /// `http://localhost:4317` (requires the `metrics` build feature).
+    ///
+    /// Unlike `--metrics-addr`, push reliably delivers terminal workflow-summary
+    /// metrics (flushed on exit), so it is preferred for short one-shot runs.
+    #[cfg(feature = "metrics")]
+    #[clap(long, value_name = "ENDPOINT")]
+    pub metrics_otlp: Option<String>,
 }
 
 impl Args {
@@ -762,17 +771,19 @@ pub async fn run(
     // same broadcast channels BEFORE `events` is moved into execute_target.
     // workflow_name/duration aren't in the events, so they're supplied here.
     #[cfg(feature = "metrics")]
-    let wdl_metrics = match &args.metrics_addr {
-        Some(addr) => {
-            let m = crate::metrics_otel::WdlMetrics::init(addr)?;
-            m.spawn_subscriber(
-                target.name().to_string(),
-                ctx.run_id.to_string(),
-                events.subscribe_engine().expect("should have engine events"),
-            );
-            Some(m)
-        }
-        None => None,
+    let wdl_metrics = if args.metrics_addr.is_some() || args.metrics_otlp.is_some() {
+        let m = crate::metrics_otel::WdlMetrics::init(
+            args.metrics_addr.as_deref(),
+            args.metrics_otlp.as_deref(),
+        )?;
+        m.spawn_subscriber(
+            target.name().to_string(),
+            ctx.run_id.to_string(),
+            events.subscribe_engine().expect("should have engine events"),
+        );
+        Some(m)
+    } else {
+        None
     };
     #[cfg(feature = "metrics")]
     let wf_start = std::time::Instant::now();
@@ -836,6 +847,8 @@ pub async fn run(
                         status,
                         wf_start.elapsed().as_secs_f64(),
                     );
+                    // Flush so OTLP push delivers the terminal metrics before exit.
+                    m.shutdown();
                 }
 
                 return match res {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -545,9 +545,12 @@ async fn progress(
                                 state.canceled += 1;
                             }
                         }
-                        // Structured task lifecycle events are consumed by the
-                        // metrics exporter, not the progress bar.
-                        EngineEvent::WdlTaskStarted { .. } | EngineEvent::WdlTaskCompleted { .. } => {}
+                        // Structured task/workflow lifecycle events are consumed
+                        // by the metrics exporter, not the progress bar.
+                        EngineEvent::WdlTaskStarted { .. }
+                        | EngineEvent::WdlTaskCompleted { .. }
+                        | EngineEvent::WorkflowStarted { .. }
+                        | EngineEvent::WorkflowCompleted { .. } => {}
                     };
 
                     progress_bar.pb_set_message(&message(&state));
@@ -771,22 +774,20 @@ pub async fn run(
     // same broadcast channels BEFORE `events` is moved into execute_target.
     // workflow_name/duration aren't in the events, so they're supplied here.
     #[cfg(feature = "metrics")]
-    let wdl_metrics = if args.metrics_addr.is_some() || args.metrics_otlp.is_some() {
+    let (wdl_metrics, mut metrics_task) = if args.metrics_addr.is_some() || args.metrics_otlp.is_some() {
         let m = crate::metrics_otel::WdlMetrics::init(
             args.metrics_addr.as_deref(),
             args.metrics_otlp.as_deref(),
         )?;
-        m.spawn_subscriber(
+        let handle = m.spawn_subscriber(
             target.name().to_string(),
             ctx.run_id.to_string(),
             events.subscribe_engine().expect("should have engine events"),
         );
-        Some(m)
+        (Some(m), Some(handle))
     } else {
-        None
+        (None, None)
     };
-    #[cfg(feature = "metrics")]
-    let wf_start = std::time::Instant::now();
 
     // Since CLI pre-resolves paths via `into_resolved_json()`, the `base_dir`
     // passed to `execute_target()` is not used for path resolution. We pass
@@ -836,18 +837,12 @@ pub async fn run(
 
                 #[cfg(feature = "metrics")]
                 if let Some(m) = &wdl_metrics {
-                    let status = match &res {
-                        Ok(()) => "completed",
-                        Err(EvaluationError::Canceled) => "canceled",
-                        Err(_) => "failed",
-                    };
-                    m.record_workflow(
-                        target.name(),
-                        &ctx.run_id.to_string(),
-                        status,
-                        wf_start.elapsed().as_secs_f64(),
-                    );
-                    // Flush so OTLP push delivers the terminal metrics before exit.
+                    // Execution is done, so the engine event senders have dropped;
+                    // drain the subscriber so all metrics (incl. the workflow
+                    // summary) are recorded, then flush the pipeline (OTLP push).
+                    if let Some(handle) = metrics_task.take() {
+                        let _ = handle.await;
+                    }
                     m.shutdown();
                 }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -200,6 +200,17 @@ pub struct Args {
     /// Optional suffix to append to the run directory name.
     #[clap(long, value_name = "SUFFIX")]
     pub suffix: Option<String>,
+
+    /// Expose Prometheus metrics for this run at the given address, e.g.
+    /// `127.0.0.1:9464` (requires the `metrics` build feature).
+    ///
+    /// Pull-based: a scraper must collect from the endpoint while the process is
+    /// alive. Best for long-running workflows. Terminal workflow-summary metrics
+    /// of a short run may be missed before exit; OTLP push (planned) addresses
+    /// that.
+    #[cfg(feature = "metrics")]
+    #[clap(long, value_name = "ADDR")]
+    pub metrics_addr: Option<String>,
 }
 
 impl Args {
@@ -744,6 +755,27 @@ pub async fn run(
         cancellation.first(),
     ));
 
+    // OTEL WDL metrics subscriber: a sibling of progress(), subscribing to the
+    // same broadcast channels BEFORE `events` is moved into execute_target.
+    // workflow_name/duration aren't in the events, so they're supplied here.
+    #[cfg(feature = "metrics")]
+    let wdl_metrics = match &args.metrics_addr {
+        Some(addr) => {
+            let m = crate::metrics_otel::WdlMetrics::init(addr)?;
+            m.spawn_subscriber(
+                target.name().to_string(),
+                events
+                    .subscribe_crankshaft()
+                    .expect("should have Crankshaft events"),
+                events.subscribe_engine().expect("should have engine events"),
+            );
+            Some(m)
+        }
+        None => None,
+    };
+    #[cfg(feature = "metrics")]
+    let wf_start = std::time::Instant::now();
+
     // Since CLI pre-resolves paths via `into_resolved_json()`, the `base_dir`
     // passed to `execute_target()` is not used for path resolution. We pass
     // CWD as a placeholder.
@@ -789,6 +821,16 @@ pub async fn run(
             res = &mut execute => {
                 let _ = transfer_progress.await;
                 let _ = crankshaft_progress.await;
+
+                #[cfg(feature = "metrics")]
+                if let Some(m) = &wdl_metrics {
+                    let status = match &res {
+                        Ok(()) => "completed",
+                        Err(EvaluationError::Canceled) => "canceled",
+                        Err(_) => "failed",
+                    };
+                    m.record_workflow(target.name(), status, wf_start.elapsed().as_secs_f64());
+                }
 
                 return match res {
                     Ok(()) => {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -536,6 +536,9 @@ async fn progress(
                                 state.canceled += 1;
                             }
                         }
+                        // Structured task lifecycle events are consumed by the
+                        // metrics exporter, not the progress bar.
+                        EngineEvent::WdlTaskStarted { .. } | EngineEvent::WdlTaskCompleted { .. } => {}
                     };
 
                     progress_bar.pb_set_message(&message(&state));
@@ -764,9 +767,7 @@ pub async fn run(
             let m = crate::metrics_otel::WdlMetrics::init(addr)?;
             m.spawn_subscriber(
                 target.name().to_string(),
-                events
-                    .subscribe_crankshaft()
-                    .expect("should have Crankshaft events"),
+                ctx.run_id.to_string(),
                 events.subscribe_engine().expect("should have engine events"),
             );
             Some(m)
@@ -829,7 +830,12 @@ pub async fn run(
                         Err(EvaluationError::Canceled) => "canceled",
                         Err(_) => "failed",
                     };
-                    m.record_workflow(target.name(), status, wf_start.elapsed().as_secs_f64());
+                    m.record_workflow(
+                        target.name(),
+                        &ctx.run_id.to_string(),
+                        status,
+                        wf_start.elapsed().as_secs_f64(),
+                    );
                 }
 
                 return match res {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,9 @@ pub mod analysis;
 pub mod commands;
 mod config;
 mod eval;
+/// OpenTelemetry metrics for WDL execution (enabled by the `metrics` feature).
+#[cfg(feature = "metrics")]
+pub mod metrics_otel;
 mod inputs;
 pub mod server;
 pub mod system;

--- a/src/metrics_otel.rs
+++ b/src/metrics_otel.rs
@@ -1,9 +1,12 @@
 //! OpenTelemetry metrics for WDL workflow/task execution.
 //!
 //! Enabled by the `metrics` cargo feature and activated at runtime by the
-//! `run --metrics-addr` flag. Rides `wdl-engine`'s existing broadcast event
-//! channels as a sibling of the run progress consumer (no execution-path
+//! `run --metrics-addr` flag. Subscribes to `wdl-engine`'s structured event
+//! channel as a sibling of the run progress consumer (no execution-path
 //! changes) and exposes a Prometheus `/metrics` endpoint.
+//!
+//! Task identity comes from the engine's structured `WdlTask*` events (the
+//! un-mangled WDL task name) — no parsing of backend task ids.
 
 use std::collections::HashMap;
 use std::io::Read as _;
@@ -13,7 +16,6 @@ use std::time::Instant;
 
 use anyhow::Context as _;
 use anyhow::Result;
-use crankshaft::events::Event as CrankshaftEvent;
 use opentelemetry::KeyValue;
 use opentelemetry::metrics::Counter;
 use opentelemetry::metrics::Histogram;
@@ -28,13 +30,24 @@ use tokio::sync::broadcast::Receiver;
 use tokio::sync::broadcast::error::RecvError;
 use wdl::engine::EngineEvent;
 
+/// Maps a task attempt's outcome to the `state` metric label.
+fn task_state(exit_code: Option<i32>, canceled: bool) -> &'static str {
+    if canceled {
+        "canceled"
+    } else if exit_code == Some(0) {
+        "completed"
+    } else {
+        "failed"
+    }
+}
+
 /// OpenTelemetry instruments for WDL execution. Cheap to clone (instruments are
 /// `Arc`-backed); the owning provider is held to keep them alive.
 #[derive(Clone)]
 pub struct WdlMetrics {
     /// Owns the metric pipeline; held to keep the instruments alive.
     _provider: SdkMeterProvider,
-    /// Tasks reaching a terminal state, by workflow/task/state/kind.
+    /// Task attempts reaching a terminal state, by workflow/task/state.
     tasks: Counter<u64>,
     /// Wall-clock duration of a task attempt.
     task_duration: Histogram<f64>,
@@ -73,7 +86,7 @@ impl WdlMetrics {
         let metrics = Self {
             tasks: meter
                 .u64_counter("sprocket_wdl_tasks")
-                .with_description("WDL tasks reaching a terminal state")
+                .with_description("WDL task attempts reaching a terminal state")
                 .build(),
             task_duration: meter
                 .f64_histogram("sprocket_wdl_task_duration_seconds")
@@ -109,129 +122,89 @@ impl WdlMetrics {
 
     /// Records the result of a whole workflow run (timed at the run.rs call site,
     /// since the engine emits no workflow-level lifecycle event).
-    pub fn record_workflow(&self, workflow: &str, status: &str, duration_secs: f64) {
+    pub fn record_workflow(&self, workflow: &str, workflow_id: &str, status: &str, duration_secs: f64) {
         self.workflow_runs.add(1, &[
             KeyValue::new("workflow", workflow.to_string()),
+            KeyValue::new("workflow_id", workflow_id.to_string()),
             KeyValue::new("status", status.to_string()),
         ]);
-        self.workflow_duration
-            .record(duration_secs, &[KeyValue::new("workflow", workflow.to_string())]);
+        self.workflow_duration.record(duration_secs, &[
+            KeyValue::new("workflow", workflow.to_string()),
+            KeyValue::new("workflow_id", workflow_id.to_string()),
+        ]);
     }
 
-    /// Spawns the event subscriber (a sibling of `run::progress`). `workflow`
-    /// labels every task metric (low cardinality).
+    /// Spawns the engine-event subscriber (a sibling of `run::progress`).
+    /// `workflow`/`workflow_id` label every task metric; `workflow_id` is
+    /// high-cardinality by design (per-run drilldown).
     pub fn spawn_subscriber(
         &self,
         workflow: String,
-        mut crankshaft: Receiver<CrankshaftEvent>,
+        workflow_id: String,
         mut engine: Receiver<EngineEvent>,
     ) {
         let m = self.clone();
         tokio::spawn(async move {
-            // crankshaft task id -> (start instant, task_name, kind)
-            let mut running: HashMap<u64, (Instant, String, &'static str)> = HashMap::new();
-            let mut names: HashMap<u64, (String, &'static str)> = HashMap::new();
+            // task attempt id -> (start instant, task name)
+            let mut running: HashMap<String, (Instant, String)> = HashMap::new();
             let mut dropped: u64 = 0;
-
             loop {
-                tokio::select! {
-                    r = crankshaft.recv() => match r {
-                        Ok(ev) => m.on_crankshaft(ev, &workflow, &mut names, &mut running),
-                        Err(RecvError::Closed) => break,
-                        Err(RecvError::Lagged(n)) => {
-                            dropped += n;
-                            tracing::warn!("WDL metrics subscriber lagged; dropped {n} crankshaft events ({dropped} total)");
-                        }
-                    },
-                    r = engine.recv() => match r {
-                        Ok(ev) => m.on_engine(ev, &workflow),
-                        Err(RecvError::Closed) => {}
-                        Err(RecvError::Lagged(n)) => {
-                            dropped += n;
-                            tracing::warn!("WDL metrics subscriber lagged; dropped {n} engine events ({dropped} total)");
-                        }
-                    },
+                match engine.recv().await {
+                    Ok(ev) => m.on_engine(ev, &workflow, &workflow_id, &mut running),
+                    Err(RecvError::Closed) => break,
+                    Err(RecvError::Lagged(n)) => {
+                        dropped += n;
+                        tracing::warn!("WDL metrics subscriber lagged; dropped {n} events ({dropped} total)");
+                    }
                 }
             }
         });
     }
 
-    /// Updates instruments from a crankshaft task lifecycle event.
-    fn on_crankshaft(
+    /// Updates instruments from a structured wdl-engine event.
+    fn on_engine(
         &self,
-        ev: CrankshaftEvent,
+        ev: EngineEvent,
         workflow: &str,
-        names: &mut HashMap<u64, (String, &'static str)>,
-        running: &mut HashMap<u64, (Instant, String, &'static str)>,
+        workflow_id: &str,
+        running: &mut HashMap<String, (Instant, String)>,
     ) {
+        let base = |task: &str| {
+            vec![
+                KeyValue::new("workflow", workflow.to_string()),
+                KeyValue::new("workflow_id", workflow_id.to_string()),
+                KeyValue::new("task", task.to_string()),
+            ]
+        };
         match ev {
-            CrankshaftEvent::TaskCreated { id, name, .. } => {
-                let (task, _shard) = split_shard(&name.to_string());
-                let kind = classify_kind(&task);
-                names.insert(id, (task, kind));
+            EngineEvent::WdlTaskStarted { id, name } => {
+                self.in_flight.add(1, &base(&name));
+                running.insert(id, (Instant::now(), name));
             }
-            CrankshaftEvent::TaskStarted { id } => {
-                let (task, kind) = names
-                    .get(&id)
-                    .cloned()
-                    .unwrap_or_else(|| ("unknown".into(), "wdl"));
-                self.in_flight.add(1, &[
-                    KeyValue::new("workflow", workflow.to_string()),
-                    KeyValue::new("task", task.clone()),
-                ]);
-                running.insert(id, (Instant::now(), task, kind));
+            EngineEvent::WdlTaskCompleted { id, name, exit_code, canceled } => {
+                let start = running.remove(&id).map(|(s, _)| s).unwrap_or_else(Instant::now);
+                self.in_flight.add(-1, &base(&name));
+                let mut attrs = base(&name);
+                attrs.push(KeyValue::new("state", task_state(exit_code, canceled)));
+                self.tasks.add(1, &attrs);
+                self.task_duration.record(start.elapsed().as_secs_f64(), &attrs);
             }
-            CrankshaftEvent::TaskCompleted { id, .. } => self.terminal(id, "completed", workflow, running),
-            CrankshaftEvent::TaskFailed { id, .. } => self.terminal(id, "failed", workflow, running),
-            CrankshaftEvent::TaskPreempted { id } => self.terminal(id, "preempted", workflow, running),
-            CrankshaftEvent::TaskCanceled { id } => self.terminal(id, "canceled", workflow, running),
-            _ => {}
-        }
-    }
-
-    /// Updates instruments from a wdl-engine event (cache hits, parking).
-    fn on_engine(&self, ev: EngineEvent, workflow: &str) {
-        match ev {
-            EngineEvent::ReusedCachedExecutionResult { id } => {
-                let (task, _shard) = split_shard(&id);
-                self.cache_hits.add(1, &[
-                    KeyValue::new("workflow", workflow.to_string()),
-                    KeyValue::new("task", task),
-                ]);
+            EngineEvent::ReusedCachedExecutionResult { name, .. } => {
+                self.cache_hits.add(1, &base(&name));
             }
             EngineEvent::TaskParked => {
-                self.parked.add(1, &[KeyValue::new("workflow", workflow.to_string())]);
+                self.parked.add(1, &[
+                    KeyValue::new("workflow", workflow.to_string()),
+                    KeyValue::new("workflow_id", workflow_id.to_string()),
+                ]);
             }
             EngineEvent::TaskUnparked { .. } => {
-                self.parked.add(-1, &[KeyValue::new("workflow", workflow.to_string())]);
+                self.parked.add(-1, &[
+                    KeyValue::new("workflow", workflow.to_string()),
+                    KeyValue::new("workflow_id", workflow_id.to_string()),
+                ]);
             }
         }
-    }
-
-    /// Records a task reaching a terminal `state`: decrement in-flight, bump the
-    /// counter, and record the attempt duration.
-    fn terminal(
-        &self,
-        id: u64,
-        state: &str,
-        workflow: &str,
-        running: &mut HashMap<u64, (Instant, String, &'static str)>,
-    ) {
-        let (start, task, kind) = running
-            .remove(&id)
-            .unwrap_or_else(|| (Instant::now(), "unknown".into(), "wdl"));
-        self.in_flight.add(-1, &[
-            KeyValue::new("workflow", workflow.to_string()),
-            KeyValue::new("task", task.clone()),
-        ]);
-        let attrs = [
-            KeyValue::new("workflow", workflow.to_string()),
-            KeyValue::new("task", task),
-            KeyValue::new("state", state.to_string()),
-            KeyValue::new("kind", kind),
-        ];
-        self.tasks.add(1, &attrs);
-        self.task_duration.record(start.elapsed().as_secs_f64(), &attrs);
     }
 }
 
@@ -256,73 +229,16 @@ fn start_metrics_server(addr: &str, registry: Registry) -> Result<()> {
     Ok(())
 }
 
-/// Splits a crankshaft task id into a stable `task_name` and an optional shard.
-///
-/// The live id format is `{task}-[{scatter_index}-...]{nonce}` (e.g.
-/// `align-0-Urx5FjZomn5B`): a trailing uniqueness nonce, with scatter index
-/// segments before it. We drop the nonce, then strip trailing purely-numeric
-/// shard segments, so scatter shards aggregate under one `task_name`.
-///
-/// NOTE: interim — this string-munging is brittle; the production fix is
-/// structured identity on the engine event (see the implementation spec).
-fn split_shard(name: &str) -> (String, Option<String>) {
-    let mut parts: Vec<&str> = name.split('-').collect();
-    // Drop the trailing crankshaft uniqueness nonce (always the last segment).
-    if parts.len() > 1 {
-        parts.pop();
-    }
-    // Strip trailing purely-numeric scatter-index segments.
-    let mut split = parts.len();
-    while split > 1
-        && !parts[split - 1].is_empty()
-        && parts[split - 1].bytes().all(|b| b.is_ascii_digit())
-    {
-        split -= 1;
-    }
-    let task = parts[..split].join("-");
-    let shard = if split < parts.len() {
-        Some(parts[split..].join("-"))
-    } else {
-        None
-    };
-    (task, shard)
-}
-
-/// Classifies a task as a WDL task (`wdl`) or a backend-injected helper
-/// (`internal`, e.g. `docker-chown`), for the metric `kind` label.
-fn classify_kind(task_name: &str) -> &'static str {
-    // Interim heuristic: backend-injected helper tasks use a `docker-` prefix.
-    // The robust signal will come from structured engine identity (spec PR3).
-    if task_name.starts_with("docker-") {
-        "internal"
-    } else {
-        "wdl"
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::classify_kind;
-    use super::split_shard;
+    use super::task_state;
 
     #[test]
-    fn split_shard_extracts_task_and_shard_from_real_ids() {
-        // real formats observed against live sprocket
-        assert_eq!(split_shard("align-0-Urx5FjZomn5B"), ("align".into(), Some("0".into())));
-        assert_eq!(
-            split_shard("call_variants-3-mJnJUlEMv8J7"),
-            ("call_variants".into(), Some("3".into()))
-        );
-        // internal helper whose base name contains a hyphen, no scatter
-        assert_eq!(split_shard("docker-chown-5jC5YIQHhXIK"), ("docker-chown".into(), None));
-        // nested scatter: drop nonce, strip both numeric levels
-        assert_eq!(split_shard("inner-0-1-NONCEabcd1234"), ("inner".into(), Some("0-1".into())));
-    }
-
-    #[test]
-    fn classify_kind_distinguishes_internal_helpers() {
-        assert_eq!(classify_kind("align"), "wdl");
-        assert_eq!(classify_kind("haplotype_caller"), "wdl");
-        assert_eq!(classify_kind("docker-chown"), "internal");
+    fn task_state_maps_outcomes() {
+        assert_eq!(task_state(Some(0), false), "completed");
+        assert_eq!(task_state(Some(1), false), "failed");
+        assert_eq!(task_state(None, false), "failed");
+        assert_eq!(task_state(None, true), "canceled");
+        assert_eq!(task_state(Some(0), true), "canceled");
     }
 }

--- a/src/metrics_otel.rs
+++ b/src/metrics_otel.rs
@@ -32,6 +32,7 @@ use prometheus::Registry;
 use prometheus::TextEncoder;
 use tokio::sync::broadcast::Receiver;
 use tokio::sync::broadcast::error::RecvError;
+use tokio::task::JoinHandle;
 use wdl::engine::EngineEvent;
 
 /// Maps a task attempt's outcome to the `state` metric label.
@@ -159,37 +160,27 @@ impl WdlMetrics {
         }
     }
 
-    /// Records the result of a whole workflow run (timed at the run.rs call site,
-    /// since the engine emits no workflow-level lifecycle event).
-    pub fn record_workflow(&self, workflow: &str, workflow_id: &str, status: &str, duration_secs: f64) {
-        self.workflow_runs.add(1, &[
-            KeyValue::new("workflow", workflow.to_string()),
-            KeyValue::new("workflow_id", workflow_id.to_string()),
-            KeyValue::new("status", status.to_string()),
-        ]);
-        self.workflow_duration.record(duration_secs, &[
-            KeyValue::new("workflow", workflow.to_string()),
-            KeyValue::new("workflow_id", workflow_id.to_string()),
-        ]);
-    }
-
     /// Spawns the engine-event subscriber (a sibling of `run::progress`).
     /// `workflow`/`workflow_id` label every task metric; `workflow_id` is
-    /// high-cardinality by design (per-run drilldown).
+    /// high-cardinality by design (per-run drilldown). Returns a handle the
+    /// caller should await before [`Self::shutdown`] so all events are recorded
+    /// before the pipeline is flushed.
     pub fn spawn_subscriber(
         &self,
         workflow: String,
         workflow_id: String,
         mut engine: Receiver<EngineEvent>,
-    ) {
+    ) -> JoinHandle<()> {
         let m = self.clone();
         tokio::spawn(async move {
             // task attempt id -> (start instant, task name)
             let mut running: HashMap<String, (Instant, String)> = HashMap::new();
+            // workflow name -> start instant
+            let mut wf_running: HashMap<String, Instant> = HashMap::new();
             let mut dropped: u64 = 0;
             loop {
                 match engine.recv().await {
-                    Ok(ev) => m.on_engine(ev, &workflow, &workflow_id, &mut running),
+                    Ok(ev) => m.on_engine(ev, &workflow, &workflow_id, &mut running, &mut wf_running),
                     Err(RecvError::Closed) => break,
                     Err(RecvError::Lagged(n)) => {
                         dropped += n;
@@ -197,7 +188,7 @@ impl WdlMetrics {
                     }
                 }
             }
-        });
+        })
     }
 
     /// Updates instruments from a structured wdl-engine event.
@@ -207,6 +198,7 @@ impl WdlMetrics {
         workflow: &str,
         workflow_id: &str,
         running: &mut HashMap<String, (Instant, String)>,
+        wf_running: &mut HashMap<String, Instant>,
     ) {
         let base = |task: &str| {
             vec![
@@ -240,6 +232,24 @@ impl WdlMetrics {
             EngineEvent::TaskUnparked { .. } => {
                 self.parked.add(-1, &[
                     KeyValue::new("workflow", workflow.to_string()),
+                    KeyValue::new("workflow_id", workflow_id.to_string()),
+                ]);
+            }
+            EngineEvent::WorkflowStarted { name } => {
+                wf_running.insert(name, Instant::now());
+            }
+            EngineEvent::WorkflowCompleted { name, status } => {
+                let elapsed = wf_running
+                    .remove(&name)
+                    .map(|s| s.elapsed().as_secs_f64())
+                    .unwrap_or(0.0);
+                self.workflow_runs.add(1, &[
+                    KeyValue::new("workflow", name.clone()),
+                    KeyValue::new("workflow_id", workflow_id.to_string()),
+                    KeyValue::new("status", status),
+                ]);
+                self.workflow_duration.record(elapsed, &[
+                    KeyValue::new("workflow", name),
                     KeyValue::new("workflow_id", workflow_id.to_string()),
                 ]);
             }

--- a/src/metrics_otel.rs
+++ b/src/metrics_otel.rs
@@ -21,8 +21,12 @@ use opentelemetry::metrics::Counter;
 use opentelemetry::metrics::Histogram;
 use opentelemetry::metrics::MeterProvider as _;
 use opentelemetry::metrics::UpDownCounter;
+use opentelemetry_otlp::MetricExporter;
+use opentelemetry_otlp::WithExportConfig as _;
 use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::PeriodicReader;
 use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::runtime;
 use prometheus::Encoder as _;
 use prometheus::Registry;
 use prometheus::TextEncoder;
@@ -45,8 +49,8 @@ fn task_state(exit_code: Option<i32>, canceled: bool) -> &'static str {
 /// `Arc`-backed); the owning provider is held to keep them alive.
 #[derive(Clone)]
 pub struct WdlMetrics {
-    /// Owns the metric pipeline; held to keep the instruments alive.
-    _provider: SdkMeterProvider,
+    /// Owns the metric pipeline; held to keep instruments alive and to flush.
+    provider: SdkMeterProvider,
     /// Task attempts reaching a terminal state, by workflow/task/state.
     tasks: Counter<u64>,
     /// Wall-clock duration of a task attempt.
@@ -70,17 +74,39 @@ impl std::fmt::Debug for WdlMetrics {
 }
 
 impl WdlMetrics {
-    /// Initializes metrics and starts the Prometheus `/metrics` server at `addr`.
-    pub fn init(addr: &str) -> Result<Self> {
-        let registry = Registry::new();
-        let exporter = opentelemetry_prometheus::exporter()
-            .with_registry(registry.clone())
-            .build()
-            .context("failed to build the Prometheus exporter")?;
-        let provider = SdkMeterProvider::builder()
-            .with_reader(exporter)
-            .with_resource(Resource::new(vec![KeyValue::new("service.name", "sprocket")]))
-            .build();
+    /// Initializes metrics. With `pull_addr`, serves Prometheus `/metrics` at
+    /// that address (scrape model). With `otlp_endpoint`, pushes via OTLP to a
+    /// collector (e.g. `http://localhost:4317`) — the reliable path for short
+    /// runs, since [`Self::shutdown`] flushes on exit. At least one is required.
+    pub fn init(pull_addr: Option<&str>, otlp_endpoint: Option<&str>) -> Result<Self> {
+        let mut builder = SdkMeterProvider::builder()
+            .with_resource(Resource::new(vec![KeyValue::new("service.name", "sprocket")]));
+
+        // Pull: Prometheus `/metrics` endpoint.
+        let pull = match pull_addr {
+            Some(addr) => {
+                let registry = Registry::new();
+                let exporter = opentelemetry_prometheus::exporter()
+                    .with_registry(registry.clone())
+                    .build()
+                    .context("failed to build the Prometheus exporter")?;
+                builder = builder.with_reader(exporter);
+                Some((addr.to_string(), registry))
+            }
+            None => None,
+        };
+
+        // Push: OTLP exporter behind a periodic reader.
+        if let Some(endpoint) = otlp_endpoint {
+            let exporter = MetricExporter::builder()
+                .with_tonic()
+                .with_endpoint(endpoint)
+                .build()
+                .context("failed to build the OTLP metric exporter")?;
+            builder = builder.with_reader(PeriodicReader::builder(exporter, runtime::Tokio).build());
+        }
+
+        let provider = builder.build();
         let meter = provider.meter("sprocket");
 
         let metrics = Self {
@@ -112,12 +138,25 @@ impl WdlMetrics {
                 .f64_histogram("sprocket_wdl_workflow_duration_seconds")
                 .with_description("Wall-clock duration of a whole workflow run")
                 .build(),
-            _provider: provider,
+            provider,
         };
 
-        start_metrics_server(addr, registry)?;
-        tracing::info!("WDL metrics exposed at http://{addr}/metrics");
+        if let Some((addr, registry)) = pull {
+            start_metrics_server(&addr, registry)?;
+            tracing::info!("WDL metrics exposed at http://{addr}/metrics");
+        }
+        if let Some(endpoint) = otlp_endpoint {
+            tracing::info!("WDL metrics pushed via OTLP to {endpoint}");
+        }
         Ok(metrics)
+    }
+
+    /// Flushes and shuts down the metric pipeline. Call before exit so OTLP
+    /// push delivers the final (e.g. workflow-summary) measurements.
+    pub fn shutdown(&self) {
+        if let Err(e) = self.provider.shutdown() {
+            tracing::debug!("error shutting down WDL metrics: {e}");
+        }
     }
 
     /// Records the result of a whole workflow run (timed at the run.rs call site,

--- a/src/metrics_otel.rs
+++ b/src/metrics_otel.rs
@@ -1,0 +1,328 @@
+//! OpenTelemetry metrics for WDL workflow/task execution.
+//!
+//! Enabled by the `metrics` cargo feature and activated at runtime by the
+//! `run --metrics-addr` flag. Rides `wdl-engine`'s existing broadcast event
+//! channels as a sibling of the run progress consumer (no execution-path
+//! changes) and exposes a Prometheus `/metrics` endpoint.
+
+use std::collections::HashMap;
+use std::io::Read as _;
+use std::io::Write as _;
+use std::net::TcpListener;
+use std::time::Instant;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use crankshaft::events::Event as CrankshaftEvent;
+use opentelemetry::KeyValue;
+use opentelemetry::metrics::Counter;
+use opentelemetry::metrics::Histogram;
+use opentelemetry::metrics::MeterProvider as _;
+use opentelemetry::metrics::UpDownCounter;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use prometheus::Encoder as _;
+use prometheus::Registry;
+use prometheus::TextEncoder;
+use tokio::sync::broadcast::Receiver;
+use tokio::sync::broadcast::error::RecvError;
+use wdl::engine::EngineEvent;
+
+/// OpenTelemetry instruments for WDL execution. Cheap to clone (instruments are
+/// `Arc`-backed); the owning provider is held to keep them alive.
+#[derive(Clone)]
+pub struct WdlMetrics {
+    /// Owns the metric pipeline; held to keep the instruments alive.
+    _provider: SdkMeterProvider,
+    /// Tasks reaching a terminal state, by workflow/task/state/kind.
+    tasks: Counter<u64>,
+    /// Wall-clock duration of a task attempt.
+    task_duration: Histogram<f64>,
+    /// Tasks currently executing, by workflow/task.
+    in_flight: UpDownCounter<i64>,
+    /// Task executions served from the call cache.
+    cache_hits: Counter<u64>,
+    /// Tasks parked waiting on local resources.
+    parked: UpDownCounter<i64>,
+    /// Completed workflow runs, by workflow/status.
+    workflow_runs: Counter<u64>,
+    /// Wall-clock duration of a whole workflow run.
+    workflow_duration: Histogram<f64>,
+}
+
+impl std::fmt::Debug for WdlMetrics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("WdlMetrics")
+    }
+}
+
+impl WdlMetrics {
+    /// Initializes metrics and starts the Prometheus `/metrics` server at `addr`.
+    pub fn init(addr: &str) -> Result<Self> {
+        let registry = Registry::new();
+        let exporter = opentelemetry_prometheus::exporter()
+            .with_registry(registry.clone())
+            .build()
+            .context("failed to build the Prometheus exporter")?;
+        let provider = SdkMeterProvider::builder()
+            .with_reader(exporter)
+            .with_resource(Resource::new(vec![KeyValue::new("service.name", "sprocket")]))
+            .build();
+        let meter = provider.meter("sprocket");
+
+        let metrics = Self {
+            tasks: meter
+                .u64_counter("sprocket_wdl_tasks")
+                .with_description("WDL tasks reaching a terminal state")
+                .build(),
+            task_duration: meter
+                .f64_histogram("sprocket_wdl_task_duration_seconds")
+                .with_description("Wall-clock duration of a WDL task attempt")
+                .build(),
+            in_flight: meter
+                .i64_up_down_counter("sprocket_wdl_tasks_in_flight")
+                .with_description("WDL tasks currently executing")
+                .build(),
+            cache_hits: meter
+                .u64_counter("sprocket_wdl_cache_hits")
+                .with_description("Task executions served from the call cache")
+                .build(),
+            parked: meter
+                .i64_up_down_counter("sprocket_wdl_tasks_parked")
+                .with_description("Tasks parked waiting on local resources")
+                .build(),
+            workflow_runs: meter
+                .u64_counter("sprocket_wdl_workflow_runs")
+                .with_description("Completed workflow runs, by workflow and status")
+                .build(),
+            workflow_duration: meter
+                .f64_histogram("sprocket_wdl_workflow_duration_seconds")
+                .with_description("Wall-clock duration of a whole workflow run")
+                .build(),
+            _provider: provider,
+        };
+
+        start_metrics_server(addr, registry)?;
+        tracing::info!("WDL metrics exposed at http://{addr}/metrics");
+        Ok(metrics)
+    }
+
+    /// Records the result of a whole workflow run (timed at the run.rs call site,
+    /// since the engine emits no workflow-level lifecycle event).
+    pub fn record_workflow(&self, workflow: &str, status: &str, duration_secs: f64) {
+        self.workflow_runs.add(1, &[
+            KeyValue::new("workflow", workflow.to_string()),
+            KeyValue::new("status", status.to_string()),
+        ]);
+        self.workflow_duration
+            .record(duration_secs, &[KeyValue::new("workflow", workflow.to_string())]);
+    }
+
+    /// Spawns the event subscriber (a sibling of `run::progress`). `workflow`
+    /// labels every task metric (low cardinality).
+    pub fn spawn_subscriber(
+        &self,
+        workflow: String,
+        mut crankshaft: Receiver<CrankshaftEvent>,
+        mut engine: Receiver<EngineEvent>,
+    ) {
+        let m = self.clone();
+        tokio::spawn(async move {
+            // crankshaft task id -> (start instant, task_name, kind)
+            let mut running: HashMap<u64, (Instant, String, &'static str)> = HashMap::new();
+            let mut names: HashMap<u64, (String, &'static str)> = HashMap::new();
+            let mut dropped: u64 = 0;
+
+            loop {
+                tokio::select! {
+                    r = crankshaft.recv() => match r {
+                        Ok(ev) => m.on_crankshaft(ev, &workflow, &mut names, &mut running),
+                        Err(RecvError::Closed) => break,
+                        Err(RecvError::Lagged(n)) => {
+                            dropped += n;
+                            tracing::warn!("WDL metrics subscriber lagged; dropped {n} crankshaft events ({dropped} total)");
+                        }
+                    },
+                    r = engine.recv() => match r {
+                        Ok(ev) => m.on_engine(ev, &workflow),
+                        Err(RecvError::Closed) => {}
+                        Err(RecvError::Lagged(n)) => {
+                            dropped += n;
+                            tracing::warn!("WDL metrics subscriber lagged; dropped {n} engine events ({dropped} total)");
+                        }
+                    },
+                }
+            }
+        });
+    }
+
+    /// Updates instruments from a crankshaft task lifecycle event.
+    fn on_crankshaft(
+        &self,
+        ev: CrankshaftEvent,
+        workflow: &str,
+        names: &mut HashMap<u64, (String, &'static str)>,
+        running: &mut HashMap<u64, (Instant, String, &'static str)>,
+    ) {
+        match ev {
+            CrankshaftEvent::TaskCreated { id, name, .. } => {
+                let (task, _shard) = split_shard(&name.to_string());
+                let kind = classify_kind(&task);
+                names.insert(id, (task, kind));
+            }
+            CrankshaftEvent::TaskStarted { id } => {
+                let (task, kind) = names
+                    .get(&id)
+                    .cloned()
+                    .unwrap_or_else(|| ("unknown".into(), "wdl"));
+                self.in_flight.add(1, &[
+                    KeyValue::new("workflow", workflow.to_string()),
+                    KeyValue::new("task", task.clone()),
+                ]);
+                running.insert(id, (Instant::now(), task, kind));
+            }
+            CrankshaftEvent::TaskCompleted { id, .. } => self.terminal(id, "completed", workflow, running),
+            CrankshaftEvent::TaskFailed { id, .. } => self.terminal(id, "failed", workflow, running),
+            CrankshaftEvent::TaskPreempted { id } => self.terminal(id, "preempted", workflow, running),
+            CrankshaftEvent::TaskCanceled { id } => self.terminal(id, "canceled", workflow, running),
+            _ => {}
+        }
+    }
+
+    /// Updates instruments from a wdl-engine event (cache hits, parking).
+    fn on_engine(&self, ev: EngineEvent, workflow: &str) {
+        match ev {
+            EngineEvent::ReusedCachedExecutionResult { id } => {
+                let (task, _shard) = split_shard(&id);
+                self.cache_hits.add(1, &[
+                    KeyValue::new("workflow", workflow.to_string()),
+                    KeyValue::new("task", task),
+                ]);
+            }
+            EngineEvent::TaskParked => {
+                self.parked.add(1, &[KeyValue::new("workflow", workflow.to_string())]);
+            }
+            EngineEvent::TaskUnparked { .. } => {
+                self.parked.add(-1, &[KeyValue::new("workflow", workflow.to_string())]);
+            }
+        }
+    }
+
+    /// Records a task reaching a terminal `state`: decrement in-flight, bump the
+    /// counter, and record the attempt duration.
+    fn terminal(
+        &self,
+        id: u64,
+        state: &str,
+        workflow: &str,
+        running: &mut HashMap<u64, (Instant, String, &'static str)>,
+    ) {
+        let (start, task, kind) = running
+            .remove(&id)
+            .unwrap_or_else(|| (Instant::now(), "unknown".into(), "wdl"));
+        self.in_flight.add(-1, &[
+            KeyValue::new("workflow", workflow.to_string()),
+            KeyValue::new("task", task.clone()),
+        ]);
+        let attrs = [
+            KeyValue::new("workflow", workflow.to_string()),
+            KeyValue::new("task", task),
+            KeyValue::new("state", state.to_string()),
+            KeyValue::new("kind", kind),
+        ];
+        self.tasks.add(1, &attrs);
+        self.task_duration.record(start.elapsed().as_secs_f64(), &attrs);
+    }
+}
+
+/// Serves the Prometheus registry on `addr` from a dedicated OS thread.
+fn start_metrics_server(addr: &str, registry: Registry) -> Result<()> {
+    let listener = TcpListener::bind(addr).with_context(|| format!("failed to bind {addr}"))?;
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let mut buf = [0u8; 1024];
+            let _ = stream.read(&mut buf);
+            let mut body = Vec::new();
+            let _ = TextEncoder::new().encode(&registry.gather(), &mut body);
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\nContent-Length: {}\r\n\r\n",
+                body.len()
+            );
+            let _ = stream.write_all(header.as_bytes());
+            let _ = stream.write_all(&body);
+        }
+    });
+    Ok(())
+}
+
+/// Splits a crankshaft task id into a stable `task_name` and an optional shard.
+///
+/// The live id format is `{task}-[{scatter_index}-...]{nonce}` (e.g.
+/// `align-0-Urx5FjZomn5B`): a trailing uniqueness nonce, with scatter index
+/// segments before it. We drop the nonce, then strip trailing purely-numeric
+/// shard segments, so scatter shards aggregate under one `task_name`.
+///
+/// NOTE: interim — this string-munging is brittle; the production fix is
+/// structured identity on the engine event (see the implementation spec).
+fn split_shard(name: &str) -> (String, Option<String>) {
+    let mut parts: Vec<&str> = name.split('-').collect();
+    // Drop the trailing crankshaft uniqueness nonce (always the last segment).
+    if parts.len() > 1 {
+        parts.pop();
+    }
+    // Strip trailing purely-numeric scatter-index segments.
+    let mut split = parts.len();
+    while split > 1
+        && !parts[split - 1].is_empty()
+        && parts[split - 1].bytes().all(|b| b.is_ascii_digit())
+    {
+        split -= 1;
+    }
+    let task = parts[..split].join("-");
+    let shard = if split < parts.len() {
+        Some(parts[split..].join("-"))
+    } else {
+        None
+    };
+    (task, shard)
+}
+
+/// Classifies a task as a WDL task (`wdl`) or a backend-injected helper
+/// (`internal`, e.g. `docker-chown`), for the metric `kind` label.
+fn classify_kind(task_name: &str) -> &'static str {
+    // Interim heuristic: backend-injected helper tasks use a `docker-` prefix.
+    // The robust signal will come from structured engine identity (spec PR3).
+    if task_name.starts_with("docker-") {
+        "internal"
+    } else {
+        "wdl"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify_kind;
+    use super::split_shard;
+
+    #[test]
+    fn split_shard_extracts_task_and_shard_from_real_ids() {
+        // real formats observed against live sprocket
+        assert_eq!(split_shard("align-0-Urx5FjZomn5B"), ("align".into(), Some("0".into())));
+        assert_eq!(
+            split_shard("call_variants-3-mJnJUlEMv8J7"),
+            ("call_variants".into(), Some("3".into()))
+        );
+        // internal helper whose base name contains a hyphen, no scatter
+        assert_eq!(split_shard("docker-chown-5jC5YIQHhXIK"), ("docker-chown".into(), None));
+        // nested scatter: drop nonce, strip both numeric levels
+        assert_eq!(split_shard("inner-0-1-NONCEabcd1234"), ("inner".into(), Some("0-1".into())));
+    }
+
+    #[test]
+    fn classify_kind_distinguishes_internal_helpers() {
+        assert_eq!(classify_kind("align"), "wdl");
+        assert_eq!(classify_kind("haplotype_caller"), "wdl");
+        assert_eq!(classify_kind("docker-chown"), "internal");
+    }
+}


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

**NOTE: This is for illustrative purposes only. DO NOT MERGE. (Totally vibe coded and would need human hands)**

We have built a lot of systems to manage the execution and monitoring of bioinformatics workflows. Most of these systems rely on polling the engine / backend for task state and then representing that information internally. While this allows us to build interactive UIs and systems it does not get to the heart of some of the problems we want to solve: Optimizing workflow performance.

The modern era has given us an answer of course: Observability. Most infrastructures and platforms now rely on using Observability to not just retroactively diagnose issues but actively monitor performance and alert before issues happen. Additionally, with the [graduation of OTEL](https://opentelemetry.io/blog/2026/otel-graduates/) in the CNCF the "standard" way of publishing metrics, logs and traces has really been solidified

## Bringing Observability to Bioinformatics

My goal with this PR was to demonstrate what an OTEL native solution could look like within sprocket. I limited the scope to publishing metrics that sprocket itself is in control of:

- task counts, statuses, runtimes, etc
- workflow counts, statuses, runtimes
- cache hits
- p95 runtime performance

What I did not instrument were the tasks themselves: CPU, Memory, processes etc.  That requires backend specific logic, but is entirely doable

🤖 The one idea: wdl-engine already broadcasts task/workflow lifecycle events to drive the progress bar. The POC adds one extra subscriber that turns those into OTEL metrics — no changes to execution logic. All behind a metrics cargo feature, off by default. 🤖 

```
Sprocket -> Alloy (OTEL Collector) -> Mimir -> Grafana Cloud Dasboard
```

You can build interactive dashboards in something that can read the metrics

<img width="1616" height="1081" alt="Screenshot 2026-06-11 at 12 26 44 PM" src="https://github.com/user-attachments/assets/40e61a06-b42b-4225-82aa-e10fd86c3f09" />

## Testing it out

1. You will need an OTEL collector and somewhere to push those otel metrics. As mentioned I tried out using Grafana Cloud 

2. build with the feature (off by default)
```
  git clone -b feat/otel-metrics https://github.com/patmagee/sprocket && cd sprocket
  cargo build --features metrics --bin sprocket
```
3. Install [alloy](https://grafana.com/docs/alloy/latest/) and configure it to receive push metrics from sprocket
```
   otelcol.receiver.otlp "sprocket" { grpc { endpoint = "127.0.0.1:4317" }
      output { metrics = [otelcol.exporter.prometheus.sprocket.input] } }
     otelcol.exporter.prometheus "sprocket" { forward_to = [prometheus.remote_write.<yours>.receiver] }
```
```
   then: curl -XPOST http://localhost:12345/-/reload
```
4.  run a workflow, pushing metrics (A generic sample pipeline.wdl + reference grafana dashboard JSON are in the repo under docs/field-trips/.)
```
  target/debug/sprocket run --metrics-otlp http://localhost:4317 pipeline.wdl
```
5.  Push (--metrics-otlp) for short runs (flush-on-exit delivers the workflow summary); pull (--metrics-addr :9464) for long-lived/server.

_disclosure: I used grafana cloud because I work at grafana, but it is free to use and try out_