### PR TITLE
fix: derive Nix vendor from `Cargo.lock` and check it in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,23 +64,6 @@ jobs:
       - name: Check source code for lints
         run: cargo --locked clippy --workspace --tests --all-features -- --deny warnings
 
-  nix:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@v22
-      - name: Cache the Nix store
-        uses: nix-community/cache-nix-action@v7
-        with:
-          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'Cargo.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-
-      # Builds every `checks` output, including the `sprocket` package and the
-      # `sprocket-smoke` test that runs the produced binary. This catches a
-      # stale flake or unbuildable `Cargo.lock` before it reaches `main`.
-      - name: Build and check the flake
-        run: nix flake check --print-build-logs
-
   check-fuzz:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,6 +64,23 @@ jobs:
       - name: Check source code for lints
         run: cargo --locked clippy --workspace --tests --all-features -- --deny warnings
 
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+      - name: Cache the Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'Cargo.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+      # Builds every `checks` output, including the `sprocket` package and the
+      # `sprocket-smoke` test that runs the produced binary. This catches a
+      # stale flake or unbuildable `Cargo.lock` before it reaches `main`.
+      - name: Build and check the flake
+        run: nix flake check --print-build-logs
+
   check-fuzz:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,36 @@
+name: Nix
+
+# Builds the flake to keep the `nix build`/`nix run` install path working. The
+# heavy build runs on every push to `main` and on pull requests that touch the
+# flake or the Cargo manifests—the only changes that can break it now that
+# dependencies are vendored straight from `Cargo.lock`. Releases are gated
+# separately in `release.yml`.
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "flake.nix"
+      - "flake.lock"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "**/*.nix"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+      - name: Cache the Nix store
+        uses: nix-community/cache-nix-action@v7
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'Cargo.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+      # Builds every `checks` output, including the `sprocket` package and the
+      # `sprocket-smoke` test that runs the produced binary.
+      - name: Build and check the flake
+        run: nix flake check --print-build-logs

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v22
       - name: Cache the Nix store
-        uses: nix-community/cache-nix-action@v7
+        uses: nix-community/cache-nix-action@v7.0.2
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'Cargo.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,24 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  # Gate the release: a published tag must build under Nix before any artifact
+  # or image is pushed, so the `nix run github:.../<tag>` install path always
+  # works. The build is normally cache-warm from the `main` runs in `nix.yml`.
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install Nix
+      uses: DeterminateSystems/nix-installer-action@v22
+    - name: Cache the Nix store
+      uses: nix-community/cache-nix-action@v7
+      with:
+        primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'Cargo.lock') }}
+        restore-prefixes-first-match: nix-${{ runner.os }}-
+    - name: Build and check the flake
+      run: nix flake check --print-build-logs
   docker-x86:
+    needs: nix
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
@@ -51,6 +68,7 @@ jobs:
         if-no-files-found: error
         retention-days: 1
   docker-arm:
+    needs: nix
     runs-on: ubuntu-24.04-arm
     steps:
     - uses: actions/checkout@v6
@@ -127,6 +145,7 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ github.repository_owner }}/sprocket:${{ steps.meta.outputs.version }}
   build_artifacts_win:
+    needs: nix
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -151,6 +170,7 @@ jobs:
       with:
         files: ./target/${{ matrix.rust-target }}/release/sprocket-${{ github.ref_name }}-${{ matrix.rust-target }}.${{ matrix.extension }}
   build_artifacts_mac:
+    needs: nix
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -177,6 +197,7 @@ jobs:
       with:
         files: ./target/${{ matrix.rust-target }}/release/sprocket-${{ github.ref_name }}-${{ matrix.rust-target }}.${{ matrix.extension }}
   build_artifacts_linux:
+    needs: nix
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@v22
     - name: Cache the Nix store
-      uses: nix-community/cache-nix-action@v7
+      uses: nix-community/cache-nix-action@v7.0.2
       with:
         primary-key: nix-${{ runner.os }}-${{ hashFiles('flake.lock', 'flake.nix', 'Cargo.lock') }}
         restore-prefixes-first-match: nix-${{ runner.os }}-

--- a/README.md
+++ b/README.md
@@ -105,16 +105,19 @@ docker pull ghcr.io/stjude-rust-labs/sprocket:v0.27.0
 ### Nix Flake
 
 Sprocket ships a [Nix](https://nixos.org/download/) flake. With flakes
-enabled, you can build or run Sprocket directly from the repository:
+enabled, you can build or run Sprocket directly from the repository. Pin a
+release tag for reproducible results:
 
 ```bash
 # Build the binary (output at ./result/bin/sprocket)
-nix build github:stjude-rust-labs/sprocket#sprocket
+nix build github:stjude-rust-labs/sprocket/v0.27.0#sprocket
 ./result/bin/sprocket --help
 
 # Or run it without installing
-nix run github:stjude-rust-labs/sprocket -- --help
+nix run github:stjude-rust-labs/sprocket/v0.27.0 -- --help
 ```
+
+Omit the `/v0.27.0` tag to track the latest commit on `main`.
 
 ## 🖥️ Development
 

--- a/flake.nix
+++ b/flake.nix
@@ -66,16 +66,12 @@
               !(base == "target" || base == "result" || lib.hasPrefix "result-" base || base == ".direnv");
           };
 
-          # We use `cargoHash` (→ `fetchCargoVendor`) rather than `cargoLock`
-          # (→ `importCargoLock`) because the latter pulls crates via
-          # `fetchurl`/curl, which crates.io now 403s for missing User-Agent
-          # headers. `fetchCargoVendor` runs Python+`requests` which sends a
-          # proper UA. As a bonus, it handles git-sourced crates (the
-          # thirtyfour fork) without per-crate hash entries.
-          #
-          # Replace fakeHash with the hash Nix prints on the first build.
-          # Any change to Cargo.lock will require updating this hash.
-          cargoHash = "sha256-lCHGTjYX+pSptdZ2fBuRUIbKaKXnCyTgkWrSOlzKRhQ=";
+          # Vendor dependencies straight from Cargo.lock via `importCargoLock`.
+          # Registry crate hashes come from Cargo.lock itself, so routine
+          # dependency bumps need no Nix changes—there is no whole-vendor hash
+          # to go stale. (`outputHashes` would only be needed for git-sourced
+          # crates, of which the workspace currently has none.)
+          cargoLock.lockFile = ./Cargo.lock;
 
           inherit nativeBuildInputs buildInputs;
 


### PR DESCRIPTION
The documented `nix build`/`nix run` commands fail for every user with a fixed-output hash mismatch. The flake pinned a manual `cargoHash` for `fetchCargoVendor` that had to be regenerated by hand on each `Cargo.lock` change. Because the flake builds floating `main`, routine dependency bumps left that hash stale, and nothing in CI built the flake to catch it. Closes #947.

### The fix

`flake.nix` now vendors dependencies through `cargoLock.lockFile = ./Cargo.lock;` (`importCargoLock`) instead of a manual `cargoHash`. Registry crate hashes come from `Cargo.lock` itself, so routine dependency bumps need no Nix change—there is no whole-vendor hash to go stale. The workspace has no git dependencies (`thirtyfour` is a plain crates.io dependency), so no `outputHashes` entries are required. This also sidesteps the active crates.io 403 against the `python-requests` user agent that `fetchCargoVendor` sends (rust-lang/crates.io#13482).

### Keeping it from breaking again

Because `cargoLock` removes the one failure mode ordinary commits could introduce, a full flake build on every PR is no longer warranted, so the verification is tiered.

A dedicated `nix.yml` builds the flake (`nix flake check`, which builds the `sprocket` package and the `sprocket-smoke` binary test) on pushes to `main` and on pull requests that touch `flake.nix`, `flake.lock`, `Cargo.lock`, `Cargo.toml`, or any `*.nix` file—the only changes that can still break it. The build installs Nix via `DeterminateSystems/nix-installer-action` and caches the store with the token-free `nix-community/cache-nix-action`.

Since the README now points users at release tags, those are guaranteed to build: a `nix` job in `release.yml` runs the same check for the tag, and every artifact and image job `needs` it, so a tag that fails under Nix is never published. That build is normally cache-warm from the `main` runs.

### Notes for review

Nix is not installed on the authoring machine, so the flake was not built locally; the `Nix / build` job on this PR performs the first end-to-end verification. The new Nix check is intentionally not configured as a required status check—a path-filtered workflow that is skipped on unrelated PRs would otherwise block merge.

---

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.