### PR TITLE
ci(py): sort python import statements

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -129,6 +129,6 @@ jobs:
       # `isort` requires third-party dependencies to be installed before running. We skip this
       # because `sprocket_bio` doesn't have any dependencies.
       - name: Check import sorting
-        uses: isort/isort-action@v1
-        with:
-          sort-paths: python
+        run: |
+          python -m pip install "isort~=8.0"
+          isort --check-only --diff python/

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -114,3 +114,21 @@ jobs:
         uses: psf/black@stable
         with:
           use_pyproject: true
+
+  sort-imports:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      # Note that `isort` requires 3rd-party dependencies be installed before running. We skip this
+      # because `sprocket_bio` doesn't have any dependencies.
+      - name: Check import sorting
+        uses: isort/isort-action@v1
+        with:
+          sort-paths: python

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -126,7 +126,7 @@ jobs:
         with:
           python-version: "3.10"
 
-      # Note that `isort` requires 3rd-party dependencies be installed before running. We skip this
+      # `isort` requires third-party dependencies to be installed before running. We skip this
       # because `sprocket_bio` doesn't have any dependencies.
       - name: Check import sorting
         uses: isort/isort-action@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,5 +48,5 @@ py_version="auto"
 skip_gitignore = true
 # Place one blank line between direct and from imports.
 lines_between_types = 1
-# `sprocket_bio` is a 1st-party package, not a 3rd-party one.
+# `sprocket_bio` is a first-party package, not a third-party one.
 known_first_party = ["sprocket_bio"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ target-version = ["py310"]
 
 [tool.isort]
 profile = "black"
-py_version="auto"
+py_version = 310
 # Do not modify files specified in `.gitignore`, such as `.venv` and `.git`.
 skip_gitignore = true
 # Place one blank line between direct and from imports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/stjude-rust-labs/sprocket"
 # Dependencies for local development, not visible to downstream consumers.
 [dependency-groups]
 # Installed by default with `maturin develop`.
-dev = ["pytest~=9.0", "mypy~=2.1", "black~=26.5"]
+dev = ["pytest~=9.0", "mypy~=2.1", "black~=26.5", "isort~=8.0"]
 
 [tool.maturin]
 module-name = "sprocket_bio._sprocket_bio"
@@ -40,3 +40,13 @@ strict = true
 
 [tool.black]
 target-version = ["py310"]
+
+[tool.isort]
+profile = "black"
+py_version="auto"
+# Do not modify files specified in `.gitignore`, such as `.venv` and `.git`.
+skip_gitignore = true
+# Place one blank line between direct and from imports.
+lines_between_types = 1
+# `sprocket_bio` is a 1st-party package, not a 3rd-party one.
+known_first_party = ["sprocket_bio"]

--- a/python/README.md
+++ b/python/README.md
@@ -53,8 +53,9 @@ pytest
 mypy python/
 python -m mypy.stubtest sprocket_bio
 
-# Format code.
+# Format code and sort import statements.
 black python/
+isort python/
 ```
 
-The Python package is located at `python/sprocket_bio` (in this folder), and the Python extension that it bundles is compiled from `crates/sprocket-py` using the [Maturin build system](https://www.maturin.rs). Dependencies and additional metadata are specified in `pyproject.toml` and `crates/sprocket-py/Cargo.toml`. Unit tests are defined in `python/tests` using the [`pytest`](https://docs.pytest.org) framework. Type and stub checking is performed by [`mypy`](https://mypy.readthedocs.io). Code formatting is performed by [`black`](https://black.readthedocs.io).
+The Python package is located at `python/sprocket_bio` (in this folder), and the Python extension that it bundles is compiled from `crates/sprocket-py` using the [Maturin build system](https://www.maturin.rs). Dependencies and additional metadata are specified in `pyproject.toml` and `crates/sprocket-py/Cargo.toml`. Unit tests are defined in `python/tests` using the [`pytest`](https://docs.pytest.org) framework. Type and stub checking is performed by [`mypy`](https://mypy.readthedocs.io). Code formatting is performed by [`black`](https://black.readthedocs.io), and import statement sorting is done by [`isort`](https://isort.readthedocs.io).


### PR DESCRIPTION
Closes #961.

This PR adds [`isort`](https://isort.readthedocs.io/en/latest/index.html) as a development dependency of the Python bindings. It ensures that Python import statements are properly sorted in CI, to save reviewers time.

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).
