### PR TITLE
fix: prevent content digesting for existing inputs in TES backend.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,9 +721,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cloud-copy"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8aaa77032b7b2de8372d393a15eb3f916d16fa9b6eddf78cbe40873295552a6"
+checksum = "24a7d1332fd09dbc2421893e885a4470efb0d8522de643e0131a17fc08ca180e"
 dependencies = [
  "anyhow",
  "base64",
@@ -735,20 +735,21 @@ dependencies = [
  "clap-verbosity-flag",
  "colored",
  "crc64fast-nvme",
+ "digest-io",
  "futures",
  "git-testament",
  "hex",
- "hmac 0.12.1",
+ "hmac 0.13.0",
  "http-cache-stream-reqwest",
  "opool",
  "pin-project-lite",
- "rand 0.9.4",
+ "rand 0.10.1",
  "reqwest",
  "reqwest-middleware",
  "secrecy",
  "serde",
  "serde-xml-rs",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror",
  "tokio",
@@ -1330,6 +1331,15 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
+]
+
+[[package]]
+name = "digest-io"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de63d600bc7fab91180bc17385f29b342468dc8ef2af09dceba450a293de3da"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ chrono = "0.4.43"
 clap = { version = "4.5.57", features = ["derive", "string"] }
 clap-verbosity-flag = { version = "3.0.4", features = ["tracing"] }
 clap_complete = "4.5.65"
-cloud-copy = { version = "0.8.0", features = ["cli"] }
+cloud-copy = { version = "0.9.0", features = ["cli"] }
 codespan-reporting = "0.13.1"
 colored = "3.1.1"
 convert_case = "0.11.0"

--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -9,12 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Added `run.http.hash_algorithm` to configure input upload content digest
+  algorithm to use (use `none` to disable, defaults to `sha256`) ([#954](https://github.com/stjude-rust-labs/sprocket/pull/954)).
 * Added `ConfigBuilder` type for merging engine configurations together ([#918](https://github.com/stjude-rust-labs/sprocket/pull/918)).
 
 #### Changed
 
 * Renamed enum terminology from `variant` to `choice` ([#638](https://github.com/stjude-rust-labs/sprocket/pull/638)).
 * Moved from `toml` to `toml-spanner` for TOML serialization ([#918](https://github.com/stjude-rust-labs/sprocket/pull/918)).
+
+#### Dependencies
+
+* Updated to `cloud-copy` 0.9.0 for a number of fixes ([#954](https://github.com/stjude-rust-labs/sprocket/pull/954)).
 
 ## 0.15.0 - 2026-06-03
 

--- a/crates/wdl-engine/src/config.rs
+++ b/crates/wdl-engine/src/config.rs
@@ -521,6 +521,12 @@ pub struct HttpConfig {
     /// Defaults to the host's available parallelism.
     #[toml(default)]
     pub parallelism: Parallelism,
+    /// The hash algorithm to use for calculating content digests for file
+    /// uploads.
+    ///
+    /// Defaults to `sha256`.
+    #[toml(default, FromToml with = parse_string, ToToml with = display)]
+    pub hash_algorithm: cloud_copy::HashAlgorithm,
 }
 
 impl Default for HttpConfig {
@@ -529,6 +535,7 @@ impl Default for HttpConfig {
             cache_dir: CACHE_DIR_SENTINEL.into(),
             retries: DEFAULT_HTTP_RETRIES,
             parallelism: Default::default(),
+            hash_algorithm: Default::default(),
         }
     }
 }

--- a/crates/wdl-engine/src/http.rs
+++ b/crates/wdl-engine/src/http.rs
@@ -193,6 +193,7 @@ impl HttpTransferer {
         let copy_config = cloud_copy::Config::builder()
             .with_link_to_cache(true)
             .with_overwrite(true)
+            .with_hash_algorithm(config.http.hash_algorithm)
             .with_maybe_retries(Some(
                 config
                     .http

--- a/tests/cli/config-init/run/stdout
+++ b/tests/cli/config-init/run/stdout
@@ -36,6 +36,7 @@ fail = "slow"
 cache_dir = "system"
 retries = 5
 parallelism = "available"
+hash_algorithm = "sha256"
 
 [run.workflow]
 
@@ -87,6 +88,7 @@ fail = "slow"
 cache_dir = "system"
 retries = 5
 parallelism = "available"
+hash_algorithm = "sha256"
 
 [server.engine.workflow]
 

--- a/tests/cli/config-resolve/multi/stdout
+++ b/tests/cli/config-resolve/multi/stdout
@@ -36,6 +36,7 @@ fail = "slow"
 cache_dir = "system"
 retries = 5
 parallelism = "available"
+hash_algorithm = "sha256"
 
 [run.workflow]
 
@@ -97,6 +98,7 @@ fail = "slow"
 cache_dir = "system"
 retries = 5
 parallelism = "available"
+hash_algorithm = "sha256"
 
 [server.engine.workflow]
 

--- a/tests/cli/config-resolve/redacted/stdout
+++ b/tests/cli/config-resolve/redacted/stdout
@@ -36,6 +36,7 @@ fail = "slow"
 cache_dir = "system"
 retries = 5
 parallelism = "available"
+hash_algorithm = "sha256"
 
 [run.workflow]
 
@@ -114,6 +115,7 @@ fail = "slow"
 cache_dir = "system"
 retries = 5
 parallelism = "available"
+hash_algorithm = "sha256"
 
 [server.engine.workflow]
 

--- a/tests/cli/config-resolve/run/stdout
+++ b/tests/cli/config-resolve/run/stdout
@@ -36,6 +36,7 @@ fail = "slow"
 cache_dir = "system"
 retries = 5
 parallelism = "available"
+hash_algorithm = "sha256"
 
 [run.workflow]
 
@@ -114,6 +115,7 @@ fail = "slow"
 cache_dir = "system"
 retries = 5
 parallelism = "available"
+hash_algorithm = "sha256"
 
 [server.engine.workflow]
 

--- a/tests/cli/config-resolve/sentinels/stdout
+++ b/tests/cli/config-resolve/sentinels/stdout
@@ -36,6 +36,7 @@ fail = "slow"
 cache_dir = "system"
 retries = 5
 parallelism = "available"
+hash_algorithm = "sha256"
 
 [run.workflow]
 
@@ -87,6 +88,7 @@ fail = "slow"
 cache_dir = "system"
 retries = 5
 parallelism = "available"
+hash_algorithm = "sha256"
 
 [server.engine.workflow]
 

--- a/tests/cli/config-resolve/unredacted/stdout
+++ b/tests/cli/config-resolve/unredacted/stdout
@@ -36,6 +36,7 @@ fail = "slow"
 cache_dir = "system"
 retries = 5
 parallelism = "available"
+hash_algorithm = "sha256"
 
 [run.workflow]
 
@@ -114,6 +115,7 @@ fail = "slow"
 cache_dir = "system"
 retries = 5
 parallelism = "available"
+hash_algorithm = "sha256"
 
 [server.engine.workflow]
 


### PR DESCRIPTION
The TES backend will upload local inputs by using setting the "overwrite" flag to false for the upload operation and ignoring the error if the resource already exists.

Internally, `cloud-copy` will check for the resource's existence and return an error. However, it does the existence check *after* it calculates the local resources digest for the upload.

`cloud-copy` was fixed to perform the existence check prior to calculating the digest.

This PR updates `cloud-copy` and also adds a new `hash_algorithm` setting to `run.http` for controlling the content digest algorithm (or `none` to disable) used by `cloud-copy`.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
