### PR TITLE
feat: emit Workflow Run RO-Crates from `sprocket run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `--ro-crate` to `sprocket run`, which emits an RO-Crate
+  (`ro-crate-metadata.json`) into the run directory on success. Workflow
+  targets produce a Workflow Run Crate with per-task step provenance
+  (Provenance Run Crate) and direct task targets produce a Process Run Crate.
+  The companion `--ro-crate-strict`, `--no-ro-crate-checksums`, and
+  `--no-ro-crate-localize` flags control the failure policy, file digests, and
+  input/output localization. Setting `run.ro_crate.logs.include_contents`
+  additionally bundles each task's stdout/stderr into the crate as scrubbed
+  log files, with secret-shaped text replaced before writing
+  ([#955](https://github.com/stjude-rust-labs/sprocket/pull/955)).
 * Nix flake providing `packages.sprocket`, a development shell with the
   full toolchain, `nix flake check` entries (package build, binary smoke
   test, and `nixfmt`/`statix`/`deadnix` lints), and a `nix fmt`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,7 +164,7 @@ dependencies = [
  "bzip2 0.4.4",
  "chrono",
  "cryptographic-message-syntax",
- "digest",
+ "digest 0.10.7",
  "flate2",
  "log",
  "md-5",
@@ -162,8 +173,8 @@ dependencies = [
  "scroll",
  "serde",
  "serde-xml-rs 0.6.0",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "signature",
  "thiserror 2.0.18",
  "url",
@@ -463,6 +474,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+ "zeroize",
+]
+
+[[package]]
 name = "bollard"
 version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +726,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,8 +783,18 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
- "inout",
+ "crypto-common 0.1.7",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -834,7 +876,7 @@ dependencies = [
  "futures",
  "git-testament",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http-cache-stream-reqwest",
  "opool",
  "pin-project-lite",
@@ -844,7 +886,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde-xml-rs 0.8.2",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -867,6 +909,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "codespan-reporting"
@@ -944,6 +992,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const_format"
@@ -1024,6 +1078,12 @@ dependencies = [
  "simple-file-manifest",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -1267,6 +1327,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cryptographic-message-syntax"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1307,6 +1376,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1315,7 +1393,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1382,8 +1460,14 @@ dependencies = [
  "log",
  "tar",
  "xz2",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
+
+[[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "defmt"
@@ -1423,7 +1507,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1460,10 +1544,23 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "zeroize",
 ]
 
 [[package]]
@@ -1547,7 +1644,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1573,7 +1670,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1595,7 +1692,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -2019,8 +2116,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2222,7 +2322,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2231,7 +2331,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2321,7 +2430,7 @@ dependencies = [
  "libc",
  "pin-project-lite",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -2370,6 +2479,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2675,6 +2793,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -3041,6 +3168,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rust2"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02"
+dependencies = [
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3141,7 +3277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3460,7 +3596,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3472,7 +3608,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3486,7 +3622,7 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3551,6 +3687,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
+]
 
 [[package]]
 name = "peak_alloc"
@@ -3777,6 +3923,12 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
 name = "ppv-lite86"
@@ -4075,6 +4227,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4111,6 +4274,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -4332,7 +4501,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -4380,6 +4549,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ro-crate-rs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bd50370fd8312670fbb685325b7a7aa9913ef0619cc856f12a2b87c89a8b0e5"
+dependencies = [
+ "chrono",
+ "dirs",
+ "log",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "url",
+ "uuid",
+ "walkdir",
+ "zip 8.6.0",
+]
+
+[[package]]
 name = "rowan"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4397,15 +4586,15 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
  "pkcs8",
  "rand_core 0.6.4",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "spki",
  "subtle",
@@ -4442,7 +4631,7 @@ version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
- "sha2",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -4939,7 +5128,7 @@ dependencies = [
  "js-sys",
  "lzma-rust",
  "nt-time",
- "sha2",
+ "sha2 0.10.9",
  "wasm-bindgen",
 ]
 
@@ -4951,7 +5140,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4962,7 +5162,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5013,7 +5224,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5145,9 +5356,11 @@ dependencies = [
  "rand 0.9.4",
  "regex",
  "reqwest 0.13.4",
+ "ro-crate-rs",
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "sha2 0.10.9",
  "shellexpand",
  "shlex 1.3.0",
  "similar",
@@ -5221,7 +5434,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -5259,7 +5472,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -5282,7 +5495,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -5292,7 +5505,7 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
@@ -5302,8 +5515,8 @@ dependencies = [
  "rand 0.8.6",
  "rsa",
  "serde",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5332,7 +5545,7 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
@@ -5342,7 +5555,7 @@ dependencies = [
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5384,7 +5597,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
  "ssh-encoding",
 ]
 
@@ -5396,7 +5609,7 @@ checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
 dependencies = [
  "base64ct",
  "pem-rfc7468",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5411,7 +5624,7 @@ dependencies = [
  "rand_core 0.6.4",
  "rsa",
  "sec1",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "ssh-cipher",
  "ssh-encoding",
@@ -5786,6 +5999,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -6832,7 +7046,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "spdx",
  "ssh-key",
  "tempfile",
@@ -7571,10 +7785,25 @@ version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
+ "aes",
+ "bzip2 0.6.1",
+ "constant_time_eq",
  "crc32fast",
+ "deflate64",
+ "flate2",
+ "getrandom 0.4.3",
+ "hmac 0.13.0",
  "indexmap 2.14.0",
+ "lzma-rust2",
  "memchr",
+ "pbkdf2",
+ "ppmd-rust",
+ "sha1 0.11.0",
+ "time",
  "typed-path",
+ "zeroize",
+ "zopfli",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -7607,7 +7836,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -7617,6 +7855,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ rayon = "1.11.0"
 regex = "1.12.3"
 reqwest = { version = "0.13.1", default-features = false, features = ["rustls", "http2", "charset"] }
 rev_buf_reader = "0.3.0"
+ro-crate-rs = "0.5"
 rowan = "0.16.1"
 secrecy = "0.10.3"
 semver = "1.0.28"
@@ -197,9 +198,11 @@ pretty_assertions.workspace = true
 rand.workspace = true
 regex.workspace = true
 reqwest.workspace = true
+ro-crate-rs.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_yaml_ng.workspace = true
+sha2.workspace = true
 shellexpand = { workspace = true, features = ["full"] }
 similar.workspace = true
 sqlx.workspace = true

--- a/crates/wdl-engine/src/eval.rs
+++ b/crates/wdl-engine/src/eval.rs
@@ -24,6 +24,7 @@ use crate::EvaluationPath;
 use crate::GuestPath;
 use crate::HostPath;
 use crate::Outputs;
+use crate::TaskInputs;
 use crate::Value;
 use crate::backend::TaskExecutionResult;
 use crate::config::FailureMode;
@@ -742,6 +743,8 @@ pub struct EvaluatedTask {
     result: TaskExecutionResult,
     /// The evaluated outputs of the task.
     outputs: Outputs,
+    /// The effective task inputs after defaults are evaluated.
+    inputs: TaskInputs,
     /// Stores the execution error for the evaluated task.
     ///
     /// This is `None` when the evaluated task successfully executed.
@@ -756,6 +759,7 @@ impl EvaluatedTask {
         Self {
             result,
             outputs: Default::default(),
+            inputs: Default::default(),
             error,
             cached,
         }
@@ -791,6 +795,11 @@ impl EvaluatedTask {
     /// Gets the stderr value of the evaluated task.
     pub fn stderr(&self) -> &Value {
         &self.result.stderr
+    }
+
+    /// Gets the effective task inputs after defaults are evaluated.
+    pub fn inputs(&self) -> &TaskInputs {
+        &self.inputs
     }
 
     /// Converts the evaluated task into its [`Outputs`].

--- a/crates/wdl-engine/src/eval/v1/task.rs
+++ b/crates/wdl-engine/src/eval/v1/task.rs
@@ -1048,6 +1048,9 @@ impl Evaluator {
 
             // Finally, associate the outputs with the evaluated task
             evaluated.outputs = outputs;
+            for (name, value) in state.inputs {
+                evaluated.inputs.set(name, value);
+            }
         }
 
         Ok(evaluated)

--- a/crates/wdl-engine/src/eval/v1/workflow.rs
+++ b/crates/wdl-engine/src/eval/v1/workflow.rs
@@ -612,6 +612,18 @@ impl Evaluator {
         inputs: WorkflowInputs,
         eval_root_dir: impl AsRef<Path>,
     ) -> EvaluationResult<Outputs> {
+        self.evaluate_workflow_with_inputs(document, inputs, eval_root_dir)
+            .await
+            .map(|(outputs, _)| outputs)
+    }
+
+    /// Evaluates a workflow and returns the outputs and effective inputs.
+    pub async fn evaluate_workflow_with_inputs(
+        &self,
+        document: &Document,
+        inputs: WorkflowInputs,
+        eval_root_dir: impl AsRef<Path>,
+    ) -> EvaluationResult<(Outputs, WorkflowInputs)> {
         let workflow = document
             .workflow()
             .context("document does not contain a workflow")?;
@@ -644,7 +656,7 @@ impl Evaluator {
         inputs: WorkflowInputs,
         eval_root_dir: &Path,
         id: &str,
-    ) -> EvaluationResult<Outputs> {
+    ) -> EvaluationResult<(Outputs, WorkflowInputs)> {
         // Validate the inputs for the workflow
         let workflow = document
             .workflow()
@@ -748,7 +760,18 @@ impl Evaluator {
             .evaluate_subgraph(Scopes::ROOT_INDEX, subgraph, Arc::new(id.to_string()))
             .await?;
 
-        let mut outputs: Outputs = state.scopes.write().await.take(Scopes::OUTPUT_INDEX).into();
+        let mut scopes = state.scopes.write().await;
+        let root = scopes.reference(Scopes::ROOT_INDEX);
+        let mut effective_inputs = WorkflowInputs::default();
+        if let Some(section) = definition.input() {
+            for decl in section.declarations() {
+                let name = decl.name();
+                if let Some(value) = root.local(name.text()) {
+                    effective_inputs.set(name.text(), value.clone());
+                }
+            }
+        }
+        let mut outputs: Outputs = scopes.take(Scopes::OUTPUT_INDEX).into();
         if let Some(section) = definition.output() {
             let indexes: HashMap<_, _> = section
                 .declarations()
@@ -757,10 +780,12 @@ impl Evaluator {
                 .collect();
             outputs.sort_by(move |a, b| indexes[a].cmp(&indexes[b]))
         }
+        drop(scopes);
 
         // Write the outputs to the workflow's root directory
         write_json_file(eval_root_dir.join(OUTPUTS_FILE), &outputs)?;
-        Ok(outputs)
+
+        Ok((outputs, effective_inputs))
     }
 }
 
@@ -1612,6 +1637,7 @@ impl State {
                                 callee_id,
                             )
                             .await
+                            .map(|(outputs, _)| outputs)
                     }
                 }
             }
@@ -1990,6 +2016,73 @@ workflow test {
                 .expect("failed to read bar `outputs.json`"),
             "{\n  \"x\": \"bar\",\n  \"y\": 1,\n  \"z\": []\n}"
         );
+    }
+
+    #[tokio::test]
+    async fn it_returns_defaulted_workflow_inputs() -> Result<()> {
+        let root_dir = TempDir::new().context("failed to create temporary directory")?;
+        fs::write(
+            root_dir.path().join("source.wdl"),
+            r#"
+version 1.2
+
+workflow test {
+    input {
+        String message = "hello"
+    }
+
+    output {
+        String out = message
+    }
+}
+"#,
+        )
+        .context("failed to write WDL source file")?;
+
+        let analyzer = Analyzer::new(
+            AnalysisConfig::default().with_diagnostics_config(DiagnosticsConfig::except_all()),
+            |(), _, _, _| async {},
+        );
+        analyzer
+            .add_directory(root_dir.path())
+            .await
+            .context("failed to add directory")?;
+        let results = analyzer
+            .analyze(())
+            .await
+            .context("failed to analyze document")?;
+        assert_eq!(results.len(), 1, "expected only one result");
+
+        let config = Config {
+            backends: [("default".to_string(), LocalBackendConfig::default().into())].into(),
+            ..Default::default()
+        };
+        let evaluator = Evaluator::new(
+            root_dir.path(),
+            config.into(),
+            Default::default(),
+            Events::disabled(),
+        )
+        .await?;
+
+        let (_, inputs) = evaluator
+            .evaluate_workflow_with_inputs(
+                results
+                    .first()
+                    .context("expected analysis result")?
+                    .document(),
+                WorkflowInputs::default(),
+                root_dir.path().join("outputs"),
+            )
+            .await
+            .map_err(|e| anyhow!("{e:?}"))?;
+
+        let Some(message) = inputs.get("message") else {
+            bail!("defaulted input was not returned");
+        };
+        assert_eq!(message.as_string().map(|s| s.as_str()), Some("hello"));
+
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -200,6 +200,24 @@ pub struct Args {
     /// Optional suffix to append to the run directory name.
     #[clap(long, value_name = "SUFFIX")]
     pub suffix: Option<String>,
+
+    /// Emit a Workflow Run RO-Crate (`ro-crate-metadata.json`) into the run
+    /// directory on success.
+    #[clap(long)]
+    pub ro_crate: bool,
+
+    /// Fail the command if requested RO-Crate emission fails.
+    #[clap(long, requires = "ro_crate")]
+    pub ro_crate_strict: bool,
+
+    /// Skip SHA-256 digests for files in the RO-Crate (faster on large outputs).
+    #[clap(long, requires = "ro_crate")]
+    pub no_ro_crate_checksums: bool,
+
+    /// Do not localize input/output data values into stable crate-relative
+    /// paths.
+    #[clap(long, requires = "ro_crate")]
+    pub no_ro_crate_localize: bool,
 }
 
 impl Args {
@@ -750,6 +768,16 @@ pub async fn run(
     let cwd = std::env::current_dir().context("failed to get current working directory")?;
     let base_dir = EvaluationPath::from(cwd.as_path());
 
+    let ro_crate = crate::system::v1::rocrate::RoCrateOptions {
+        include_log_contents: config.run.ro_crate.logs.include_contents,
+        ..crate::system::v1::rocrate::RoCrateOptions::from_flags(
+            args.ro_crate,
+            args.ro_crate_strict,
+            args.no_ro_crate_checksums,
+            args.no_ro_crate_localize,
+        )
+    };
+
     let mut execute = Box::pin(execute_target(
         db.clone(),
         &ctx,
@@ -762,6 +790,7 @@ pub async fn run(
         &run_dir,
         &base_dir,
         args.index_on.as_deref(),
+        ro_crate,
     ));
 
     loop {
@@ -986,4 +1015,36 @@ fn initialize_file_logging(handle: FileReloadHandle, run_dir: &Path) -> Result<(
     handle
         .reload(layer().with_ansi(false).with_writer(log_file))
         .context("failed to initialize file logging")
+}
+
+#[cfg(test)]
+mod ro_crate_flag_tests {
+    use clap::Parser;
+
+    use super::Args;
+
+    // A URL source parses without a filesystem-existence check, isolating the
+    // flag behavior under test.
+    const SOURCE: &str = "https://example.com/wf.wdl";
+
+    #[test]
+    fn parses_ro_crate_flags() {
+        let args = Args::parse_from([
+            "run",
+            SOURCE,
+            "--ro-crate",
+            "--no-ro-crate-checksums",
+            "--no-ro-crate-localize",
+        ]);
+        assert!(args.ro_crate);
+        assert!(args.no_ro_crate_checksums);
+        assert!(args.no_ro_crate_localize);
+        assert!(!args.ro_crate_strict);
+    }
+
+    #[test]
+    fn strict_requires_ro_crate() {
+        let res = Args::try_parse_from(["run", SOURCE, "--ro-crate-strict"]);
+        assert!(res.is_err(), "strict without --ro-crate should error");
+    }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -301,6 +301,24 @@ pub struct AnalyzerConfig {
     pub except: Vec<String>,
 }
 
+/// Represents RO-Crate configuration for the Sprocket `run` command.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Toml)]
+#[toml(Toml, rename_all = "snake_case", deny_unknown_fields)]
+pub struct RoCrateConfig {
+    /// Log content configuration.
+    #[toml(default, style = Header)]
+    pub logs: RoCrateLogConfig,
+}
+
+/// Represents RO-Crate log configuration for the Sprocket `run` command.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Toml)]
+#[toml(Toml, rename_all = "snake_case", deny_unknown_fields)]
+pub struct RoCrateLogConfig {
+    /// Include log contents in emitted RO-Crate metadata.
+    #[toml(default)]
+    pub include_contents: bool,
+}
+
 /// Represents the configuration for the Sprocket `run` command.
 #[derive(Debug, Clone, PartialEq, Eq, Toml)]
 #[toml(Toml, rename_all = "snake_case", deny_unknown_fields)]
@@ -329,6 +347,10 @@ pub struct RunConfig {
     /// The default is `5000`.
     #[toml(default = DEFAULT_EVENTS_CHANNEL_CAPACITY)]
     pub events_capacity: u32,
+
+    /// RO-Crate emission configuration.
+    #[toml(default, style = Header)]
+    pub ro_crate: RoCrateConfig,
 }
 
 impl Default for RunConfig {
@@ -337,6 +359,7 @@ impl Default for RunConfig {
             engine: EngineConfig::default(),
             output_dir: DEFAULT_OUTPUT_DIRECTORY.into(),
             events_capacity: DEFAULT_EVENTS_CHANNEL_CAPACITY,
+            ro_crate: RoCrateConfig::default(),
         }
     }
 }

--- a/src/system/v1.rs
+++ b/src/system/v1.rs
@@ -3,3 +3,4 @@
 pub mod db;
 pub mod exec;
 pub mod fs;
+pub mod rocrate;

--- a/src/system/v1/exec.rs
+++ b/src/system/v1/exec.rs
@@ -517,6 +517,9 @@ impl RunnableExecutor {
             &run_dir,
             &base_dir,
             self.index_on.as_deref(),
+            // RO-Crate emission is a CLI-only `sprocket run` feature; the HTTP
+            // execution path does not emit.
+            crate::system::v1::rocrate::RoCrateOptions::disabled(),
         )
         .await
         {
@@ -609,6 +612,7 @@ pub async fn analyze_wdl_document(
 ///
 /// Creates provenance index entries (if `index_on` is provided), serializes
 /// outputs, and marks the run as completed.
+#[allow(clippy::too_many_arguments)]
 async fn set_run_success(
     db: &dyn Database,
     ctx: &RunContext,
@@ -616,6 +620,9 @@ async fn set_run_success(
     outputs: Outputs,
     run_dir: &RunDirectory,
     index_on: Option<&str>,
+    document: &AnalysisDocument,
+    inputs: &Inputs,
+    ro_crate: &crate::system::v1::rocrate::RoCrateOptions,
 ) -> Result<()> {
     // Serialize outputs
     let outputs_with_name = outputs.with_name(target.name());
@@ -667,6 +674,23 @@ async fn set_run_success(
         "run `{}` ({}) completed successfully",
         ctx.run_generated_name, ctx.run_id
     );
+
+    // Emit the RO-Crate after the run is recorded complete. A strict-mode failure
+    // here propagates as a nonzero command exit but leaves the run successful.
+    if ro_crate.enabled {
+        crate::system::v1::rocrate::emit(
+            db,
+            ctx.run_id,
+            target,
+            document,
+            inputs,
+            &outputs_with_name,
+            run_dir,
+            ro_crate,
+        )
+        .await?;
+    }
+
     Ok(())
 }
 
@@ -689,7 +713,7 @@ async fn execute_workflow_target(
     inputs: Inputs,
     run_dir: &RunDirectory,
     base_dir: &EvaluationPath,
-) -> Result<Option<Outputs>, EvaluationError> {
+) -> Result<Option<(Outputs, Inputs)>, EvaluationError> {
     // Write inputs to file
     let inputs_file = run_dir.inputs_file();
     fs::write(
@@ -728,10 +752,10 @@ async fn execute_workflow_target(
         .context("failed to create workflow evaluator")?;
 
     match evaluator
-        .evaluate_workflow(document, inputs, run_dir.root())
+        .evaluate_workflow_with_inputs(document, inputs, run_dir.root())
         .await
     {
-        Ok(outputs) => Ok(Some(outputs)),
+        Ok((outputs, inputs)) => Ok(Some((outputs, Inputs::Workflow(inputs)))),
         Err(EvaluationError::Canceled) => Ok(None),
         Err(e) => Err(e),
     }
@@ -758,7 +782,7 @@ async fn execute_task_target(
     inputs: Inputs,
     run_dir: &RunDirectory,
     base_dir: &EvaluationPath,
-) -> Result<Option<Outputs>, EvaluationError> {
+) -> Result<Option<(Outputs, Inputs)>, EvaluationError> {
     let task = document.task_by_name(target.name()).with_context(|| {
         format!(
             "task `{name}` was not found in the document",
@@ -796,7 +820,10 @@ async fn execute_task_target(
         Err(e) => return Err(e),
     };
 
-    evaluated_task.into_outputs().map(Some)
+    let inputs = Inputs::Task(evaluated_task.inputs().clone());
+    evaluated_task
+        .into_outputs()
+        .map(|outputs| Some((outputs, inputs)))
 }
 
 /// Execute a workflow or task target.
@@ -836,13 +863,14 @@ pub async fn execute_target(
     run_dir: &RunDirectory,
     base_dir: &EvaluationPath,
     index_on: Option<&str>,
+    ro_crate: crate::system::v1::rocrate::RoCrateOptions,
 ) -> Result<(), EvaluationError> {
     let config = Arc::new(config);
     db.start_run(ctx.run_id, ctx.started_at)
         .await
         .map_err(anyhow::Error::from)?;
 
-    let result: Result<Option<Outputs>, EvaluationError> = async {
+    let result: Result<Option<(Outputs, Inputs)>, EvaluationError> = async {
         match target {
             Target::Task(_) => {
                 execute_task_target(
@@ -878,8 +906,19 @@ pub async fn execute_target(
     .await;
 
     match result {
-        Ok(Some(outputs)) => {
-            set_run_success(db.as_ref(), ctx, target, outputs, run_dir, index_on).await?;
+        Ok(Some((outputs, inputs))) => {
+            set_run_success(
+                db.as_ref(),
+                ctx,
+                target,
+                outputs,
+                run_dir,
+                index_on,
+                &document,
+                &inputs,
+                &ro_crate,
+            )
+            .await?;
             Ok(())
         }
         Ok(None) => {

--- a/src/system/v1/rocrate/build.rs
+++ b/src/system/v1/rocrate/build.rs
@@ -1,0 +1,514 @@
+//! Assembles the Workflow Run RO-Crate graph from a `RunCrateContext`.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use rocraters::ro_crate::constraints::DataType;
+use rocraters::ro_crate::constraints::EntityValue;
+use rocraters::ro_crate::constraints::Id;
+use rocraters::ro_crate::constraints::License;
+use rocraters::ro_crate::context::ContextItem;
+use rocraters::ro_crate::contextual_entity::ContextualEntity;
+use rocraters::ro_crate::data_entity::DataEntity;
+use rocraters::ro_crate::graph_vector::GraphVector;
+use rocraters::ro_crate::metadata_descriptor::MetadataDescriptor;
+use rocraters::ro_crate::rocrate::RoCrate;
+use rocraters::ro_crate::rocrate::RoCrateContext;
+use rocraters::ro_crate::root::RootDataEntity;
+use wdl::analysis::document::Input;
+use wdl::analysis::document::Output;
+use wdl::analysis::types::Optional;
+
+use super::METADATA_FILE;
+use super::PROCESS_PROFILE;
+use super::PROFILES;
+use super::PROVENANCE_RUN_CRATE_PROFILE;
+use super::ROCRATE_CONTEXT;
+use super::RoCrateOptions;
+use super::RunCrateContext;
+use super::WFRUN_CONTEXT;
+use super::WORKFLOW_ID;
+use super::WORKFLOW_RO_CRATE_PROFILE;
+use super::WORKFLOW_RUN_CRATE_PROFILE;
+use super::formal::formal_parameter;
+use super::value::sanitize_component;
+use super::value::value_to_entities;
+use crate::system::v1::exec::Target;
+
+/// Wraps an `@id` reference as an `EntityValue`.
+fn ev_id(s: &str) -> EntityValue {
+    EntityValue::EntityId(Id::Id(s.to_string()))
+}
+
+/// Wraps a list of `@id` references as an `EntityValue`.
+fn ev_ids(v: Vec<String>) -> EntityValue {
+    EntityValue::EntityId(Id::IdArray(v))
+}
+
+/// Extracts `@id` references from a single or array id value.
+fn id_value_ids(value: EntityValue) -> Vec<String> {
+    match value {
+        EntityValue::EntityId(Id::Id(id)) => vec![id],
+        EntityValue::EntityId(Id::IdArray(ids)) => ids,
+        _ => Vec::new(),
+    }
+}
+
+/// Wraps a string literal as an `EntityValue`.
+fn ev_str(s: &str) -> EntityValue {
+    EntityValue::EntityString(s.to_string())
+}
+
+/// Builds the `dynamic_entity` map from `(key, value)` pairs.
+fn bag(pairs: Vec<(&str, EntityValue)>) -> Option<HashMap<String, EntityValue>> {
+    Some(pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+}
+
+/// Builds the `CreativeWork` contextual entity that a `conformsTo` profile URI
+/// resolves to, so the reference is not dangling.
+fn profile_entity(id: &str) -> GraphVector {
+    let (name, version) = match id {
+        PROCESS_PROFILE => ("Process Run Crate", "0.1"),
+        WORKFLOW_RUN_CRATE_PROFILE => ("Workflow Run Crate", "0.1"),
+        PROVENANCE_RUN_CRATE_PROFILE => ("Provenance Run Crate", "0.1"),
+        WORKFLOW_RO_CRATE_PROFILE => ("Workflow RO-Crate", "1.0"),
+        _ => ("RO-Crate profile", ""),
+    };
+    let mut props = vec![("name", ev_str(name))];
+    if !version.is_empty() {
+        props.push(("version", ev_str(version)));
+    }
+    GraphVector::ContextualEntity(ContextualEntity {
+        id: id.to_string(),
+        type_: DataType::Term("CreativeWork".to_string()),
+        dynamic_entity: bag(props),
+    })
+}
+
+/// The selected callable's input and output declarations, by name.
+type CallableInterface<'a> = (Vec<(String, &'a Input)>, Vec<(String, &'a Output)>);
+
+/// Returns the selected callable's input and output declarations.
+fn callable_interface<'a>(ctx: &'a RunCrateContext<'a>) -> CallableInterface<'a> {
+    match ctx.target {
+        Target::Workflow(name) => {
+            if let Some(wf) = ctx.document.workflow().filter(|w| w.name() == name) {
+                return (
+                    wf.inputs().iter().map(|(k, v)| (k.clone(), v)).collect(),
+                    wf.outputs().iter().map(|(k, v)| (k.clone(), v)).collect(),
+                );
+            }
+            (Vec::new(), Vec::new())
+        }
+        Target::Task(name) => {
+            if let Some(task) = ctx.document.task_by_name(name) {
+                return (
+                    task.inputs().iter().map(|(k, v)| (k.clone(), v)).collect(),
+                    task.outputs().iter().map(|(k, v)| (k.clone(), v)).collect(),
+                );
+            }
+            (Vec::new(), Vec::new())
+        }
+    }
+}
+
+/// Builds the full Workflow Run RO-Crate graph for a completed run.
+///
+/// Localizing inputs/outputs can fail (e.g. an un-localizable remote value); the
+/// error propagates so the caller can honor `--ro-crate-strict`.
+pub fn build_run_crate(ctx: &RunCrateContext<'_>, opts: &RoCrateOptions) -> Result<RoCrate> {
+    let crate_root = ctx.run_dir.root();
+    let mut crate_ = RoCrate {
+        context: RoCrateContext::ReferenceContext(ROCRATE_CONTEXT.to_string()),
+        graph: Vec::new(),
+    };
+    crate_.add_context(ContextItem::ReferenceItem(WFRUN_CONTEXT.to_string()));
+
+    // Workflow targets emit a Workflow Run Crate with a `ComputationalWorkflow`
+    // main entity. Direct task targets emit a Process Run Crate: a task is a
+    // single process, not a workflow, so we type its WDL source as plain
+    // `SoftwareSourceCode` and claim only the Process Run Crate profile rather
+    // than fabricating a workflow that does not exist.
+    let is_workflow = matches!(ctx.target, Target::Workflow(_));
+    let wf_name = ctx.target.name().to_string();
+    let (wf_desc, mut wf_types, mut profiles): (String, Vec<String>, Vec<&str>) = if is_workflow {
+        (
+            format!("WDL workflow `{wf_name}`"),
+            vec![
+                "File".to_string(),
+                "SoftwareSourceCode".to_string(),
+                "ComputationalWorkflow".to_string(),
+            ],
+            PROFILES.to_vec(),
+        )
+    } else {
+        (
+            format!("WDL task `{wf_name}`"),
+            vec!["File".to_string(), "SoftwareSourceCode".to_string()],
+            vec![PROCESS_PROFILE],
+        )
+    };
+    if is_workflow {
+        profiles.push(PROVENANCE_RUN_CRATE_PROFILE);
+    }
+    let mut task_step_ids = Vec::new();
+    let mut task_control_ids = Vec::new();
+    let mut task_tool_ids = Vec::new();
+    let mut data_parts = Vec::new();
+    if is_workflow && !ctx.tasks.is_empty() {
+        for (index, task) in ctx.tasks.iter().enumerate() {
+            let ids = super::tasks::task_step_entities(task, index + 1, &mut crate_.graph);
+            let slug = sanitize_component(&task.name);
+            if let Some(log) = ctx.task_logs.iter().find(|log| log.task_name == task.name) {
+                let log_ids = super::tasks::task_log_entities(
+                    &slug,
+                    &ids.action,
+                    log,
+                    crate_root,
+                    opts,
+                    &mut crate_.graph,
+                )?;
+                data_parts.extend(log_ids);
+            }
+            task_step_ids.push(ids.step);
+            task_control_ids.push(ids.control);
+            task_tool_ids.push(ids.tool);
+        }
+    }
+    if !task_step_ids.is_empty() {
+        wf_types.push("HowTo".to_string());
+    }
+    let (inputs_iface, outputs_iface) = callable_interface(ctx);
+    let input_param_ids = inputs_iface
+        .iter()
+        .map(|(name, _)| format!("#param-in-{name}"))
+        .collect::<Vec<_>>();
+    let output_param_ids = outputs_iface
+        .iter()
+        .map(|(name, _)| format!("#param-out-{name}"))
+        .collect::<Vec<_>>();
+    let input_params = inputs_iface
+        .iter()
+        .map(|(name, _)| (name.clone(), format!("#param-in-{name}")))
+        .collect::<HashMap<_, _>>();
+    let output_params = outputs_iface
+        .iter()
+        .map(|(name, _)| (name.clone(), format!("#param-out-{name}")))
+        .collect::<HashMap<_, _>>();
+
+    // Timing is recorded only when actually known; `startTime`/`endTime` are not
+    // required, so we omit them rather than fabricate values.
+    // Use the canonical ISO 8601 / `xsd:dateTime` form (`...Z`, no fractional
+    // seconds) that RO-Crate consumers and validators expect.
+    let iso =
+        |t: chrono::DateTime<chrono::Utc>| t.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+    let started = ctx.run.started_at.map(iso);
+    let ended = ctx.run.completed_at.map(iso);
+    // `date_published` is required on the root dataset; use a real run timestamp
+    // (start when known, else the creation time) rather than inventing one.
+    let date_published = iso(ctx.run.started_at.unwrap_or(ctx.run.created_at));
+
+    // Metadata descriptor. Per Workflow RO-Crate, it conforms to RO-Crate 1.1 and
+    // (for workflow targets) the Workflow RO-Crate profile.
+    let descriptor_conforms = if is_workflow {
+        Id::IdArray(vec![
+            "https://w3id.org/ro/crate/1.1".to_string(),
+            WORKFLOW_RO_CRATE_PROFILE.to_string(),
+        ])
+    } else {
+        Id::Id("https://w3id.org/ro/crate/1.1".to_string())
+    };
+    crate_
+        .graph
+        .push(GraphVector::MetadataDescriptor(MetadataDescriptor {
+            id: METADATA_FILE.to_string(),
+            type_: DataType::Term("CreativeWork".to_string()),
+            conforms_to: descriptor_conforms,
+            about: Id::Id("./".to_string()),
+            dynamic_entity: None,
+        }));
+
+    // Engine `SoftwareApplication`.
+    crate_
+        .graph
+        .push(GraphVector::ContextualEntity(ContextualEntity {
+            id: "#engine".to_string(),
+            type_: DataType::Term("SoftwareApplication".to_string()),
+            dynamic_entity: bag(vec![
+                ("name", ev_str(&ctx.engine.name)),
+                ("version", ev_str(&ctx.engine.version)),
+                ("url", ev_str(&ctx.engine.repository)),
+            ]),
+        }));
+
+    // Submitter agent — emitted only when a real submitter is known; never
+    // invented.
+    let agent_name = ctx
+        .session
+        .map(|s| s.created_by.as_str())
+        .filter(|n| !n.is_empty());
+    if let Some(name) = agent_name {
+        crate_
+            .graph
+            .push(GraphVector::ContextualEntity(ContextualEntity {
+                id: "#agent".to_string(),
+                type_: DataType::Term("Person".to_string()),
+                dynamic_entity: bag(vec![("name", ev_str(name))]),
+            }));
+    }
+
+    // Main executable entity (the materialized WDL source, written by
+    // `materialize_sources`).
+    let mut workflow_props = vec![
+        ("name", ev_str(&wf_name)),
+        ("description", ev_str(&wf_desc)),
+        ("programmingLanguage", ev_id("#wdl")),
+    ];
+    // Record the source location only when it is a remote URL; a local source
+    // path would leak host filesystem layout.
+    if ctx.run.source.contains("://") {
+        workflow_props.push(("url", ev_str(&ctx.run.source)));
+    }
+    // `input`/`output` are `ComputationalWorkflow` properties; only attach them to
+    // a workflow entity. For task targets the formal parameters are still emitted
+    // and linked from the realized values via `exampleOfWork`.
+    if is_workflow {
+        if !input_param_ids.is_empty() {
+            workflow_props.push(("input", ev_ids(input_param_ids)));
+        }
+        if !output_param_ids.is_empty() {
+            workflow_props.push(("output", ev_ids(output_param_ids)));
+        }
+        if !task_step_ids.is_empty() {
+            workflow_props.push(("step", ev_ids(task_step_ids)));
+            workflow_props.push(("hasPart", ev_ids(task_tool_ids)));
+        }
+    }
+    crate_.graph.push(GraphVector::DataEntity(DataEntity {
+        id: WORKFLOW_ID.to_string(),
+        type_: DataType::TermArray(wf_types),
+        dynamic_entity: bag(workflow_props),
+    }));
+    crate_
+        .graph
+        .push(GraphVector::ContextualEntity(ContextualEntity {
+            id: "#wdl".to_string(),
+            type_: DataType::Term("ComputerLanguage".to_string()),
+            dynamic_entity: bag(vec![
+                ("name", ev_str("WDL")),
+                ("url", ev_str("https://openwdl.org")),
+            ]),
+        }));
+
+    // Formal parameters from the selected callable's interface.
+    for (name, input) in inputs_iface {
+        let pid = format!("#param-in-{name}");
+        crate_
+            .graph
+            .push(formal_parameter(&pid, &name, input.ty(), input.required()));
+    }
+    for (name, output) in outputs_iface {
+        let pid = format!("#param-out-{name}");
+        crate_.graph.push(formal_parameter(
+            &pid,
+            &name,
+            output.ty(),
+            !output.ty().is_optional(),
+        ));
+    }
+
+    // Realized inputs/outputs. Crate-contained data entities (those whose `@id`
+    // is a crate-relative path, not a `#`-prefixed `PropertyValue`) are collected
+    // so the root dataset can reference them from `hasPart`.
+    let mut input_ids = Vec::new();
+    for (name, value) in ctx.inputs_iter() {
+        let id = value_to_entities("input", name, value, crate_root, opts, &mut crate_.graph)?;
+        if let Some(param_id) = input_params.get(name) {
+            let mut property = HashMap::new();
+            property.insert("exampleOfWork".to_string(), ev_id(param_id));
+            crate_.add_dynamic_entity_property(&id, property);
+        }
+        if !id.starts_with('#') {
+            data_parts.push(id.clone());
+        }
+        input_ids.push(id);
+    }
+    let mut output_ids = Vec::new();
+    for (name, value) in ctx.outputs.iter() {
+        let id = value_to_entities("output", name, value, crate_root, opts, &mut crate_.graph)?;
+        if let Some(param_id) = output_params.get(name) {
+            let mut property = HashMap::new();
+            property.insert("exampleOfWork".to_string(), ev_id(param_id));
+            crate_.add_dynamic_entity_property(&id, property);
+        }
+        if !id.starts_with('#') {
+            data_parts.push(id.clone());
+        }
+        output_ids.push(id);
+    }
+
+    // Engine `OrganizeAction` — the workflow engine orchestrating the run. Only
+    // meaningful for workflow targets; a single task is one process with no
+    // orchestration. Its `result` is the run `CreateAction` (`object` is reserved
+    // for the step/control actions added with step-level provenance later).
+    if is_workflow {
+        let mut organize_props = vec![
+            ("name", ev_str("Workflow orchestration")),
+            ("instrument", ev_id("#engine")),
+            ("result", ev_id("#run")),
+        ];
+        // The agent is the submitter (when known); the engine is the instrument.
+        if agent_name.is_some() {
+            organize_props.push(("agent", ev_id("#agent")));
+        }
+        if !task_control_ids.is_empty() {
+            organize_props.push(("object", ev_ids(task_control_ids)));
+        }
+        if let Some(s) = &started {
+            organize_props.push(("startTime", ev_str(s)));
+        }
+        if let Some(e) = &ended {
+            organize_props.push(("endTime", ev_str(e)));
+        }
+        crate_
+            .graph
+            .push(GraphVector::ContextualEntity(ContextualEntity {
+                id: "#organize".to_string(),
+                type_: DataType::Term("OrganizeAction".to_string()),
+                dynamic_entity: bag(organize_props),
+            }));
+    }
+
+    // Workflow-level `CreateAction`.
+    let run_description = format!("Execution of {wf_desc}");
+    let mut run_props = vec![
+        ("name", ev_str(&ctx.run.name)),
+        ("description", ev_str(&run_description)),
+        ("instrument", ev_id(WORKFLOW_ID)),
+        (
+            "actionStatus",
+            ev_id("http://schema.org/CompletedActionStatus"),
+        ),
+    ];
+    // Omit empty `object`/`result` rather than emitting empty arrays.
+    if !input_ids.is_empty() {
+        run_props.push(("object", ev_ids(input_ids.clone())));
+    }
+    if !output_ids.is_empty() {
+        run_props.push(("result", ev_ids(output_ids.clone())));
+    }
+    if agent_name.is_some() {
+        run_props.push(("agent", ev_id("#agent")));
+    }
+    if let Some(s) = &started {
+        run_props.push(("startTime", ev_str(s)));
+    }
+    if let Some(e) = &ended {
+        run_props.push(("endTime", ev_str(e)));
+    }
+    crate_
+        .graph
+        .push(GraphVector::ContextualEntity(ContextualEntity {
+            id: "#run".to_string(),
+            type_: DataType::Term("CreateAction".to_string()),
+            dynamic_entity: bag(run_props),
+        }));
+
+    // Define a `CreativeWork` entity for each conformance profile so the
+    // `conformsTo` references resolve.
+    for profile in &profiles {
+        crate_.graph.push(profile_entity(profile));
+    }
+
+    // Root dataset. `mentions` references the action entities that describe the
+    // run (data entities are referenced from `hasPart`, not `mentions`).
+    let mut mentions = vec!["#run".to_string()];
+    if is_workflow {
+        mentions.push("#organize".to_string());
+    }
+    // `hasPart` lists the crate-contained data entities: the main WDL source and
+    // every localized/in-place input/output file or directory.
+    let mut has_part = vec![WORKFLOW_ID.to_string()];
+    has_part.extend(data_parts);
+    let mut root_props = vec![
+        (
+            "conformsTo",
+            ev_ids(profiles.iter().map(|s| s.to_string()).collect()),
+        ),
+        ("mainEntity", ev_id(WORKFLOW_ID)),
+        ("mentions", ev_ids(mentions)),
+        ("hasPart", ev_ids(has_part)),
+    ];
+    if agent_name.is_some() {
+        root_props.push(("author", ev_id("#agent")));
+    }
+    crate_
+        .graph
+        .push(GraphVector::RootDataEntity(RootDataEntity {
+            id: "./".to_string(),
+            type_: DataType::Term("Dataset".to_string()),
+            name: ctx.run.name.clone(),
+            description: wf_desc,
+            date_published,
+            // Required by the data model; Sprocket does not assert a license for
+            // the run's data, so this honestly records that none was specified.
+            license: License::Description("license not specified".to_string()),
+            dynamic_entity: bag(root_props),
+        }));
+
+    Ok(crate_)
+}
+
+/// Links materialized import `@id`s to the root dataset's `hasPart`.
+pub fn add_import_parts(crate_: &mut RoCrate, import_ids: &[String]) {
+    if import_ids.is_empty() {
+        return;
+    }
+    for entity in &mut crate_.graph {
+        let GraphVector::RootDataEntity(root) = entity else {
+            continue;
+        };
+        if root.id != "./" {
+            continue;
+        }
+
+        let dynamic = root.dynamic_entity.get_or_insert_with(HashMap::new);
+        let mut ids = dynamic
+            .remove("hasPart")
+            .map(id_value_ids)
+            .unwrap_or_default();
+        for id in import_ids {
+            if !ids.contains(id) {
+                ids.push(id.clone());
+            }
+        }
+        dynamic.insert("hasPart".to_string(), ev_ids(ids));
+        return;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_import_parts_links_imports_to_root() {
+        let mut crate_ = RoCrate {
+            context: RoCrateContext::ReferenceContext(ROCRATE_CONTEXT.to_string()),
+            graph: vec![GraphVector::RootDataEntity(RootDataEntity {
+                id: "./".to_string(),
+                type_: DataType::Term("Dataset".to_string()),
+                name: "test run".to_string(),
+                description: "test crate".to_string(),
+                date_published: "2026-01-01T00:00:00Z".to_string(),
+                license: License::Description("license not specified".to_string()),
+                dynamic_entity: bag(vec![("hasPart", ev_ids(vec!["#tool-task".to_string()]))]),
+            })],
+        };
+        add_import_parts(&mut crate_, &["workflow/tasks.wdl".to_string()]);
+        let json = serde_json::to_string(&crate_).unwrap();
+        assert!(json.contains("hasPart"));
+        assert!(json.contains("#tool-task"));
+        assert!(json.contains("workflow/tasks.wdl"));
+    }
+}

--- a/src/system/v1/rocrate/context.rs
+++ b/src/system/v1/rocrate/context.rs
@@ -1,0 +1,94 @@
+//! The data contract collected during a run and consumed by the crate builder.
+
+use crate::system::v1::db::models::Run;
+use crate::system::v1::db::models::Session;
+use crate::system::v1::exec::Target;
+use crate::system::v1::fs::RunDirectory;
+
+/// Identifying metadata for the Sprocket engine, used for the engine
+/// `SoftwareApplication` entity.
+#[derive(Debug, Clone)]
+pub struct EngineInfo {
+    /// Package name (e.g. `sprocket`).
+    pub name: String,
+    /// Package version.
+    pub version: String,
+    /// Repository URL.
+    pub repository: String,
+}
+
+impl EngineInfo {
+    /// Reads engine identity from build-time Cargo metadata.
+    pub fn from_build() -> Self {
+        Self {
+            name: env!("CARGO_PKG_NAME").to_string(),
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            repository: option_env!("CARGO_PKG_REPOSITORY")
+                .filter(|s| !s.is_empty())
+                .unwrap_or("https://github.com/stjude-rust-labs/sprocket")
+                .to_string(),
+        }
+    }
+}
+
+/// Scrubbed task logs that may be materialized into the crate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScrubbedLog {
+    /// The task name the streams belong to.
+    pub task_name: String,
+    /// Scrubbed standard output, if present.
+    pub stdout: Option<String>,
+    /// Scrubbed standard error, if present.
+    pub stderr: Option<String>,
+}
+
+/// All typed run state needed to build a Workflow Run RO-Crate. Borrowed so the
+/// builder runs without taking ownership of execution state.
+#[derive(Debug)]
+pub struct RunCrateContext<'a> {
+    /// The completed run's DB row.
+    pub run: &'a Run,
+    /// The session row (submitter attribution), if available.
+    pub session: Option<&'a Session>,
+    /// The analyzed document (workflow/task interface, imports, source).
+    pub document: &'a wdl::analysis::Document,
+    /// The selected run target.
+    pub target: &'a Target,
+    /// Typed inputs supplied to the run.
+    pub inputs: &'a wdl::engine::Inputs,
+    /// Typed outputs produced by the run.
+    pub outputs: &'a wdl::engine::Outputs,
+    /// The run directory (crate root).
+    pub run_dir: &'a RunDirectory,
+    /// The run's task rows (one per WDL task name at the current database
+    /// granularity), used for step-level provenance.
+    pub tasks: &'a [crate::system::v1::db::models::Task],
+    /// Scrubbed task logs to materialize as crate files.
+    pub task_logs: &'a [ScrubbedLog],
+    /// Engine identity.
+    pub engine: EngineInfo,
+}
+
+impl RunCrateContext<'_> {
+    /// Iterates the realized inputs as `(name, value)`, flattening the
+    /// task/workflow `Inputs` enum.
+    pub fn inputs_iter(&self) -> Box<dyn Iterator<Item = (&str, &wdl::engine::Value)> + '_> {
+        match self.inputs {
+            wdl::engine::Inputs::Task(t) => Box::new(t.iter()),
+            wdl::engine::Inputs::Workflow(w) => Box::new(w.iter()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn engine_info_from_env_is_populated() {
+        let e = EngineInfo::from_build();
+        assert_eq!(e.name, "sprocket");
+        assert!(!e.version.is_empty());
+        assert!(e.repository.starts_with("http"));
+    }
+}

--- a/src/system/v1/rocrate/formal.rs
+++ b/src/system/v1/rocrate/formal.rs
@@ -1,0 +1,82 @@
+//! Maps WDL interface declarations to RO-Crate `FormalParameter` entities.
+
+use std::collections::HashMap;
+
+use rocraters::ro_crate::constraints::DataType;
+use rocraters::ro_crate::constraints::EntityValue;
+use rocraters::ro_crate::constraints::Id;
+use rocraters::ro_crate::contextual_entity::ContextualEntity;
+use rocraters::ro_crate::graph_vector::GraphVector;
+use wdl::analysis::types::PrimitiveType;
+use wdl::analysis::types::Type;
+
+/// Bioschemas `FormalParameter` profile that the parameter entities conform to.
+const FORMAL_PARAMETER_PROFILE: &str =
+    "https://bioschemas.org/profiles/FormalParameter/1.0-RELEASE";
+
+/// Returns the `additionalType` term for a WDL type. Primitives map to
+/// schema.org `DataType`s (with `File`/`Dataset` for `File`/`Directory` per
+/// RO-Crate convention); compound values map to `PropertyValue`, the schema.org
+/// type for structured values.
+pub fn additional_type(ty: &Type) -> String {
+    if let Some(p) = ty.as_primitive() {
+        return match p {
+            PrimitiveType::Boolean => "Boolean",
+            PrimitiveType::Integer => "Integer",
+            PrimitiveType::Float => "Float",
+            PrimitiveType::String => "Text",
+            PrimitiveType::File => "File",
+            PrimitiveType::Directory => "Dataset",
+        }
+        .to_string();
+    }
+    // Arrays, pairs, maps, and structs are all structured values.
+    "PropertyValue".to_string()
+}
+
+/// Builds the `dynamic_entity` map from `(key, value)` pairs.
+fn bag(pairs: Vec<(&str, EntityValue)>) -> Option<HashMap<String, EntityValue>> {
+    Some(pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+}
+
+/// Builds a `FormalParameter` contextual entity for a named declaration.
+pub fn formal_parameter(id: &str, name: &str, ty: &Type, value_required: bool) -> GraphVector {
+    GraphVector::ContextualEntity(ContextualEntity {
+        id: id.to_string(),
+        type_: DataType::Term("FormalParameter".to_string()),
+        dynamic_entity: bag(vec![
+            ("name", EntityValue::EntityString(name.to_string())),
+            (
+                "additionalType",
+                EntityValue::EntityString(additional_type(ty)),
+            ),
+            ("valueRequired", EntityValue::EntityBool(value_required)),
+            (
+                "conformsTo",
+                EntityValue::EntityId(Id::Id(FORMAL_PARAMETER_PROFILE.to_string())),
+            ),
+        ]),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn additional_type_for_primitive_file() {
+        let ty = Type::Primitive(PrimitiveType::File, false);
+        assert_eq!(additional_type(&ty), "File");
+    }
+
+    #[test]
+    fn formal_parameter_has_id_and_type() {
+        let ty = Type::Primitive(PrimitiveType::String, false);
+        let gv = formal_parameter("#param-x", "x", &ty, true);
+        assert_eq!(gv.get_id().as_str(), "#param-x");
+        let json = serde_json::to_string(&gv).unwrap();
+        assert!(json.contains("FormalParameter"));
+        assert!(json.contains("\"name\":\"x\""));
+        assert!(json.contains("\"valueRequired\":true"));
+    }
+}

--- a/src/system/v1/rocrate/mod.rs
+++ b/src/system/v1/rocrate/mod.rs
@@ -1,0 +1,816 @@
+//! Workflow Run RO-Crate emission for completed runs.
+
+mod build;
+mod context;
+mod formal;
+mod redact;
+mod source;
+mod tasks;
+mod value;
+
+pub use build::add_import_parts;
+pub use build::build_run_crate;
+pub use context::EngineInfo;
+pub use context::RunCrateContext;
+pub use context::ScrubbedLog;
+pub use formal::formal_parameter;
+pub use redact::RedactionPolicy;
+pub use redact::Scrubbed;
+pub use source::materialize_sources;
+pub use tasks::TaskEntityIds;
+pub use tasks::task_action_status;
+pub use tasks::task_step_entities;
+pub use value::value_to_entities;
+
+/// RO-Crate 1.1 base context.
+pub const ROCRATE_CONTEXT: &str = "https://w3id.org/ro/crate/1.1/context";
+/// Workflow Run RO-Crate term context.
+pub const WFRUN_CONTEXT: &str = "https://w3id.org/ro/terms/workflow-run/context";
+/// Process Run Crate profile, claimed by both workflow and task targets.
+pub const PROCESS_PROFILE: &str = "https://w3id.org/ro/wfrun/process/0.1";
+/// Workflow Run Crate profile.
+pub const WORKFLOW_RUN_CRATE_PROFILE: &str = "https://w3id.org/ro/wfrun/workflow/0.1";
+/// Provenance Run Crate profile.
+pub const PROVENANCE_RUN_CRATE_PROFILE: &str = "https://w3id.org/ro/wfrun/provenance/0.1";
+/// Workflow RO-Crate profile.
+pub const WORKFLOW_RO_CRATE_PROFILE: &str = "https://w3id.org/workflowhub/workflow-ro-crate/1.0";
+/// Profiles a workflow-target crate conforms to. Task targets conform only to
+/// the Process Run Crate profile, since there is no `ComputationalWorkflow`.
+pub const PROFILES: &[&str] = &[
+    PROCESS_PROFILE,
+    WORKFLOW_RUN_CRATE_PROFILE,
+    WORKFLOW_RO_CRATE_PROFILE,
+];
+/// The metadata descriptor filename.
+pub const METADATA_FILE: &str = "ro-crate-metadata.json";
+/// The main workflow entity id, materialized under `workflow/`.
+pub const WORKFLOW_ID: &str = "workflow/workflow.wdl";
+
+/// Controls whether and how a run emits an RO-Crate.
+#[derive(Debug, Clone, Copy)]
+pub struct RoCrateOptions {
+    /// Whether to emit `ro-crate-metadata.json` at all.
+    pub enabled: bool,
+    /// Whether an emission failure should fail the command.
+    pub strict: bool,
+    /// Whether to compute SHA-256 digests for `File`/`Directory` entities.
+    pub checksums: bool,
+    /// Whether to localize input/output data values into crate-relative paths.
+    pub localize: bool,
+    /// Whether to include log contents in crate metadata.
+    pub include_log_contents: bool,
+}
+
+impl RoCrateOptions {
+    /// Builds options from the `--ro-crate`, `--ro-crate-strict`,
+    /// `--no-ro-crate-checksums`, and `--no-ro-crate-localize` flags. The `no_*`
+    /// values are raw flags, so each behavior is enabled when its flag is
+    /// `false`.
+    pub fn from_flags(enabled: bool, strict: bool, no_checksums: bool, no_localize: bool) -> Self {
+        Self {
+            enabled,
+            strict,
+            checksums: !no_checksums,
+            localize: !no_localize,
+            include_log_contents: false,
+        }
+    }
+
+    /// Options that emit nothing (used by non-CLI run paths).
+    pub fn disabled() -> Self {
+        Self {
+            enabled: false,
+            strict: false,
+            checksums: false,
+            localize: false,
+            include_log_contents: false,
+        }
+    }
+}
+
+/// Recursively collects every `{"@id": "..."}` reference value in a JSON tree.
+fn collect_id_refs(value: &serde_json::Value, out: &mut Vec<String>) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (k, v) in map {
+                if k == "@id"
+                    && let Some(s) = v.as_str()
+                {
+                    out.push(s.to_string());
+                } else {
+                    collect_id_refs(v, out);
+                }
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                collect_id_refs(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Structural validation before writing. The graph must contain the required
+/// entities, every `@id` must be unique, and every `@id` reference must resolve
+/// to a defined entity or an absolute URI (no dangling references).
+fn validate(crate_: &rocraters::ro_crate::rocrate::RoCrate) -> anyhow::Result<()> {
+    let ids = crate_.get_all_ids();
+    for required in [METADATA_FILE, "./", WORKFLOW_ID, "#run"] {
+        anyhow::ensure!(
+            ids.iter().any(|i| *i == required),
+            "RO-Crate missing required entity `{required}`"
+        );
+    }
+
+    let mut defined = std::collections::HashSet::new();
+    for id in &ids {
+        anyhow::ensure!(
+            defined.insert((*id).clone()),
+            "RO-Crate has a duplicate `@id` `{id}`"
+        );
+    }
+
+    use anyhow::Context as _;
+    let json = serde_json::to_value(crate_).context("serializing RO-Crate for validation")?;
+    let mut refs = Vec::new();
+    collect_id_refs(&json, &mut refs);
+    for r in refs {
+        // Entity self-ids are in `defined`; references must resolve there, unless
+        // they are absolute URIs (contexts, profiles, schema.org terms).
+        if r.starts_with("http://") || r.starts_with("https://") {
+            continue;
+        }
+        anyhow::ensure!(
+            defined.contains(&r),
+            "RO-Crate has a dangling `@id` reference `{r}`"
+        );
+    }
+    Ok(())
+}
+
+/// Builds, materializes sources for, validates, and writes the crate into the
+/// run directory.
+pub fn write_run_crate(ctx: &RunCrateContext<'_>, opts: &RoCrateOptions) -> anyhow::Result<()> {
+    let mut crate_ = build_run_crate(ctx, opts)?;
+    let import_ids = materialize_sources(ctx.document, ctx.run_dir.root(), &mut crate_.graph)?;
+    add_import_parts(&mut crate_, &import_ids);
+    validate(&crate_)?;
+    let path = ctx.run_dir.root().join(METADATA_FILE);
+    rocraters::ro_crate::write::write_crate(&crate_, path.to_string_lossy().to_string())
+        .map_err(|e| anyhow::anyhow!("writing RO-Crate metadata: {e}"))?;
+    Ok(())
+}
+
+/// Reads and scrubs one task log stream.
+async fn scrub_task_log_stream(
+    db: &dyn crate::system::v1::db::Database,
+    task_name: &str,
+    source: crate::system::v1::db::models::LogSource,
+    policy: &RedactionPolicy,
+) -> anyhow::Result<Option<String>> {
+    let logs = db
+        .get_task_logs(task_name, Some(source), Some(i64::MAX), None)
+        .await?;
+    let chunks = logs
+        .iter()
+        .flat_map(|log| log.chunk.iter().copied())
+        .collect::<Vec<_>>();
+    if chunks.is_empty() {
+        return Ok(None);
+    }
+    let text = String::from_utf8_lossy(&chunks);
+    let scrubbed = policy.scrub(&text);
+    Ok(Some(scrubbed.text))
+}
+
+/// Collects provenance and emits the crate for a completed run.
+///
+/// Honors `opts.strict`: on failure it returns the error when strict, else logs
+/// a warning and returns `Ok`. Called *after* the run is recorded complete, so a
+/// strict failure surfaces as a nonzero command exit without changing the run's
+/// recorded success.
+#[allow(clippy::too_many_arguments)]
+pub async fn emit(
+    db: &dyn crate::system::v1::db::Database,
+    run_id: uuid::Uuid,
+    target: &crate::system::v1::exec::Target,
+    document: &wdl::analysis::Document,
+    inputs: &wdl::engine::Inputs,
+    outputs: &wdl::engine::Outputs,
+    run_dir: &crate::system::v1::fs::RunDirectory,
+    opts: &RoCrateOptions,
+) -> anyhow::Result<()> {
+    use crate::system::v1::db::models::LogSource;
+    use anyhow::Context as _;
+
+    if !opts.enabled {
+        return Ok(());
+    }
+
+    let result = async {
+        let run = db
+            .get_run(run_id)
+            .await?
+            .with_context(|| format!("run `{run_id}` not found"))?;
+        let session = db.get_session(run.session_uuid).await?;
+        // Fetch every task for the run; `list_tasks` otherwise returns only the
+        // first page.
+        let tasks = db
+            .list_tasks(Some(run_id), None, Some(i64::MAX), None)
+            .await?;
+        let scrubbed_logs = if opts.include_log_contents {
+            let policy = RedactionPolicy;
+            let mut logs = Vec::new();
+            for task in &tasks {
+                let stdout = scrub_task_log_stream(db, &task.name, LogSource::Stdout, &policy)
+                    .await
+                    .with_context(|| format!("reading stdout log for task `{}`", task.name))?;
+                let stderr = scrub_task_log_stream(db, &task.name, LogSource::Stderr, &policy)
+                    .await
+                    .with_context(|| format!("reading stderr log for task `{}`", task.name))?;
+                if stdout.is_some() || stderr.is_some() {
+                    logs.push(ScrubbedLog {
+                        task_name: task.name.clone(),
+                        stdout,
+                        stderr,
+                    });
+                }
+            }
+            logs
+        } else {
+            Vec::new()
+        };
+        let ctx = RunCrateContext {
+            run: &run,
+            session: session.as_ref(),
+            document,
+            target,
+            inputs,
+            outputs,
+            run_dir,
+            tasks: &tasks,
+            task_logs: &scrubbed_logs,
+            engine: EngineInfo::from_build(),
+        };
+        write_run_crate(&ctx, opts)
+    }
+    .await;
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(e) if opts.strict => Err(e.context("RO-Crate emission failed (--ro-crate-strict)")),
+        Err(e) => {
+            tracing::warn!("requested RO-Crate artifact was not written: {e:#}");
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_from_flags_maps_correctly() {
+        let o = RoCrateOptions::from_flags(true, false, false, false);
+        assert!(o.enabled && o.checksums && o.localize && !o.strict && !o.include_log_contents);
+        let off = RoCrateOptions::disabled();
+        assert!(!off.enabled && !off.include_log_contents);
+    }
+
+    #[test]
+    fn validation_rejects_crate_without_required_entities() {
+        let crate_ = rocraters::ro_crate::rocrate::RoCrate {
+            context: rocraters::ro_crate::rocrate::RoCrateContext::ReferenceContext(
+                ROCRATE_CONTEXT.to_string(),
+            ),
+            graph: Vec::new(),
+        };
+        assert!(validate(&crate_).is_err());
+    }
+
+    #[test]
+    fn validation_rejects_dangling_reference() {
+        use rocraters::ro_crate::constraints::DataType;
+        use rocraters::ro_crate::constraints::EntityValue;
+        use rocraters::ro_crate::constraints::Id;
+        use rocraters::ro_crate::contextual_entity::ContextualEntity;
+        use rocraters::ro_crate::graph_vector::GraphVector;
+
+        let stub = |id: &str| {
+            GraphVector::ContextualEntity(ContextualEntity {
+                id: id.to_string(),
+                type_: DataType::Term("Thing".to_string()),
+                dynamic_entity: None,
+            })
+        };
+        let mut graph = vec![stub(METADATA_FILE), stub("./"), stub(WORKFLOW_ID)];
+        // `#run` references an entity that is never defined.
+        graph.push(GraphVector::ContextualEntity(ContextualEntity {
+            id: "#run".to_string(),
+            type_: DataType::Term("CreateAction".to_string()),
+            dynamic_entity: Some(
+                [(
+                    "agent".to_string(),
+                    EntityValue::EntityId(Id::Id("#ghost".to_string())),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+        }));
+        let crate_ = rocraters::ro_crate::rocrate::RoCrate {
+            context: rocraters::ro_crate::rocrate::RoCrateContext::ReferenceContext(
+                ROCRATE_CONTEXT.to_string(),
+            ),
+            graph,
+        };
+        let err = validate(&crate_).unwrap_err();
+        assert!(err.to_string().contains("dangling"), "{err}");
+    }
+
+    /// End-to-end: analyze a tiny workflow, build a `RunCrateContext` from
+    /// hand-built provenance, and assert the written crate is well-formed. Uses
+    /// the real analyzer; no execution backend (and thus no Docker) is required.
+    #[tokio::test]
+    async fn writes_workflow_run_crate_end_to_end() {
+        use std::str::FromStr as _;
+
+        use chrono::Utc;
+        use uuid::Uuid;
+        use wdl::engine::Inputs;
+        use wdl::engine::Outputs;
+        use wdl::engine::Value;
+        use wdl::engine::WorkflowInputs;
+
+        use crate::analysis::Source;
+        use crate::commands::validate::analyze_source;
+        use crate::system::v1::db::models::Run;
+        use crate::system::v1::db::models::RunStatus;
+        use crate::system::v1::db::models::Session;
+        use crate::system::v1::db::models::SprocketCommand;
+        use crate::system::v1::db::models::Task;
+        use crate::system::v1::db::models::TaskStatus;
+        use crate::system::v1::exec::Target;
+        use crate::system::v1::fs::OutputDirectory;
+
+        let dir = tempfile::tempdir().unwrap();
+        let wdl = dir.path().join("source.wdl");
+        let task_wdl = dir.path().join("tasks.wdl");
+        std::fs::write(
+            &wdl,
+            r#"version 1.3
+
+import "tasks.wdl" as tasks
+
+workflow myworkflow {
+    input {
+        String greeting = "hi"
+    }
+
+    call tasks.echo {
+        input:
+            greeting = greeting
+    }
+
+    output {
+        String message = echo.message
+    }
+}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            &task_wdl,
+            r#"version 1.3
+
+task echo {
+    input {
+        String greeting
+    }
+
+    command <<<
+        echo "~{greeting}"
+    >>>
+
+    output {
+        String message = read_string(stdout())
+    }
+}
+"#,
+        )
+        .unwrap();
+
+        let source = Source::from_str(wdl.to_str().unwrap()).unwrap();
+        let document = analyze_source(&source, None)
+            .await
+            .expect("analysis should succeed");
+
+        let output_dir = OutputDirectory::new(dir.path().join("out"));
+        let run_dir = output_dir.ensure_workflow_run("myworkflow").unwrap();
+
+        let now = Utc::now();
+        let session = Session {
+            uuid: Uuid::new_v4(),
+            subcommand: SprocketCommand::Run,
+            created_by: "tester".to_string(),
+            created_at: now,
+        };
+        let run = Run {
+            uuid: Uuid::new_v4(),
+            session_uuid: session.uuid,
+            name: "tiny-run".to_string(),
+            source: "source.wdl".to_string(),
+            target: Some("myworkflow".to_string()),
+            status: RunStatus::Completed,
+            inputs: "{}".to_string(),
+            outputs: Some("{}".to_string()),
+            error: None,
+            directory: Some(run_dir.root().display().to_string()),
+            index_directory: None,
+            started_at: Some(now),
+            completed_at: Some(now),
+            created_at: now,
+        };
+        let target = Target::Workflow("myworkflow".to_string());
+        let tasks = vec![Task {
+            name: "echo".to_string(),
+            run_uuid: run.uuid,
+            status: TaskStatus::Completed,
+            exit_status: Some(0),
+            error: None,
+            created_at: now,
+            started_at: Some(now),
+            completed_at: Some(now),
+        }];
+        let mut workflow_inputs = WorkflowInputs::default();
+        workflow_inputs.set("greeting", Value::from("hi".to_string()));
+        let inputs = Inputs::Workflow(workflow_inputs);
+        let outputs = Outputs::from_iter([("message".to_string(), Value::from("hi".to_string()))]);
+        let scrubbed = RedactionPolicy.scrub("authorization: Bearer abc.def\n");
+        let task_logs = vec![ScrubbedLog {
+            task_name: "echo".to_string(),
+            stdout: Some(scrubbed.text),
+            stderr: None,
+        }];
+
+        let ctx = RunCrateContext {
+            run: &run,
+            session: Some(&session),
+            document: &document,
+            target: &target,
+            inputs: &inputs,
+            outputs: &outputs,
+            run_dir: &run_dir,
+            tasks: &tasks,
+            task_logs: &task_logs,
+            engine: EngineInfo::from_build(),
+        };
+
+        let mut opts = RoCrateOptions::from_flags(true, false, false, false);
+        opts.include_log_contents = true;
+        write_run_crate(&ctx, &opts).expect("should write the crate");
+
+        let meta = run_dir.root().join(METADATA_FILE);
+        assert!(meta.exists(), "metadata file should exist");
+
+        let text = std::fs::read_to_string(&meta).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let graph = json["@graph"].as_array().expect("@graph array");
+        let run_action = graph
+            .iter()
+            .find(|e| e["@id"] == "#run")
+            .expect("#run entity");
+        assert_eq!(run_action["@type"], "CreateAction");
+
+        for marker in [
+            "https://w3id.org/ro/wfrun/process/0.1",
+            "https://w3id.org/ro/wfrun/workflow/0.1",
+            "https://w3id.org/ro/wfrun/provenance/0.1",
+            "https://w3id.org/workflowhub/workflow-ro-crate/1.0",
+            ROCRATE_CONTEXT,
+            WFRUN_CONTEXT,
+        ] {
+            assert!(text.contains(marker), "crate should reference `{marker}`");
+        }
+        let compact = text.split_whitespace().collect::<String>();
+        assert!(compact.contains("\"input\":[{\"@id\":\"#param-in-greeting\"}]"));
+        assert!(compact.contains("\"output\":[{\"@id\":\"#param-out-message\"}]"));
+        assert!(compact.contains("\"exampleOfWork\":{\"@id\":\"#param-in-greeting\"}"));
+        assert!(compact.contains("\"exampleOfWork\":{\"@id\":\"#param-out-message\"}"));
+        assert!(compact.contains("\"valueRequired\":false"));
+        assert!(compact.contains(
+            "\"@type\":[\"File\",\"SoftwareSourceCode\",\"ComputationalWorkflow\",\"HowTo\"]"
+        ));
+        assert!(compact.contains("\"step\":[{\"@id\":\"#step-echo\"}]"));
+        assert!(compact.contains("\"object\":[{\"@id\":\"#control-echo\"}]"));
+
+        let workflow = graph
+            .iter()
+            .find(|e| e["@id"] == WORKFLOW_ID)
+            .expect("workflow entity");
+        let workflow_has_part = workflow["hasPart"].as_array().expect("workflow hasPart");
+        assert!(workflow_has_part.iter().any(|p| p["@id"] == "#tool-echo"));
+        assert!(
+            workflow_has_part
+                .iter()
+                .all(|p| p["@id"] != "workflow/tasks.wdl")
+        );
+        let root = graph
+            .iter()
+            .find(|e| e["@id"] == "./")
+            .expect("root entity");
+        let root_has_part = root["hasPart"].as_array().expect("root hasPart");
+        assert!(
+            root_has_part
+                .iter()
+                .any(|p| p["@id"] == "workflow/tasks.wdl")
+        );
+        assert!(
+            root_has_part
+                .iter()
+                .any(|p| p["@id"] == "logs/echo/stdout.log")
+        );
+        let log_file = graph
+            .iter()
+            .find(|e| e["@id"] == "logs/echo/stdout.log")
+            .expect("stdout log entity");
+        assert_eq!(log_file["@type"], "File");
+        assert_eq!(log_file["about"]["@id"], "#task-echo");
+        let log_text =
+            std::fs::read_to_string(run_dir.root().join("logs/echo/stdout.log")).unwrap();
+        assert!(log_text.contains("[REDACTED]"));
+        assert!(!log_text.contains("abc.def"));
+
+        // The WDL source is materialized into the crate.
+        assert!(run_dir.root().join(WORKFLOW_ID).exists());
+    }
+
+    /// Unknown timing and an unknown submitter are omitted, not fabricated.
+    #[tokio::test]
+    async fn omits_unknown_timing_and_agent() {
+        use std::str::FromStr as _;
+
+        use chrono::Utc;
+        use uuid::Uuid;
+        use wdl::engine::Inputs;
+        use wdl::engine::Outputs;
+        use wdl::engine::WorkflowInputs;
+
+        use crate::analysis::Source;
+        use crate::commands::validate::analyze_source;
+        use crate::system::v1::db::models::Run;
+        use crate::system::v1::db::models::RunStatus;
+        use crate::system::v1::exec::Target;
+        use crate::system::v1::fs::OutputDirectory;
+
+        let dir = tempfile::tempdir().unwrap();
+        let wdl = dir.path().join("source.wdl");
+        std::fs::write(
+            &wdl,
+            "version 1.3\n\nworkflow myworkflow {\n    output {\n    }\n}\n",
+        )
+        .unwrap();
+
+        let source = Source::from_str(wdl.to_str().unwrap()).unwrap();
+        let document = analyze_source(&source, None).await.expect("analysis");
+
+        let output_dir = OutputDirectory::new(dir.path().join("out"));
+        let run_dir = output_dir.ensure_workflow_run("myworkflow").unwrap();
+
+        // No `started_at`/`completed_at`, and no session.
+        let run = Run {
+            uuid: Uuid::new_v4(),
+            session_uuid: Uuid::new_v4(),
+            name: "tiny-run".to_string(),
+            source: "source.wdl".to_string(),
+            target: Some("myworkflow".to_string()),
+            status: RunStatus::Completed,
+            inputs: "{}".to_string(),
+            outputs: Some("{}".to_string()),
+            error: None,
+            directory: Some(run_dir.root().display().to_string()),
+            index_directory: None,
+            started_at: None,
+            completed_at: None,
+            created_at: Utc::now(),
+        };
+        let target = Target::Workflow("myworkflow".to_string());
+        let inputs = Inputs::Workflow(WorkflowInputs::default());
+        let outputs = Outputs::default();
+
+        let ctx = RunCrateContext {
+            run: &run,
+            session: None,
+            document: &document,
+            target: &target,
+            inputs: &inputs,
+            outputs: &outputs,
+            run_dir: &run_dir,
+            tasks: &[],
+            task_logs: &[],
+            engine: EngineInfo::from_build(),
+        };
+
+        write_run_crate(&ctx, &RoCrateOptions::from_flags(true, false, false, false))
+            .expect("should write the crate");
+
+        let text = std::fs::read_to_string(run_dir.root().join(METADATA_FILE)).unwrap();
+        assert!(!text.contains("startTime"), "must not fabricate startTime");
+        assert!(!text.contains("endTime"), "must not fabricate endTime");
+        assert!(!text.contains("#agent"), "must not fabricate an agent");
+        assert!(!text.contains("unknown"), "must not invent an agent name");
+        // The required root `datePublished` is still present (a real timestamp).
+        assert!(text.contains("datePublished"));
+        assert!(
+            !run_dir.root().join("logs").exists(),
+            "empty task logs must not materialize a logs directory"
+        );
+    }
+
+    /// A direct task target emits a Process Run Crate: no `ComputationalWorkflow`
+    /// type, no workflow profile, no `OrganizeAction`.
+    #[tokio::test]
+    async fn task_target_emits_process_crate() {
+        use std::str::FromStr as _;
+
+        use chrono::Utc;
+        use uuid::Uuid;
+        use wdl::engine::Inputs;
+        use wdl::engine::Outputs;
+        use wdl::engine::TaskInputs;
+
+        use crate::analysis::Source;
+        use crate::commands::validate::analyze_source;
+        use crate::system::v1::db::models::Run;
+        use crate::system::v1::db::models::RunStatus;
+        use crate::system::v1::exec::Target;
+        use crate::system::v1::fs::OutputDirectory;
+
+        let dir = tempfile::tempdir().unwrap();
+        let wdl = dir.path().join("source.wdl");
+        std::fs::write(
+            &wdl,
+            "version 1.3\n\ntask mytask {\n    command <<<>>>\n    output {\n        String message = \"hi\"\n    }\n}\n",
+        )
+        .unwrap();
+
+        let source = Source::from_str(wdl.to_str().unwrap()).unwrap();
+        let document = analyze_source(&source, None).await.expect("analysis");
+
+        let output_dir = OutputDirectory::new(dir.path().join("out"));
+        let run_dir = output_dir.ensure_workflow_run("mytask").unwrap();
+
+        let now = Utc::now();
+        let run = Run {
+            uuid: Uuid::new_v4(),
+            session_uuid: Uuid::new_v4(),
+            name: "tiny-run".to_string(),
+            source: "source.wdl".to_string(),
+            target: Some("mytask".to_string()),
+            status: RunStatus::Completed,
+            inputs: "{}".to_string(),
+            outputs: Some("{}".to_string()),
+            error: None,
+            directory: Some(run_dir.root().display().to_string()),
+            index_directory: None,
+            started_at: Some(now),
+            completed_at: Some(now),
+            created_at: now,
+        };
+        let target = Target::Task("mytask".to_string());
+        let inputs = Inputs::Task(TaskInputs::default());
+        let outputs = Outputs::default();
+
+        let ctx = RunCrateContext {
+            run: &run,
+            session: None,
+            document: &document,
+            target: &target,
+            inputs: &inputs,
+            outputs: &outputs,
+            run_dir: &run_dir,
+            tasks: &[],
+            task_logs: &[],
+            engine: EngineInfo::from_build(),
+        };
+
+        write_run_crate(&ctx, &RoCrateOptions::from_flags(true, false, false, false))
+            .expect("should write the crate");
+
+        let text = std::fs::read_to_string(run_dir.root().join(METADATA_FILE)).unwrap();
+        assert!(
+            !text.contains("ComputationalWorkflow"),
+            "a task target must not claim to be a workflow"
+        );
+        assert!(text.contains(PROCESS_PROFILE));
+        assert!(
+            !text.contains(WORKFLOW_RO_CRATE_PROFILE),
+            "a task target must not claim the Workflow RO-Crate profile"
+        );
+        assert!(
+            !text.contains("OrganizeAction"),
+            "a single task has no orchestration action"
+        );
+    }
+
+    /// A `File` input is localized under `inputs/`, listed in the root
+    /// `hasPart`, and linked to its `FormalParameter` via `exampleOfWork`.
+    #[tokio::test]
+    async fn localizes_file_input_end_to_end() {
+        use std::str::FromStr as _;
+
+        use chrono::Utc;
+        use uuid::Uuid;
+        use wdl::engine::Inputs;
+        use wdl::engine::Outputs;
+        use wdl::engine::PrimitiveValue;
+        use wdl::engine::WorkflowInputs;
+
+        use crate::analysis::Source;
+        use crate::commands::validate::analyze_source;
+        use crate::system::v1::db::models::Run;
+        use crate::system::v1::db::models::RunStatus;
+        use crate::system::v1::exec::Target;
+        use crate::system::v1::fs::OutputDirectory;
+
+        let dir = tempfile::tempdir().unwrap();
+        let wdl = dir.path().join("source.wdl");
+        std::fs::write(
+            &wdl,
+            "version 1.3\n\nworkflow myworkflow {\n    input {\n        File reads\n    }\n\n    output {\n    }\n}\n",
+        )
+        .unwrap();
+        // The input file lives outside the run directory, so it is localized.
+        let reads = dir.path().join("reads.bam");
+        std::fs::write(&reads, b"BAM").unwrap();
+
+        let source = Source::from_str(wdl.to_str().unwrap()).unwrap();
+        let document = analyze_source(&source, None).await.expect("analysis");
+
+        let output_dir = OutputDirectory::new(dir.path().join("out"));
+        let run_dir = output_dir.ensure_workflow_run("myworkflow").unwrap();
+
+        let now = Utc::now();
+        let run = Run {
+            uuid: Uuid::new_v4(),
+            session_uuid: Uuid::new_v4(),
+            name: "tiny-run".to_string(),
+            source: "source.wdl".to_string(),
+            target: Some("myworkflow".to_string()),
+            status: RunStatus::Completed,
+            inputs: "{}".to_string(),
+            outputs: Some("{}".to_string()),
+            error: None,
+            directory: Some(run_dir.root().display().to_string()),
+            index_directory: None,
+            started_at: Some(now),
+            completed_at: Some(now),
+            created_at: now,
+        };
+        let target = Target::Workflow("myworkflow".to_string());
+        let mut wi = WorkflowInputs::default();
+        wi.set("reads", PrimitiveValue::new_file(reads.to_str().unwrap()));
+        let inputs = Inputs::Workflow(wi);
+        let outputs = Outputs::default();
+
+        let ctx = RunCrateContext {
+            run: &run,
+            session: None,
+            document: &document,
+            target: &target,
+            inputs: &inputs,
+            outputs: &outputs,
+            run_dir: &run_dir,
+            tasks: &[],
+            task_logs: &[],
+            engine: EngineInfo::from_build(),
+        };
+
+        write_run_crate(&ctx, &RoCrateOptions::from_flags(true, false, false, false))
+            .expect("should write the crate");
+
+        // The file was copied into the crate under `inputs/`.
+        assert!(run_dir.root().join("inputs/reads/reads.bam").exists());
+
+        let text = std::fs::read_to_string(run_dir.root().join(METADATA_FILE)).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+        let graph = json["@graph"].as_array().unwrap();
+
+        let file = graph
+            .iter()
+            .find(|e| e["@id"] == "inputs/reads/reads.bam")
+            .expect("localized file entity");
+        assert_eq!(file["@type"], "File");
+        assert_eq!(file["exampleOfWork"]["@id"], "#param-in-reads");
+
+        let root = graph.iter().find(|e| e["@id"] == "./").unwrap();
+        let has_part = root["hasPart"].as_array().unwrap();
+        assert!(
+            has_part
+                .iter()
+                .any(|p| p["@id"] == "inputs/reads/reads.bam"),
+            "localized input should be in root hasPart"
+        );
+    }
+}

--- a/src/system/v1/rocrate/redact.rs
+++ b/src/system/v1/rocrate/redact.rs
@@ -1,0 +1,107 @@
+//! Redaction helpers for RO-Crate log content.
+
+use std::sync::OnceLock;
+
+use regex::Regex;
+
+/// Replaces secret-shaped text before it is written into RO-Crate metadata.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RedactionPolicy;
+
+impl RedactionPolicy {
+    /// Scrubs common secret shapes from text.
+    pub fn scrub(&self, text: &str) -> Scrubbed {
+        let mut redactions = 0;
+        let mut scrubbed = text.to_string();
+
+        scrubbed = secret_regex()
+            .replace_all(&scrubbed, |_: &regex::Captures<'_>| {
+                redactions += 1;
+                "[REDACTED]".to_string()
+            })
+            .into_owned();
+
+        Scrubbed {
+            text: scrubbed,
+            redactions,
+        }
+    }
+}
+
+/// Text after redaction and the number of replacements made.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Scrubbed {
+    /// The scrubbed text.
+    pub text: String,
+    /// The number of redactions applied.
+    pub redactions: usize,
+}
+
+/// Returns the shared regex used for secret redaction.
+fn secret_regex() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+
+    REGEX.get_or_init(|| {
+        compile_regex(concat!(
+            r"(?s:-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----)",
+            r"|(?i:\bBearer\s+[-A-Za-z0-9._~+/=]+)",
+            r"|\bAKIA[0-9A-Z]{16}\b",
+            r#"|(?i:\b(?:password|passwd|secret|token|api[_-]?key|access[_-]?key)\b\s*(?:=|:)\s*(?:"[^"\r\n]*"|'[^'\r\n]*'|[^\s,;]+))"#,
+        ))
+    })
+}
+
+/// Compiles a static redaction regex.
+fn compile_regex(pattern: &str) -> Regex {
+    match Regex::new(pattern) {
+        Ok(regex) => regex,
+        Err(error) => panic!("invalid redaction regex `{pattern}`: {error}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scrubs_bearer_tokens() {
+        let scrubbed = RedactionPolicy.scrub("authorization: Bearer abc.def-123");
+
+        assert_eq!(scrubbed.text, "authorization: [REDACTED]");
+        assert_eq!(scrubbed.redactions, 1);
+    }
+
+    #[test]
+    fn scrubs_aws_access_keys() {
+        let scrubbed = RedactionPolicy.scrub("aws key AKIA0123456789ABCDEF was logged");
+
+        assert_eq!(scrubbed.text, "aws key [REDACTED] was logged");
+        assert_eq!(scrubbed.redactions, 1);
+    }
+
+    #[test]
+    fn scrubs_pem_private_key_blocks() {
+        let scrubbed = RedactionPolicy.scrub(
+            "before\n-----BEGIN RSA PRIVATE KEY-----\nsecret\n-----END RSA PRIVATE KEY-----\nafter",
+        );
+
+        assert_eq!(scrubbed.text, "before\n[REDACTED]\nafter");
+        assert_eq!(scrubbed.redactions, 1);
+    }
+
+    #[test]
+    fn scrubs_key_value_secrets() {
+        let scrubbed = RedactionPolicy.scrub("password=hunter2 api_key: \"abc 123\" ok=true");
+
+        assert_eq!(scrubbed.text, "[REDACTED] [REDACTED] ok=true");
+        assert_eq!(scrubbed.redactions, 2);
+    }
+
+    #[test]
+    fn leaves_clean_text_unchanged() {
+        let scrubbed = RedactionPolicy.scrub("workflow completed without sensitive output");
+
+        assert_eq!(scrubbed.text, "workflow completed without sensitive output");
+        assert_eq!(scrubbed.redactions, 0);
+    }
+}

--- a/src/system/v1/rocrate/source.rs
+++ b/src/system/v1/rocrate/source.rs
@@ -1,0 +1,131 @@
+//! Materializes resolved WDL source into the crate under `workflow/`.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use rocraters::ro_crate::constraints::DataType;
+use rocraters::ro_crate::data_entity::DataEntity;
+use rocraters::ro_crate::graph_vector::GraphVector;
+use url::Url;
+use wdl::analysis::Document;
+use wdl::ast::AstNode;
+
+use super::WORKFLOW_ID;
+
+/// Derives a crate-relative `workflow/`-rooted file name for an import URL,
+/// collision-renaming repeated basenames using `used`.
+fn import_path_for(url: &Url, used: &mut HashSet<String>) -> String {
+    let raw = url
+        .path_segments()
+        .and_then(|mut s| s.next_back())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("import.wdl");
+    let base = super::value::sanitize_component(raw);
+    let base = base.as_str();
+    let mut candidate = format!("workflow/{base}");
+    let mut n = 1;
+    while used.contains(&candidate) {
+        let stem = base.strip_suffix(".wdl").unwrap_or(base);
+        candidate = format!("workflow/{stem}-{n}.wdl");
+        n += 1;
+    }
+    used.insert(candidate.clone());
+    candidate
+}
+
+/// Reads the full resolved source text of a document.
+fn document_text(document: &Document) -> String {
+    document.root().text().to_string()
+}
+
+/// Returns `(crate_relative_path, source_text)` for the main document and every
+/// transitively imported document. The main document maps to [`WORKFLOW_ID`];
+/// imports are de-duplicated by resolved URL and collision-renamed.
+pub fn collect_sources(document: &Document) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = vec![(WORKFLOW_ID.to_string(), document_text(document))];
+    let mut used: HashSet<String> = HashSet::from([WORKFLOW_ID.to_string()]);
+    let mut seen_urls: HashSet<String> = HashSet::from([document.uri().as_str().to_string()]);
+
+    // Iteratively walk the import graph.
+    let mut stack: Vec<Document> = document
+        .namespaces()
+        .map(|(_, ns)| ns.document().clone())
+        .collect();
+    while let Some(doc) = stack.pop() {
+        let url = doc.uri().as_str().to_string();
+        if !seen_urls.insert(url) {
+            continue;
+        }
+        let path = import_path_for(doc.uri(), &mut used);
+        out.push((path, document_text(&doc)));
+        for (_, ns) in doc.namespaces() {
+            stack.push(ns.document().clone());
+        }
+    }
+    out
+}
+
+/// Writes every collected source under `crate_root`, pushing a
+/// `File`/`SoftwareSourceCode` entity for each **import** (the main workflow
+/// entity at [`WORKFLOW_ID`] is owned by the crate builder). Returns the import
+/// `@id`s for linking under the workflow entity's `hasPart`.
+pub fn materialize_sources(
+    document: &Document,
+    crate_root: &Path,
+    graph: &mut Vec<GraphVector>,
+) -> Result<Vec<String>> {
+    let mut import_ids = Vec::new();
+    for (rel, text) in collect_sources(document) {
+        let abs = crate_root.join(&rel);
+        if let Some(parent) = abs.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating crate directory `{}`", parent.display()))?;
+        }
+        std::fs::write(&abs, text.as_bytes())
+            .with_context(|| format!("writing crate source `{}`", abs.display()))?;
+
+        if rel != WORKFLOW_ID {
+            graph.push(GraphVector::DataEntity(DataEntity {
+                id: rel.clone(),
+                type_: DataType::TermArray(vec![
+                    "File".to_string(),
+                    "SoftwareSourceCode".to_string(),
+                ]),
+                dynamic_entity: Some(
+                    [(
+                        "name".to_string(),
+                        rocraters::ro_crate::constraints::EntityValue::EntityString(rel.clone()),
+                    )]
+                    .into_iter()
+                    .collect(),
+                ),
+            }));
+            import_ids.push(rel);
+        }
+    }
+    Ok(import_ids)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use url::Url;
+
+    use super::import_path_for;
+
+    #[test]
+    fn import_paths_are_under_workflow_and_collision_renamed() {
+        let mut used = HashSet::new();
+        let a = import_path_for(&Url::parse("file:///x/tasks.wdl").unwrap(), &mut used);
+        let b = import_path_for(
+            &Url::parse("https://example.com/y/tasks.wdl").unwrap(),
+            &mut used,
+        );
+        assert_eq!(a, "workflow/tasks.wdl");
+        assert_eq!(b, "workflow/tasks-1.wdl", "repeated basename is renamed");
+        assert!(a.starts_with("workflow/") && b.starts_with("workflow/"));
+    }
+}

--- a/src/system/v1/rocrate/tasks.rs
+++ b/src/system/v1/rocrate/tasks.rs
@@ -1,0 +1,298 @@
+//! Maps v1 task records to step-level RO-Crate provenance entities.
+//!
+//! The v1 database stores one task row per WDL task name (the task monitor keys
+//! tasks by name; Crankshaft ids, shards, and retry attempts are not persisted),
+//! so provenance is emitted at name granularity: one tool/step/action/control
+//! bundle per task row. True per-execution identity (shard/attempt) requires
+//! extending the task monitor and schema and is left to a follow-on.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use chrono::DateTime;
+use chrono::SecondsFormat;
+use chrono::Utc;
+use rocraters::ro_crate::constraints::DataType;
+use rocraters::ro_crate::constraints::EntityValue;
+use rocraters::ro_crate::constraints::Id;
+use rocraters::ro_crate::contextual_entity::ContextualEntity;
+use rocraters::ro_crate::data_entity::DataEntity;
+use rocraters::ro_crate::graph_vector::GraphVector;
+use sha2::Digest;
+use sha2::Sha256;
+
+use super::RoCrateOptions;
+use super::context::ScrubbedLog;
+use super::value::sanitize_component;
+use crate::system::v1::db::models::Task;
+use crate::system::v1::db::models::TaskStatus;
+
+/// The `@id`s of the entities emitted for one task.
+#[derive(Debug, Clone)]
+pub struct TaskEntityIds {
+    /// The tool entity (`SoftwareApplication`) representing the WDL task.
+    pub tool: String,
+    /// The planned `HowToStep`.
+    pub step: String,
+    /// The tool-execution `CreateAction`.
+    pub action: String,
+    /// The `ControlAction` tying the step to the execution.
+    pub control: String,
+}
+
+/// Builds a `dynamic_entity` map from `(key, value)` pairs.
+fn bag(pairs: Vec<(&str, EntityValue)>) -> Option<HashMap<String, EntityValue>> {
+    Some(pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+}
+
+/// Wraps an `@id` reference as an `EntityValue`.
+fn ev_id(s: &str) -> EntityValue {
+    EntityValue::EntityId(Id::Id(s.to_string()))
+}
+
+/// Wraps a string as an `EntityValue`.
+fn ev_str(s: &str) -> EntityValue {
+    EntityValue::EntityString(s.to_string())
+}
+
+/// Computes the SHA-256 of a file as a lowercase hex string.
+fn sha256_hex(path: &Path) -> std::io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher)?;
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Canonical `xsd:dateTime` form (`...Z`, no fractional seconds).
+fn iso(t: DateTime<Utc>) -> String {
+    t.to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+/// Maps a v1 task status onto a schema.org `ActionStatus` URI.
+pub fn task_action_status(s: &TaskStatus) -> &'static str {
+    match s {
+        TaskStatus::Completed => "http://schema.org/CompletedActionStatus",
+        TaskStatus::Failed | TaskStatus::Canceled | TaskStatus::Preempted => {
+            "http://schema.org/FailedActionStatus"
+        }
+        TaskStatus::Running => "http://schema.org/ActiveActionStatus",
+        TaskStatus::Pending => "http://schema.org/PotentialActionStatus",
+    }
+}
+
+/// Writes scrubbed task logs into the crate and appends their `File` entities.
+pub fn task_log_entities(
+    slug: &str,
+    action_id: &str,
+    log: &ScrubbedLog,
+    crate_root: &Path,
+    opts: &RoCrateOptions,
+    graph: &mut Vec<GraphVector>,
+) -> Result<Vec<String>> {
+    let mut ids = Vec::new();
+    for (stream, text) in [
+        ("stdout", log.stdout.as_deref()),
+        ("stderr", log.stderr.as_deref()),
+    ] {
+        let Some(text) = text else {
+            continue;
+        };
+        let id = format!("logs/{slug}/{stream}.log");
+        let path = crate_root.join(&id);
+        let log_dir = crate_root.join("logs").join(slug);
+        std::fs::create_dir_all(&log_dir)
+            .with_context(|| format!("creating task log directory `{}`", log_dir.display()))?;
+        std::fs::write(&path, text)
+            .with_context(|| format!("writing scrubbed task log `{}`", path.display()))?;
+
+        let meta = std::fs::metadata(&path)
+            .with_context(|| format!("reading task log metadata `{}`", path.display()))?;
+        let mut props = vec![
+            (
+                "name",
+                ev_str(&format!("{stream} log for {}", log.task_name)),
+            ),
+            (
+                "description",
+                ev_str(&format!(
+                    "Scrubbed {stream} log; secret-shaped text was replaced before materialization."
+                )),
+            ),
+            ("encodingFormat", ev_str("text/plain")),
+            ("contentSize", EntityValue::Entityi64(meta.len() as i64)),
+            ("about", ev_id(action_id)),
+        ];
+        if opts.checksums {
+            let hex = sha256_hex(&path)
+                .with_context(|| format!("checksumming scrubbed task log `{}`", path.display()))?;
+            props.push(("sha256", EntityValue::EntityString(hex)));
+        }
+        graph.push(GraphVector::DataEntity(DataEntity {
+            id: id.clone(),
+            type_: DataType::Term("File".to_string()),
+            dynamic_entity: bag(props),
+        }));
+        ids.push(id);
+    }
+
+    Ok(ids)
+}
+
+/// Appends the provenance entities for one task to `graph` and returns their
+/// `@id`s. Per the Provenance Run Crate profile:
+///
+/// - a tool entity (`SoftwareApplication`) represents the WDL task;
+/// - the `HowToStep` is the planned step and references the tool via
+///   `workExample`;
+/// - the `CreateAction` records the execution and references the tool via
+///   `instrument`;
+/// - the `ControlAction` ties the step (`instrument`) to the execution
+///   (`object`).
+///
+/// Task input/output links are intentionally omitted: the database does not
+/// record which concrete files a task consumed or produced, and the profile
+/// forbids guessing them.
+pub fn task_step_entities(
+    task: &Task,
+    position: usize,
+    graph: &mut Vec<GraphVector>,
+) -> TaskEntityIds {
+    let slug = sanitize_component(&task.name);
+    let tool_id = format!("#tool-{slug}");
+    let step_id = format!("#step-{slug}");
+    let action_id = format!("#task-{slug}");
+    let control_id = format!("#control-{slug}");
+
+    // Tool entity: the WDL task definition that was executed.
+    graph.push(GraphVector::ContextualEntity(ContextualEntity {
+        id: tool_id.clone(),
+        type_: DataType::Term("SoftwareApplication".to_string()),
+        dynamic_entity: bag(vec![
+            ("name", ev_str(&task.name)),
+            ("description", ev_str(&format!("WDL task `{}`", task.name))),
+        ]),
+    }));
+
+    // Planned step.
+    graph.push(GraphVector::ContextualEntity(ContextualEntity {
+        id: step_id.clone(),
+        type_: DataType::Term("HowToStep".to_string()),
+        dynamic_entity: bag(vec![
+            ("name", ev_str(&task.name)),
+            ("position", EntityValue::Entityi64(position as i64)),
+            ("workExample", ev_id(&tool_id)),
+        ]),
+    }));
+
+    // Tool execution.
+    let mut action_props = vec![
+        ("name", ev_str(&task.name)),
+        ("instrument", ev_id(&tool_id)),
+        ("actionStatus", ev_id(task_action_status(&task.status))),
+    ];
+    if let Some(start) = task.started_at {
+        action_props.push(("startTime", ev_str(&iso(start))));
+    }
+    if let Some(end) = task.completed_at {
+        action_props.push(("endTime", ev_str(&iso(end))));
+    }
+    // Exit code is intentionally not emitted: there is no `exitStatus` term in the
+    // RO-Crate or workflow-run contexts, so it would break compacted JSON-LD
+    // conformance. Success/failure is conveyed by `actionStatus` and, on failure,
+    // the context-defined `error`.
+    if let Some(error) = task.error.as_deref().filter(|e| !e.is_empty()) {
+        action_props.push(("error", ev_str(error)));
+    }
+    graph.push(GraphVector::ContextualEntity(ContextualEntity {
+        id: action_id.clone(),
+        type_: DataType::Term("CreateAction".to_string()),
+        dynamic_entity: bag(action_props),
+    }));
+
+    // Step execution control: links the planned step to the execution.
+    graph.push(GraphVector::ContextualEntity(ContextualEntity {
+        id: control_id.clone(),
+        type_: DataType::Term("ControlAction".to_string()),
+        dynamic_entity: bag(vec![
+            ("instrument", ev_id(&step_id)),
+            ("object", ev_id(&action_id)),
+        ]),
+    }));
+
+    TaskEntityIds {
+        tool: tool_id,
+        step: step_id,
+        action: action_id,
+        control: control_id,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use super::*;
+
+    fn completed_task(name: &str, exit: i32) -> Task {
+        let now = Utc::now();
+        Task {
+            name: name.to_string(),
+            run_uuid: uuid::Uuid::new_v4(),
+            status: TaskStatus::Completed,
+            exit_status: Some(exit),
+            error: None,
+            created_at: now,
+            started_at: Some(now),
+            completed_at: Some(now),
+        }
+    }
+
+    #[test]
+    fn status_maps_to_schema_uris() {
+        assert_eq!(
+            task_action_status(&TaskStatus::Completed),
+            "http://schema.org/CompletedActionStatus"
+        );
+        assert_eq!(
+            task_action_status(&TaskStatus::Failed),
+            "http://schema.org/FailedActionStatus"
+        );
+        assert_eq!(
+            task_action_status(&TaskStatus::Preempted),
+            "http://schema.org/FailedActionStatus"
+        );
+        assert_eq!(
+            task_action_status(&TaskStatus::Running),
+            "http://schema.org/ActiveActionStatus"
+        );
+    }
+
+    #[test]
+    fn task_produces_tool_step_action_and_control() {
+        let task = completed_task("align", 0);
+        let mut graph = Vec::new();
+        let ids = task_step_entities(&task, 1, &mut graph);
+        assert_eq!(ids.tool, "#tool-align");
+        assert_eq!(ids.action, "#task-align");
+
+        let json = serde_json::to_string(&graph).unwrap();
+        assert!(json.contains("SoftwareApplication"));
+        assert!(json.contains("HowToStep"));
+        assert!(json.contains("ControlAction"));
+        assert!(json.contains("workExample"));
+        assert!(json.contains("CompletedActionStatus"));
+
+        // The execution references the tool via `instrument`, the step via
+        // `workExample`, and the control ties step to action.
+        let v: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let action = v
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| e["@id"] == "#task-align")
+            .unwrap();
+        assert_eq!(action["instrument"]["@id"], "#tool-align");
+    }
+}

--- a/src/system/v1/rocrate/value.rs
+++ b/src/system/v1/rocrate/value.rs
@@ -1,0 +1,924 @@
+//! Converts runtime WDL values into type-aware RO-Crate entities.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context as _;
+use anyhow::Result;
+use rocraters::ro_crate::constraints::DataType;
+use rocraters::ro_crate::constraints::EntityValue;
+use rocraters::ro_crate::constraints::Id;
+use rocraters::ro_crate::contextual_entity::ContextualEntity;
+use rocraters::ro_crate::data_entity::DataEntity;
+use rocraters::ro_crate::graph_vector::GraphVector;
+use sha2::Digest;
+use sha2::Sha256;
+use wdl::engine::Value;
+
+use super::RoCrateOptions;
+
+/// Builds the `dynamic_entity` map from `(key, value)` pairs.
+fn bag(pairs: Vec<(&str, EntityValue)>) -> Option<HashMap<String, EntityValue>> {
+    Some(pairs.into_iter().map(|(k, v)| (k.to_string(), v)).collect())
+}
+
+/// Computes the SHA-256 of a file as a lowercase hex string.
+fn sha256_hex(path: &Path) -> std::io::Result<String> {
+    let mut file = std::fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    std::io::copy(&mut file, &mut hasher)?;
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Adds one length-delimited string to a stable hash.
+fn update_stable_hash(hasher: &mut Sha256, value: &str) {
+    hasher.update((value.len() as u64).to_be_bytes());
+    hasher.update(value.as_bytes());
+}
+
+/// Stable, path-free placeholder `@id` for a non-localized data value. The hash
+/// is derived from `role` + `rel` (the WDL traversal position), NOT from the
+/// source absolute path, so it is stable and reveals no host layout.
+fn external_placeholder_id(role: &str, rel: &str, basename: &str) -> String {
+    let mut hasher = Sha256::new();
+    update_stable_hash(&mut hasher, role);
+    update_stable_hash(&mut hasher, rel);
+    let hash = format!("{:x}", hasher.finalize());
+    format!(
+        "external/{}/{}/{}",
+        sanitize_component(role),
+        hash,
+        sanitize_component(basename)
+    )
+}
+
+/// Encodes one path component so it cannot affect crate layout.
+pub(super) fn sanitize_component(component: &str) -> String {
+    if component == "." {
+        return "%2e".to_string();
+    }
+    if component == ".." {
+        return "%2e%2e".to_string();
+    }
+
+    let mut sanitized = String::new();
+    for byte in component.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'.' | b'_' | b'-' => {
+                sanitized.push(byte as char);
+            }
+            _ => {
+                sanitized.push_str(&format!("%{byte:02x}"));
+            }
+        }
+    }
+
+    if sanitized.is_empty() {
+        "_".to_string()
+    } else {
+        sanitized
+    }
+}
+
+/// Encodes a traversal path while preserving its component structure.
+fn sanitize_relative_path(path: &str) -> String {
+    let components = path
+        .split(['/', '\\'])
+        .filter(|component| !component.is_empty())
+        .map(sanitize_component)
+        .collect::<Vec<_>>();
+
+    if components.is_empty() {
+        "_".to_string()
+    } else {
+        components.join("/")
+    }
+}
+
+/// Recursively copies a directory tree.
+fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<()> {
+    std::fs::create_dir_all(dest)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        anyhow::ensure!(
+            !file_type.is_symlink(),
+            "cannot localize symlink `{}` into the crate",
+            entry.path().display()
+        );
+        let to = dest.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_dir_recursive(&entry.path(), &to)?;
+        } else {
+            std::fs::copy(entry.path(), &to)?;
+        }
+    }
+    Ok(())
+}
+
+/// Returns `true` when a host path string refers to a remote URL.
+fn is_remote(path_str: &str) -> bool {
+    path_str.contains("://")
+}
+
+/// Appends a trailing slash to directory `@id`s, per the RO-Crate convention
+/// that `Dataset` identifiers end with `/`.
+fn finalize_id(id: &str, is_dir: bool) -> String {
+    if is_dir && !id.ends_with('/') {
+        format!("{id}/")
+    } else {
+        id.to_string()
+    }
+}
+
+/// Ensures a path is a regular file (or a directory when `is_dir`), rejecting
+/// FIFOs, devices, sockets, and type mismatches that could hang or corrupt a
+/// copy/checksum.
+fn ensure_regular_or_dir(path: &Path, is_dir: bool) -> Result<()> {
+    let meta =
+        std::fs::metadata(path).with_context(|| format!("inspecting `{}`", path.display()))?;
+    if is_dir {
+        anyhow::ensure!(
+            meta.is_dir(),
+            "expected a directory at `{}`",
+            path.display()
+        );
+    } else {
+        anyhow::ensure!(
+            meta.is_file(),
+            "cannot represent non-regular file `{}` in the crate",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+/// Rejects symlinks and non-regular files before localizing an external value.
+fn ensure_localizable(src: &Path, is_dir: bool) -> Result<()> {
+    let meta = std::fs::symlink_metadata(src).with_context(|| {
+        format!(
+            "inspecting data value `{}` before localization",
+            src.display()
+        )
+    })?;
+    anyhow::ensure!(
+        !meta.file_type().is_symlink(),
+        "cannot localize symlink `{}` into the crate; rerun with \
+         `--no-ro-crate-localize` to record an external reference instead",
+        src.display()
+    );
+    ensure_regular_or_dir(src, is_dir)
+}
+
+/// Determines the crate-relative `@id` for a data value, copying local files and
+/// directories under `inputs/`/`outputs/` when `opts.localize`, else returning an
+/// `external/` placeholder plus a redacted original-location marker. Returns any
+/// extra entity properties to record (e.g. the external marker).
+fn localize_data_path(
+    src: &str,
+    is_dir: bool,
+    role: &str,
+    rel: &str,
+    crate_root: &Path,
+    opts: &RoCrateOptions,
+) -> Result<(String, Vec<(&'static str, EntityValue)>)> {
+    let src_path = Path::new(src);
+    let basename = src_path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or("data");
+
+    // Already inside the crate root (e.g. run outputs): reference in place.
+    // Canonicalize both sides so a `..` segment or a symlink whose target escapes
+    // the crate root is NOT treated as in-crate; such paths fall through to the
+    // rejection logic below rather than being silently followed.
+    if let Ok(canon_root) = crate_root.canonicalize()
+        && let Ok(canon_src) = src_path.canonicalize()
+        && let Ok(rel_existing) = canon_src.strip_prefix(&canon_root)
+        && let Some(rel_str) = rel_existing.to_str()
+    {
+        ensure_regular_or_dir(&canon_src, is_dir)?;
+        return Ok((finalize_id(rel_str, is_dir), Vec::new()));
+    }
+
+    if !opts.localize {
+        // Record that an external value exists, without leaking the host path or
+        // traversing its contents.
+        let id = finalize_id(&external_placeholder_id(role, rel, basename), is_dir);
+        let marker = vec![(
+            "contentLocation",
+            EntityValue::EntityString("[redacted: external, not localized]".to_string()),
+        )];
+        return Ok((id, marker));
+    }
+
+    // Localization is on. Remote download is not supported in this build; per the
+    // spec, failing to localize an enabled value fails emission (non-fatal unless
+    // `--ro-crate-strict`).
+    if is_remote(src) {
+        anyhow::bail!(
+            "cannot localize remote data value `{src}` into the crate; rerun with \
+             `--no-ro-crate-localize` to record an external reference instead"
+        );
+    }
+    ensure_localizable(src_path, is_dir)?;
+
+    let base = format!(
+        "{}/{}/{}",
+        sanitize_component(role),
+        sanitize_relative_path(rel),
+        sanitize_component(basename)
+    );
+    let dest = crate_root.join(&base);
+    anyhow::ensure!(
+        dest.starts_with(crate_root),
+        "localized crate path escaped the crate root"
+    );
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating crate directory `{}`", parent.display()))?;
+    }
+    if is_dir {
+        copy_dir_recursive(src_path, &dest)
+            .with_context(|| format!("localizing directory `{src}`"))?;
+    } else {
+        std::fs::copy(src, &dest).with_context(|| format!("localizing file `{src}`"))?;
+    }
+    Ok((finalize_id(&base, is_dir), Vec::new()))
+}
+
+/// Pushes a child `File` entity (with size and optional checksum) for every
+/// readable file under a localized directory, returning their `@id`s for the
+/// parent `Dataset`'s `hasPart`.
+fn directory_part_entities(
+    dir_id: &str,
+    dir_abs: &Path,
+    opts: &RoCrateOptions,
+    graph: &mut Vec<GraphVector>,
+) -> Result<Vec<String>> {
+    let mut parts = Vec::new();
+    let mut stack = vec![dir_abs.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let entries = std::fs::read_dir(&dir)
+            .with_context(|| format!("reading localized directory `{}`", dir.display()))?;
+        for entry in entries {
+            let entry = entry
+                .with_context(|| format!("reading localized directory `{}`", dir.display()))?;
+            let path = entry.path();
+            let file_type = entry
+                .file_type()
+                .with_context(|| format!("reading file type for `{}`", path.display()))?;
+            anyhow::ensure!(
+                !file_type.is_symlink(),
+                "refusing to follow symlink `{}` inside a crate directory",
+                path.display()
+            );
+            if file_type.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            anyhow::ensure!(
+                file_type.is_file(),
+                "refusing to include non-regular file `{}` in the crate",
+                path.display()
+            );
+            let rel = path
+                .strip_prefix(dir_abs)
+                .with_context(|| format!("relativizing localized file `{}`", path.display()))?;
+            let rel_str = rel.to_str().with_context(|| {
+                format!("localized file path was not utf-8 `{}`", path.display())
+            })?;
+            let id = format!("{dir_id}/{rel_str}");
+            let mut props = vec![("name", EntityValue::EntityString(rel_str.to_string()))];
+            let meta = std::fs::metadata(&path).with_context(|| {
+                format!("reading metadata for localized file `{}`", path.display())
+            })?;
+            props.push(("contentSize", EntityValue::Entityi64(meta.len() as i64)));
+            if opts.checksums {
+                let hex = sha256_hex(&path)
+                    .with_context(|| format!("checksumming localized file `{}`", path.display()))?;
+                props.push(("sha256", EntityValue::EntityString(hex)));
+            }
+            graph.push(GraphVector::DataEntity(DataEntity {
+                id: id.clone(),
+                type_: DataType::Term("File".to_string()),
+                dynamic_entity: bag(props),
+            }));
+            parts.push(id);
+        }
+    }
+    Ok(parts)
+}
+
+/// Pushes a `File`/`Dataset` data entity for a data value and returns its
+/// crate-relative `@id`. Localizes per [`localize_data_path`]; directories carry
+/// per-file checksums via `hasPart` rather than an aggregate tree hash.
+fn data_entity(
+    src: &str,
+    is_dir: bool,
+    role: &str,
+    rel: &str,
+    crate_root: &Path,
+    opts: &RoCrateOptions,
+    graph: &mut Vec<GraphVector>,
+) -> Result<String> {
+    let (id, extra) = localize_data_path(src, is_dir, role, rel, crate_root, opts)?;
+
+    // Deduplicate: the same path used as both an input and an output (or repeated
+    // in a structure) must be a single data entity with a unique `@id`, not a
+    // duplicate. If it is already in the graph, just reference it.
+    if graph.iter().any(|g| g.get_id() == &id) {
+        return Ok(id);
+    }
+
+    let name = Path::new(&id)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(&id)
+        .to_string();
+
+    let is_external = id.starts_with("external/");
+    // Where the materialized bytes live: under the crate for localized/in-place
+    // values, or at the original source for external (non-localized) values. The
+    // crate-relative id may carry a trailing slash (directories), so trim it when
+    // forming a filesystem path.
+    let stat_path: PathBuf = if is_external {
+        PathBuf::from(src)
+    } else {
+        crate_root.join(id.trim_end_matches('/'))
+    };
+
+    let mut props = vec![("name", EntityValue::EntityString(name))];
+    props.extend(extra);
+
+    if is_dir {
+        // Enumerate only directories whose bytes live in the crate (localized or
+        // in-place). External, non-localized directories are referenced as a
+        // placeholder without traversing or checksumming host contents.
+        if !is_external {
+            let parts = directory_part_entities(id.trim_end_matches('/'), &stat_path, opts, graph)?;
+            if !parts.is_empty() {
+                props.push(("hasPart", EntityValue::EntityId(Id::IdArray(parts))));
+            }
+        }
+    } else if let Ok(meta) = std::fs::metadata(&stat_path) {
+        props.push(("contentSize", EntityValue::Entityi64(meta.len() as i64)));
+        // Only checksum genuine regular files; hashing a FIFO/device would hang.
+        if opts.checksums
+            && meta.is_file()
+            && let Ok(hex) = sha256_hex(&stat_path)
+        {
+            props.push(("sha256", EntityValue::EntityString(hex)));
+        }
+    }
+
+    let ty = if is_dir {
+        DataType::Term("Dataset".to_string())
+    } else {
+        DataType::Term("File".to_string())
+    };
+    graph.push(GraphVector::DataEntity(DataEntity {
+        id: id.clone(),
+        type_: ty,
+        dynamic_entity: bag(props),
+    }));
+    Ok(id)
+}
+
+/// Recursively converts a value into an `EntityValue`, lifting any nested
+/// `File`/`Directory` into its own data entity and returning an `EntityId`
+/// reference to it. `rel` is the traversal path used for stable data-entity IDs.
+fn value_to_entity_value(
+    value: &Value,
+    role: &str,
+    rel: &str,
+    crate_root: &Path,
+    opts: &RoCrateOptions,
+    graph: &mut Vec<GraphVector>,
+) -> Result<EntityValue> {
+    if value.is_none() {
+        return Ok(EntityValue::EntityNull(None));
+    }
+    if let Some(f) = value.as_file() {
+        let id = data_entity(f.as_str(), false, role, rel, crate_root, opts, graph)?;
+        return Ok(EntityValue::EntityId(Id::Id(id)));
+    }
+    if let Some(d) = value.as_directory() {
+        let id = data_entity(d.as_str(), true, role, rel, crate_root, opts, graph)?;
+        return Ok(EntityValue::EntityId(Id::Id(id)));
+    }
+    if let Some(b) = value.as_boolean() {
+        return Ok(EntityValue::EntityBool(b));
+    }
+    if let Some(i) = value.as_integer() {
+        return Ok(EntityValue::Entityi64(i));
+    }
+    if let Some(f) = value.as_float() {
+        return Ok(EntityValue::Entityf64(f));
+    }
+    if let Some(s) = value.as_string() {
+        return Ok(EntityValue::EntityString(s.to_string()));
+    }
+    if let Some(arr) = value.as_array() {
+        let mut items = Vec::new();
+        for (i, v) in arr.as_slice().iter().enumerate() {
+            items.push(value_to_entity_value(
+                v,
+                role,
+                &format!("{rel}/{i}"),
+                crate_root,
+                opts,
+                graph,
+            )?);
+        }
+        return Ok(EntityValue::EntityVec(items));
+    }
+    if let Some(obj) = value.as_object() {
+        let mut map = HashMap::new();
+        for (k, v) in obj.iter() {
+            map.insert(
+                k.to_string(),
+                value_to_entity_value(v, role, &format!("{rel}/{k}"), crate_root, opts, graph)?,
+            );
+        }
+        return Ok(EntityValue::EntityObject(map));
+    }
+    if let Some(st) = value.as_struct() {
+        let mut map = HashMap::new();
+        for (k, v) in st.iter() {
+            map.insert(
+                k.to_string(),
+                value_to_entity_value(v, role, &format!("{rel}/{k}"), crate_root, opts, graph)?,
+            );
+        }
+        return Ok(EntityValue::EntityObject(map));
+    }
+    if let Some(m) = value.as_map() {
+        let mut map = HashMap::new();
+        for (k, v) in m.iter() {
+            let key = format!("{k}");
+            let entry =
+                value_to_entity_value(v, role, &format!("{rel}/{key}"), crate_root, opts, graph)?;
+            map.insert(key, entry);
+        }
+        return Ok(EntityValue::EntityObject(map));
+    }
+    if let Some(p) = value.as_pair() {
+        let left = value_to_entity_value(
+            p.left(),
+            role,
+            &format!("{rel}/left"),
+            crate_root,
+            opts,
+            graph,
+        )?;
+        let right = value_to_entity_value(
+            p.right(),
+            role,
+            &format!("{rel}/right"),
+            crate_root,
+            opts,
+            graph,
+        )?;
+        return Ok(EntityValue::EntityVec(vec![left, right]));
+    }
+    // Hidden/Call/TypeNameRef and anything unexpected: fall back to display.
+    Ok(EntityValue::EntityString(format!("{value}")))
+}
+
+/// Role-threaded form of [`value_to_entities`]. `role` is `inputs`/`outputs` (the
+/// crate-relative layout prefix) and `rel` is the value's traversal path.
+fn value_to_entities_roled(
+    id_prefix: &str,
+    role: &str,
+    rel: &str,
+    value: &Value,
+    crate_root: &Path,
+    opts: &RoCrateOptions,
+    graph: &mut Vec<GraphVector>,
+) -> Result<String> {
+    // Top-level File/Directory: the value *is* the data entity.
+    if let Some(f) = value.as_file() {
+        return data_entity(f.as_str(), false, role, rel, crate_root, opts, graph);
+    }
+    if let Some(d) = value.as_directory() {
+        return data_entity(d.as_str(), true, role, rel, crate_root, opts, graph);
+    }
+
+    // Everything else: a PropertyValue carrying the (possibly structured) value.
+    let id = format!("#{id_prefix}-{rel}");
+    let entity_value = value_to_entity_value(value, role, rel, crate_root, opts, graph)?;
+    graph.push(GraphVector::ContextualEntity(ContextualEntity {
+        id: id.clone(),
+        type_: DataType::Term("PropertyValue".to_string()),
+        dynamic_entity: bag(vec![
+            ("name", EntityValue::EntityString(rel.to_string())),
+            ("value", entity_value),
+        ]),
+    }));
+    Ok(id)
+}
+
+/// Converts a named value into RO-Crate graph entities, appending File/Dataset
+/// data entities to `graph` and returning the entity `@id` that represents the
+/// value (a data-entity id for File/Directory, else a `PropertyValue` id).
+///
+/// `id_prefix` is `input`/`output`; it determines both the `PropertyValue` id and
+/// the `inputs/`/`outputs/` localization layout.
+pub fn value_to_entities(
+    id_prefix: &str,
+    name: &str,
+    value: &Value,
+    crate_root: &Path,
+    opts: &RoCrateOptions,
+    graph: &mut Vec<GraphVector>,
+) -> Result<String> {
+    let role = match id_prefix {
+        "input" => "inputs",
+        "output" => "outputs",
+        other => anyhow::bail!("unknown ro-crate value prefix `{other}`"),
+    };
+    value_to_entities_roled(id_prefix, role, name, value, crate_root, opts, graph)
+}
+
+#[cfg(test)]
+mod tests {
+    use rocraters::ro_crate::graph_vector::GraphVector;
+    use wdl::analysis::types::MapType;
+    use wdl::analysis::types::PrimitiveType;
+    use wdl::engine::Map;
+    use wdl::engine::PrimitiveValue;
+    use wdl::engine::Value;
+
+    use super::*;
+
+    /// Builds a `File` WDL value pointing at `path`.
+    pub(super) fn file_value(path: &Path) -> Value {
+        PrimitiveValue::new_file(path.to_str().unwrap()).into()
+    }
+
+    fn ids(graph: &[GraphVector]) -> Vec<String> {
+        graph.iter().map(|g| g.get_id().clone()).collect()
+    }
+
+    #[test]
+    fn primitive_becomes_property_value() {
+        let opts = RoCrateOptions::from_flags(true, false, true, false);
+        let mut graph = Vec::new();
+        let v = Value::from("hello".to_string());
+        let id = value_to_entities(
+            "input",
+            "greeting",
+            &v,
+            Path::new("/tmp"),
+            &opts,
+            &mut graph,
+        )
+        .unwrap();
+        assert_eq!(id, "#input-greeting");
+        assert!(ids(&graph).iter().any(|i| i == "#input-greeting"));
+    }
+
+    #[test]
+    fn file_in_crate_root_is_referenced_in_place() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("out.txt");
+        std::fs::write(&p, b"abc").unwrap();
+        // no_checksums = true
+        let opts = RoCrateOptions::from_flags(true, false, true, false);
+        let mut graph = Vec::new();
+        let v = file_value(&p);
+        let id = value_to_entities("output", "f", &v, dir.path(), &opts, &mut graph).unwrap();
+        assert_eq!(id, "out.txt");
+        let json = serde_json::to_string(&graph).unwrap();
+        assert!(json.contains("\"File\""));
+        assert!(json.contains("contentSize"));
+        assert!(!json.contains("sha256"));
+    }
+
+    #[test]
+    fn localizes_local_input_by_copy() {
+        let src_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("reads.bam");
+        std::fs::write(&src, b"BAM").unwrap();
+        let crate_dir = tempfile::tempdir().unwrap();
+        // localize on
+        let opts = RoCrateOptions::from_flags(true, false, false, false);
+        let mut graph = Vec::new();
+        let id = value_to_entities_roled(
+            "input",
+            "inputs",
+            "aligner.reads",
+            &file_value(&src),
+            crate_dir.path(),
+            &opts,
+            &mut graph,
+        )
+        .unwrap();
+        assert_eq!(id, "inputs/aligner.reads/reads.bam");
+        assert!(
+            crate_dir.path().join(&id).exists(),
+            "file copied into crate"
+        );
+    }
+
+    #[test]
+    fn no_localize_uses_external_placeholder_not_abs_path() {
+        let src_dir = tempfile::tempdir().unwrap();
+        let src = src_dir.path().join("reads.bam");
+        std::fs::write(&src, b"BAM").unwrap();
+        let crate_dir = tempfile::tempdir().unwrap();
+        // no_localize = true
+        let opts = RoCrateOptions::from_flags(true, false, false, true);
+        let mut graph = Vec::new();
+        let id = value_to_entities_roled(
+            "input",
+            "inputs",
+            "aligner.reads",
+            &file_value(&src),
+            crate_dir.path(),
+            &opts,
+            &mut graph,
+        )
+        .unwrap();
+        assert!(id.starts_with("external/inputs/"), "got `{id}`");
+        assert!(
+            !id.contains(src_dir.path().to_str().unwrap()),
+            "must not embed abs path"
+        );
+        let json = serde_json::to_string(&graph).unwrap();
+        assert!(json.contains("contentLocation"));
+    }
+
+    #[test]
+    fn external_placeholder_ids_are_stable() {
+        let id = external_placeholder_id("inputs", "input.file", "artifact.bin");
+
+        assert_eq!(
+            id,
+            "external/inputs/0196bfc88e0b2be3c90cabc955115006e0e05db28b4362304d53c06fc6a9193c/artifact.bin"
+        );
+    }
+
+    #[test]
+    fn localization_sanitizes_traversal_components() -> Result<()> {
+        let src_dir = tempfile::tempdir()?;
+        let src = src_dir.path().join("reads.bam");
+        std::fs::write(&src, b"BAM")?;
+        let crate_dir = tempfile::tempdir()?;
+        let opts = RoCrateOptions::from_flags(true, false, false, false);
+        let mut graph = Vec::new();
+
+        let id = value_to_entities_roled(
+            "input",
+            "inputs",
+            "samples/../../escape",
+            &file_value(&src),
+            crate_dir.path(),
+            &opts,
+            &mut graph,
+        )?;
+
+        assert_eq!(id, "inputs/samples/%2e%2e/%2e%2e/escape/reads.bam");
+        assert!(crate_dir.path().join(&id).exists());
+        assert!(!crate_dir.path().join("escape/reads.bam").exists());
+
+        Ok(())
+    }
+
+    #[test]
+    fn localization_sanitizes_map_keys() -> Result<()> {
+        let src_dir = tempfile::tempdir()?;
+        let src = src_dir.path().join("reads.bam");
+        std::fs::write(&src, b"BAM")?;
+        let crate_dir = tempfile::tempdir()?;
+        let opts = RoCrateOptions::from_flags(true, false, false, false);
+        let value = Value::from(Map::new(
+            MapType::new(PrimitiveType::String, PrimitiveType::File),
+            [("../../../outside".to_string(), file_value(&src))],
+        )?);
+        let mut graph = Vec::new();
+
+        value_to_entities(
+            "input",
+            "samples",
+            &value,
+            crate_dir.path(),
+            &opts,
+            &mut graph,
+        )?;
+
+        let id = ids(&graph)
+            .into_iter()
+            .find(|id| id.starts_with("inputs/samples/") && id.ends_with("/reads.bam"))
+            .ok_or_else(|| anyhow::anyhow!("localized file entity was not emitted"))?;
+        assert!(
+            !Path::new(&id)
+                .components()
+                .any(|component| matches!(component, std::path::Component::ParentDir))
+        );
+        assert!(crate_dir.path().join(id).exists());
+        if let Some(parent) = crate_dir.path().parent() {
+            assert!(!parent.join("outside/reads.bam").exists());
+        }
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn localization_rejects_symlink_files() -> Result<()> {
+        let src_dir = tempfile::tempdir()?;
+        let target = src_dir.path().join("target.bam");
+        std::fs::write(&target, b"BAM")?;
+        let link = src_dir.path().join("link.bam");
+        std::os::unix::fs::symlink(&target, &link)?;
+        let crate_dir = tempfile::tempdir()?;
+        let opts = RoCrateOptions::from_flags(true, false, false, false);
+        let mut graph = Vec::new();
+
+        let Err(err) = value_to_entities(
+            "input",
+            "reads",
+            &file_value(&link),
+            crate_dir.path(),
+            &opts,
+            &mut graph,
+        ) else {
+            anyhow::bail!("symlink localization unexpectedly succeeded");
+        };
+
+        assert!(
+            err.chain()
+                .any(|cause| cause.to_string().contains("cannot localize symlink"))
+        );
+        assert!(!crate_dir.path().join("inputs/reads/link.bam").exists());
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn localization_rejects_symlinks_inside_directories() -> Result<()> {
+        let src_dir = tempfile::tempdir()?;
+        let input_dir = src_dir.path().join("input");
+        std::fs::create_dir(&input_dir)?;
+        let target = src_dir.path().join("target.txt");
+        std::fs::write(&target, b"secret")?;
+        std::os::unix::fs::symlink(&target, input_dir.join("link.txt"))?;
+        let crate_dir = tempfile::tempdir()?;
+        let opts = RoCrateOptions::from_flags(true, false, false, false);
+        let mut graph = Vec::new();
+        let input_dir = input_dir
+            .to_str()
+            .ok_or_else(|| anyhow::anyhow!("input directory path was not utf-8"))?;
+
+        let Err(err) = value_to_entities_roled(
+            "input",
+            "inputs",
+            "dataset",
+            &PrimitiveValue::new_directory(input_dir).into(),
+            crate_dir.path(),
+            &opts,
+            &mut graph,
+        ) else {
+            anyhow::bail!("directory symlink localization unexpectedly succeeded");
+        };
+
+        assert!(
+            err.chain()
+                .any(|cause| cause.to_string().contains("cannot localize symlink"))
+        );
+        assert!(
+            !crate_dir
+                .path()
+                .join("inputs/dataset/input/link.txt")
+                .exists()
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn directory_part_entities_reports_read_errors() -> Result<()> {
+        let missing_dir = tempfile::tempdir()?.path().join("missing");
+        let opts = RoCrateOptions::from_flags(true, false, false, false);
+        let mut graph = Vec::new();
+
+        let Err(err) =
+            directory_part_entities("inputs/dataset/input", &missing_dir, &opts, &mut graph)
+        else {
+            anyhow::bail!("directory part generation unexpectedly succeeded");
+        };
+
+        assert!(err.to_string().contains("reading localized directory"));
+        assert!(graph.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn value_to_entities_rejects_unknown_prefixes() {
+        let opts = RoCrateOptions::from_flags(true, false, false, false);
+        let mut graph = Vec::new();
+        let Err(err) = value_to_entities(
+            "parameter",
+            "item",
+            &Value::from("value".to_string()),
+            Path::new("/tmp"),
+            &opts,
+            &mut graph,
+        ) else {
+            panic!("unknown prefix unexpectedly succeeded");
+        };
+
+        assert!(err.to_string().contains("unknown ro-crate value prefix"));
+        assert!(graph.is_empty());
+    }
+
+    #[test]
+    fn localized_directory_id_has_trailing_slash() -> Result<()> {
+        let src_dir = tempfile::tempdir()?;
+        std::fs::write(src_dir.path().join("a.txt"), b"a")?;
+        let crate_dir = tempfile::tempdir()?;
+        let opts = RoCrateOptions::from_flags(true, false, false, false);
+        let mut graph = Vec::new();
+
+        let id = data_entity(
+            src_dir.path().to_str().unwrap(),
+            true,
+            "inputs",
+            "d",
+            crate_dir.path(),
+            &opts,
+            &mut graph,
+        )?;
+
+        assert!(id.ends_with('/'), "directory id should end with `/`: {id}");
+        let json = serde_json::to_string(&graph).unwrap();
+        assert!(json.contains("Dataset"));
+        assert!(
+            json.contains("a.txt"),
+            "localized child file should be listed"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn external_directory_is_not_traversed() -> Result<()> {
+        let src_dir = tempfile::tempdir()?;
+        std::fs::write(src_dir.path().join("secret.txt"), b"s")?;
+        let crate_dir = tempfile::tempdir()?;
+        // no_localize = true
+        let opts = RoCrateOptions::from_flags(true, false, false, true);
+        let mut graph = Vec::new();
+
+        let id = data_entity(
+            src_dir.path().to_str().unwrap(),
+            true,
+            "inputs",
+            "d",
+            crate_dir.path(),
+            &opts,
+            &mut graph,
+        )?;
+
+        assert!(id.starts_with("external/") && id.ends_with('/'));
+        let json = serde_json::to_string(&graph).unwrap();
+        assert!(
+            !json.contains("secret.txt"),
+            "external directory contents must not be enumerated"
+        );
+        assert!(!json.contains("hasPart"));
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn in_crate_symlink_escape_is_rejected() -> Result<()> {
+        let outside = tempfile::tempdir()?;
+        let secret = outside.path().join("secret.txt");
+        std::fs::write(&secret, b"x")?;
+        let crate_dir = tempfile::tempdir()?;
+        let link = crate_dir.path().join("link.txt");
+        std::os::unix::fs::symlink(&secret, &link)?;
+        let opts = RoCrateOptions::from_flags(true, false, false, false);
+        let mut graph = Vec::new();
+
+        let result = data_entity(
+            link.to_str().unwrap(),
+            false,
+            "outputs",
+            "o",
+            crate_dir.path(),
+            &opts,
+            &mut graph,
+        );
+        assert!(
+            result.is_err(),
+            "a symlink in the crate root that escapes it must be rejected"
+        );
+        Ok(())
+    }
+}

--- a/tests/cli/config-init/run/stdout
+++ b/tests/cli/config-init/run/stdout
@@ -32,6 +32,11 @@ suppress_env_specific_output = false
 experimental_features_enabled = false
 fail = "slow"
 
+[run.ro_crate]
+
+[run.ro_crate.logs]
+include_contents = false
+
 [run.http]
 cache_dir = "system"
 retries = 5

--- a/tests/cli/config-resolve/multi/stdout
+++ b/tests/cli/config-resolve/multi/stdout
@@ -32,6 +32,11 @@ suppress_env_specific_output = false
 experimental_features_enabled = false
 fail = "slow"
 
+[run.ro_crate]
+
+[run.ro_crate.logs]
+include_contents = false
+
 [run.http]
 cache_dir = "system"
 retries = 5

--- a/tests/cli/config-resolve/redacted/stdout
+++ b/tests/cli/config-resolve/redacted/stdout
@@ -32,6 +32,11 @@ suppress_env_specific_output = false
 experimental_features_enabled = false
 fail = "slow"
 
+[run.ro_crate]
+
+[run.ro_crate.logs]
+include_contents = false
+
 [run.http]
 cache_dir = "system"
 retries = 5

--- a/tests/cli/config-resolve/run/stdout
+++ b/tests/cli/config-resolve/run/stdout
@@ -32,6 +32,11 @@ suppress_env_specific_output = false
 experimental_features_enabled = false
 fail = "slow"
 
+[run.ro_crate]
+
+[run.ro_crate.logs]
+include_contents = false
+
 [run.http]
 cache_dir = "system"
 retries = 5

--- a/tests/cli/config-resolve/sentinels/stdout
+++ b/tests/cli/config-resolve/sentinels/stdout
@@ -32,6 +32,11 @@ suppress_env_specific_output = false
 experimental_features_enabled = false
 fail = "slow"
 
+[run.ro_crate]
+
+[run.ro_crate.logs]
+include_contents = false
+
 [run.http]
 cache_dir = "system"
 retries = 5

--- a/tests/cli/config-resolve/unredacted/stdout
+++ b/tests/cli/config-resolve/unredacted/stdout
@@ -32,6 +32,11 @@ suppress_env_specific_output = false
 experimental_features_enabled = false
 fail = "slow"
 
+[run.ro_crate]
+
+[run.ro_crate.logs]
+include_contents = false
+
 [run.http]
 cache_dir = "system"
 retries = 5

--- a/tests/cli/run/help/stdout
+++ b/tests/cli/run/help/stdout
@@ -105,10 +105,22 @@ Options:
   -c, --config <CONFIG>
           Path to the configuration file
 
+      --ro-crate
+          Emit a Workflow Run RO-Crate (`ro-crate-metadata.json`) into the run directory on success
+
+      --ro-crate-strict
+          Fail the command if requested RO-Crate emission fails
+
   -s, --skip-config-search
           Skip searching for and loading configuration files.
           
           Only a configuration file specified as a command line argument will be used.
+
+      --no-ro-crate-checksums
+          Skip SHA-256 digests for files in the RO-Crate (faster on large outputs)
+
+      --no-ro-crate-localize
+          Do not localize input/output data values into stable crate-relative paths
 
   -h, --help
           Print help (see a summary with '-h')


### PR DESCRIPTION
Adds opt-in [RO-Crate](https://www.researchobject.org/ro-crate/) emission to `sprocket run`.

An RO-Crate packages a run's data with machine-readable provenance—the workflow that executed, its inputs and outputs, the tasks it ran, and who launched it and when—in a portable `ro-crate-metadata.json` that other tools can read without knowing anything about Sprocket.

When a run succeeds with `--ro-crate`, Sprocket builds the crate from the typed execution state at the success hook and writes it into the run directory: a workflow target produces a Workflow Run Crate carrying per-task step provenance, while a direct task target produces a Process Run Crate.

`File`/`Directory` entities carry `contentSize` and SHA-256 digests, timestamps and the submitter are recorded only when actually known, and the emitted crates validate against the Process, Workflow, and Provenance Run Crate 0.5 profiles via `rocrate-validator`.

Emission is non-fatal by default; `--ro-crate-strict` turns a failure into a nonzero exit, `--no-ro-crate-checksums` skips digests, and `--no-ro-crate-localize` records external references instead of copying data into the crate.

Localization is hardened against escaping the crate root, and optional log bundling scrubs secrets before anything is written.

Three enrichments are deferred: remote data-value localization (a remote value currently fails under `--ro-crate` or is recorded as an external reference), per-execution task identity (the monitor collapses executions to one database row per task), and a user-extensible redaction allowlist.

Note that `ro-crate-rs` pulls the pure-Rust `libbz2-rs-sys` (carrying the `bzip2-1.0.6` license), so `cargo deny check` fails; this is expected until `ro-crate-rs` cuts a release that drops it, and `deny.toml` is intentionally left unchanged.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.

