### PR TITLE
feat: Add Diagnostic::help() getter

### DIFF
--- a/crates/wdl-grammar/src/diagnostic.rs
+++ b/crates/wdl-grammar/src/diagnostic.rs
@@ -325,6 +325,11 @@ impl Diagnostic {
         self.fix.as_deref()
     }
 
+    /// Gets the optional help message of the diagnostic.
+    pub fn help(&self) -> Option<&str> {
+        self.help.as_deref()
+    }
+
     /// Gets the labels of the diagnostic.
     pub fn labels(&self) -> impl Iterator<Item = &Label> {
         self.labels.iter()

--- a/crates/wdl-grammar/tests/diagnostic.rs
+++ b/crates/wdl-grammar/tests/diagnostic.rs
@@ -1,3 +1,5 @@
+//! Tests related to the `Diagnostic` struct.
+
 use wdl_grammar::Diagnostic;
 
 #[test]

--- a/crates/wdl-grammar/tests/diagnostic.rs
+++ b/crates/wdl-grammar/tests/diagnostic.rs
@@ -1,0 +1,29 @@
+use wdl_grammar::Diagnostic;
+
+#[test]
+fn test_diagnostic_help_getter_with_value() {
+    let diagnostic = Diagnostic::error("test error").with_help("This is helpful");
+
+    assert_eq!(diagnostic.help(), Some("This is helpful"));
+}
+
+#[test]
+fn test_diagnostic_help_getter_without_value() {
+    let diagnostic = Diagnostic::error("test error");
+
+    assert_eq!(diagnostic.help(), None);
+}
+
+#[test]
+fn test_help_getter_consistency() {
+    let diagnostic = Diagnostic::warning("test warning")
+        .with_help("help message")
+        .with_fix("fix message")
+        .with_rule("TestRule");
+
+    // Verify all getters work together
+    assert_eq!(diagnostic.help(), Some("help message"));
+    assert_eq!(diagnostic.fix(), Some("fix message"));
+    assert_eq!(diagnostic.rule(), Some("TestRule"));
+    assert_eq!(diagnostic.message(), "test warning");
+}


### PR DESCRIPTION
### Description
Adds a getter method for the `help` field of the `Diagnostic` struct to ensure API consistency with other field getters.

### Changes
- Added `pub fn help(&self) -> Option<&str>` method to `Diagnostic` struct in `crates/wdl-grammar/src/diagnostic.rs`
- Method follows the same pattern as existing getters (`fix()`, `message()`, `rule()`)
- Added comprehensive unit tests in `crates/wdl-grammar/tests/diagnostic.rs`:
  - `test_diagnostic_help_getter_with_value()` - Tests getter returns value when help is set
  - `test_diagnostic_help_getter_without_value()` - Tests getter returns None when help is not set
  - `test_help_getter_consistency()` - Tests all getters work together consistently

Closes #934

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).
