### PR TITLE
ci(py): use python-version-file when installing python

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version-file: "pyproject.toml"
 
       - name: Create virtual environment
         run: python -m venv --upgrade-deps .venv
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version-file: "pyproject.toml"
 
       - name: Create virtual environment
         run: python -m venv --upgrade-deps .venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* CI now reads the Python version from `pyproject.toml` via `python-version-file` instead of hardcoding it in each job ([#972](https://github.com/stjude-rust-labs/sprocket/pull/972)).
+
 ## 0.27.0 - 2026-06-26
 
 ### Added


### PR DESCRIPTION
## Description

`actions/setup-python` supports the `python-version-file` input, which reads the Python version from `pyproject.toml` (via `requires-python`). This replaces the hardcoded `python-version: "3.10"` in the `test` and `type-check` jobs, so `pyproject.toml` becomes the single source of truth instead of duplicating the version in every job.

## Changes

- `.github/workflows/python-ci.yml`: replaced hardcoded `python-version` with `python-version-file: "pyproject.toml"` in the `test` and `type-check` jobs.

## Testing

- Confirmed `pyproject.toml` declares `requires-python = ">=3.10"`.
- Ran `actionlint` against the workflow file — no new issues introduced.
- CI on this PR itself is the functional test.

#### Fixes #972

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
