### PR TITLE
feat(wdl-grammar)!: add recursion limit for expressions

### DIFF
--- a/crates/wdl-grammar/CHANGELOG.md
+++ b/crates/wdl-grammar/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   identical diagnostics ([#927](https://github.com/stjude-rust-labs/sprocket/pull/927)).
 * In nested expressions, only the innermost expression will produce an "unexpected end of input"
   diagnostic ([#927](https://github.com/stjude-rust-labs/sprocket/pull/927)).
+* `Parser` now has a hard recursion limit of `128` on nested expressions ([#930](https://github.com/stjude-rust-labs/sprocket/pull/930)).
 
 ## 0.23.0 - 2026-06-03
 

--- a/crates/wdl-grammar/src/grammar/v1.rs
+++ b/crates/wdl-grammar/src/grammar/v1.rs
@@ -2291,14 +2291,19 @@ fn expr_with_precedence(
     marker: Marker,
     min_precedence: u8,
 ) -> Result<CompletedMarker, (Marker, ParseDiagnostic)> {
+    let mut parser = match parser.recurse() {
+        Ok(p) => p,
+        Err(e) => return Err((marker, e)),
+    };
+
     // First parse an atom or a prefix operation as the left-hand side
     let mut lhs = match parser.peek() {
         Some((token, _)) if ATOM_EXPECTED_SET.contains(token.into_raw()) => {
             let lhs = parser.start();
-            match atom_expr(parser, lhs, token) {
+            match atom_expr(&mut parser, lhs, token) {
                 Ok(lhs) => lhs,
                 Err((lhs, e)) => {
-                    lhs.abandon(parser);
+                    lhs.abandon(&mut parser);
                     return Err((marker, e));
                 }
             }
@@ -2309,7 +2314,7 @@ fn expr_with_precedence(
             let rhs = parser.start();
             let (precedence, kind, associativity) = prefix_precedence(token);
             match expr_with_precedence(
-                parser,
+                &mut parser,
                 rhs,
                 // Add one to the precedence for left-associative operators
                 match associativity {
@@ -2317,10 +2322,10 @@ fn expr_with_precedence(
                     Associativity::Right => precedence,
                 },
             ) {
-                Ok(_) => prefix.complete(parser, kind),
+                Ok(_) => prefix.complete(&mut parser, kind),
                 Err((rhs, e)) => {
-                    prefix.abandon(parser);
-                    rhs.abandon(parser);
+                    prefix.abandon(&mut parser);
+                    rhs.abandon(&mut parser);
                     return Err((marker, e));
                 }
             }
@@ -2331,7 +2336,7 @@ fn expr_with_precedence(
     };
 
     // Extend the parent chain of the left-hand side to the provided marker.
-    lhs = lhs.extend_to(parser, marker);
+    lhs = lhs.extend_to(&mut parser, marker);
 
     loop {
         // Check for either an infix or postfix operation
@@ -2343,13 +2348,13 @@ fn expr_with_precedence(
                     break;
                 }
 
-                let infix = lhs.precede(parser);
+                let infix = lhs.precede(&mut parser);
                 parser.next();
 
                 // Recuse for the right-hand side
                 let rhs = parser.start();
                 if let Err((rhs, e)) = expr_with_precedence(
-                    parser,
+                    &mut parser,
                     rhs,
                     // Add one to the precedence for left-associative operators
                     match associativity {
@@ -2357,11 +2362,11 @@ fn expr_with_precedence(
                         Associativity::Right => precedence,
                     },
                 ) {
-                    rhs.abandon(parser);
+                    rhs.abandon(&mut parser);
                     return Err((infix, e));
                 }
 
-                lhs = infix.complete(parser, kind);
+                lhs = infix.complete(&mut parser, kind);
             }
             Some((token, _)) if POSTFIX_OPERATOR_EXPECTED_SET.contains(token.into_raw()) => {
                 // The operation is a postfix operation; check the precedence level
@@ -2376,10 +2381,10 @@ fn expr_with_precedence(
                 }
 
                 // Call the operation-specific parse function
-                let postfix = lhs.precede(parser);
+                let postfix = lhs.precede(&mut parser);
                 let res = match token {
-                    Token::OpenBracket => index_expr(parser, postfix),
-                    Token::Dot => access_expr(parser, postfix),
+                    Token::OpenBracket => index_expr(&mut parser, postfix),
+                    Token::Dot => access_expr(&mut parser, postfix),
                     _ => panic!("unexpected postfix operator"),
                 };
 

--- a/crates/wdl-grammar/src/parser.rs
+++ b/crates/wdl-grammar/src/parser.rs
@@ -6,6 +6,8 @@
 //! The design of this is very much based on `rust-analyzer`.
 
 use std::fmt;
+use std::ops::Deref;
+use std::ops::DerefMut;
 
 use indexmap::IndexSet;
 use logos::Logos;
@@ -317,6 +319,8 @@ where
     diagnostic_context: DiagnosticContext,
     /// The buffered events from a peek operation.
     buffered: Vec<Event>,
+    /// The current expression depth of the parser.
+    expr_depth: usize,
 }
 
 impl<'a, T> Interpolator<'a, T>
@@ -373,6 +377,7 @@ where
             recovery: self.recovery,
             diagnostic_context: self.diagnostic_context,
             buffered: Default::default(),
+            expr_depth: self.expr_depth,
         }
     }
 }
@@ -420,6 +425,8 @@ struct DiagnosticContext {
     diagnostics: IndexSet<Diagnostic>,
     /// Whether the parser has reached the end of the input.
     eof: bool,
+    /// Whether the parser has encountered a fatal error.
+    halt: bool,
 }
 
 /// Implements a WDL parser.
@@ -447,6 +454,49 @@ where
     diagnostic_context: DiagnosticContext,
     /// The buffered events from a peek operation.
     buffered: Vec<Event>,
+    /// The current expression depth.
+    expr_depth: usize,
+}
+
+/// The maximum recursion depth for nested expressions.
+const MAX_DEPTH: usize = 128;
+
+/// Guard for limiting the depth of recursive expression parsing.
+#[allow(missing_debug_implementations)]
+pub struct RecursionGuard<'a, 'b, T>
+where
+    T: ParserToken<'a>,
+{
+    parser: &'b mut Parser<'a, T>,
+}
+
+impl<'a, 'b, T> Drop for RecursionGuard<'a, 'b, T>
+where
+    T: ParserToken<'a>,
+{
+    fn drop(&mut self) {
+        self.parser.expr_depth -= 1;
+    }
+}
+
+impl<'a, 'b, T> Deref for RecursionGuard<'a, 'b, T>
+where
+    T: ParserToken<'a>,
+{
+    type Target = Parser<'a, T>;
+
+    fn deref(&self) -> &Self::Target {
+        self.parser
+    }
+}
+
+impl<'a, 'b, T> DerefMut for RecursionGuard<'a, 'b, T>
+where
+    T: ParserToken<'a>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.parser
+    }
 }
 
 impl<'a, T> Parser<'a, T>
@@ -462,7 +512,20 @@ where
             recovery: Default::default(),
             diagnostic_context: Default::default(),
             buffered: Default::default(),
+            expr_depth: 0,
         }
+    }
+
+    /// Increase the current expression depth by 1.
+    pub(super) fn recurse(&mut self) -> Result<RecursionGuard<'a, '_, T>, ParseDiagnostic> {
+        self.expr_depth += 1;
+        if self.expr_depth > MAX_DEPTH {
+            self.diagnostic_context.halt = true;
+            return Err(Diagnostic::error("expression nested too deep")
+                .with_label("this exceeds the parser's nesting limit", self.span())
+                .into());
+        }
+        Ok(RecursionGuard { parser: self })
     }
 
     /// Get the version of the document.
@@ -673,7 +736,7 @@ where
 
         let mut next: Option<(T, Span)> = self.peek();
         while let Some((token, _)) = next {
-            if token == until {
+            if token == until || self.diagnostic_context.halt {
                 break;
             }
 
@@ -701,6 +764,10 @@ where
 
                 self.recover(e);
                 marker.abandon(self);
+
+                if self.diagnostic_context.halt {
+                    break;
+                }
             }
 
             next = self.peek();
@@ -1014,6 +1081,7 @@ where
             events: std::mem::take(&mut self.events),
             diagnostic_context: std::mem::take(&mut self.diagnostic_context),
             buffered: std::mem::take(&mut self.buffered),
+            expr_depth: self.expr_depth,
         };
         let (p, result) = cb(input);
         *self = p;
@@ -1036,6 +1104,7 @@ where
             recovery: self.recovery,
             diagnostic_context: self.diagnostic_context,
             buffered: self.buffered,
+            expr_depth: self.expr_depth,
         }
     }
 
@@ -1051,6 +1120,7 @@ where
             recovery: self.recovery,
             diagnostic_context: self.diagnostic_context,
             buffered: self.buffered,
+            expr_depth: self.expr_depth,
         }
     }
 
@@ -1213,5 +1283,41 @@ where
         }
 
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expression_depth_limit() {
+        let ok_map_literal = format!(
+            "{} : {}",
+            "{".repeat(MAX_DEPTH - 1),
+            "}".repeat(MAX_DEPTH - 1)
+        );
+        let source = format!(
+            r#"task foo {{
+            command <<<>>>
+
+            Map[String, Int] woah = {ok_map_literal}
+        }}"#
+        );
+        let mut parser = Parser::new(Lexer::new(&source));
+        crate::grammar::v1::items(&mut parser);
+        assert!(!parser.diagnostic_context.halt);
+
+        let bad_map_literal = format!("{} : {}", "{".repeat(MAX_DEPTH), "}".repeat(MAX_DEPTH));
+        let source = format!(
+            r#"task foo {{
+            command <<<>>>
+
+            Map[String, Int] woah = {bad_map_literal}
+        }}"#
+        );
+        let mut parser = Parser::new(Lexer::new(&source));
+        crate::grammar::v1::items(&mut parser);
+        assert!(parser.diagnostic_context.halt);
     }
 }

--- a/crates/wdl-grammar/src/parser.rs
+++ b/crates/wdl-grammar/src/parser.rs
@@ -467,6 +467,7 @@ pub struct RecursionGuard<'a, 'b, T>
 where
     T: ParserToken<'a>,
 {
+    /// The parser that is being guarded.
     parser: &'b mut Parser<'a, T>,
 }
 


### PR DESCRIPTION
This adds a hard recursion limit of **128** when parsing expressions.

When fuzzing, I keep ending up with files with huge map literals that take minutes to parse. A max depth of 128 should be way more than enough in the real world

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
