### PR TITLE
chore: fix `sprocket format --max-line-length` docs

### DIFF
--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -49,8 +49,8 @@ pub struct Args {
     )]
     pub indentation_size: Option<usize>,
 
-    /// The maximum line length (default is 90). 0 means do not use a maximum
-    /// line length.
+    /// The maximum line length (default is 90, valid range is 60–240). `none` means do not use a
+    /// maximum line length.
     #[arg(long, value_name = "LENGTH", global = true)]
     pub max_line_length: Option<String>,
 

--- a/src/commands/format.rs
+++ b/src/commands/format.rs
@@ -49,8 +49,8 @@ pub struct Args {
     )]
     pub indentation_size: Option<usize>,
 
-    /// The maximum line length (default is 90, valid range is 60–240). `none` means do not use a
-    /// maximum line length.
+    /// The maximum line length (default is 90, valid range is 60–240). `none`
+    /// means do not use a maximum line length.
     #[arg(long, value_name = "LENGTH", global = true)]
     pub max_line_length: Option<String>,
 


### PR DESCRIPTION
The actual and advertised behaviors of `--max-line-length` in `sprocket format` are out of alignment; this aligns the docs to the implementation. Closes #969.

`MaxLineLength` uses `const SENTINEL: &str = "none"` [here](https://github.com/stjude-rust-labs/sprocket/blob/8a27069fc750590ca39e4dc5e5d7d6207e5f3326/crates/wdl-format/src/config/max_line_length.rs#L30), and the CLI parser maps `"none" => None` [here](https://github.com/stjude-rust-labs/sprocket/blob/8a27069fc750590ca39e4dc5e5d7d6207e5f3326/src/commands/format.rs#L135). It appears the 0 sentinel was part of an earlier design, but the help comment was never updated for the current design.


Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
