### PR TITLE
fix(wdl-analysis): make runtime key type checking version-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
-
-* `runtime` section key type checking (e.g. for `cpu`, `gpu`, `disks`,
-  `maxRetries`, and `returnCodes`) is now version-aware: these keys are no
-  longer type checked in WDL 1.0 documents, since they were not formally
-  typed until WDL 1.1 ([#811](https://github.com/stjude-rust-labs/sprocket/pull/979)).
-
 ## 0.27.0 - 2026-06-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* `runtime` section key type checking (e.g. for `cpu`, `gpu`, `disks`,
+  `maxRetries`, and `returnCodes`) is now version-aware: these keys are no
+  longer type checked in WDL 1.0 documents, since they were not formally
+  typed until WDL 1.1 ([#811](https://github.com/stjude-rust-labs/sprocket/pull/979)).
+
 ## 0.27.0 - 2026-06-26
 
 ### Added

--- a/crates/gauntlet/Gauntlet.toml
+++ b/crates/gauntlet/Gauntlet.toml
@@ -3078,11 +3078,6 @@ message = "TrioAnalysis.wdl:80:14: warning[UnusedInput]: unused input `ref_index
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62f889d0c2b79fb65c28b1d2727ae7992/BenchmarkVCFs/TrioAnalysis.wdl/#L80"
 
 [[diagnostics]]
-document = "broadinstitute/palantir-workflows:/Fingerprints/GetFingerprintMetrics.wdl"
-message = "GetFingerprintMetrics.wdl:45:11: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62f889d0c2b79fb65c28b1d2727ae7992/Fingerprints/GetFingerprintMetrics.wdl/#L45"
-
-[[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:125:64: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62f889d0c2b79fb65c28b1d2727ae7992/FunctionalEquivalence/FunctionalEquivalence.wdl/#L125"
@@ -3194,11 +3189,6 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl"
-message = "Glimpse2MergeBatches.wdl:164:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62f889d0c2b79fb65c28b1d2727ae7992/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl/#L164"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl"
 message = "Glimpse2MergeBatches.wdl:181:14: warning[UnusedInput]: unused input `vcf_index`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62f889d0c2b79fb65c28b1d2727ae7992/GlimpseImputationPipeline/Glimpse2MergeBatches.wdl/#L181"
 
@@ -3251,11 +3241,6 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62
 document = "broadinstitute/palantir-workflows:/HaplotypeMap/BuildHaplotypeMap.wdl"
 message = "BuildHaplotypeMap.wdl:17:1: error: a WDL document must start with a version statement"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62f889d0c2b79fb65c28b1d2727ae7992/HaplotypeMap/BuildHaplotypeMap.wdl/#L17"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/JointCalling/CreateSampleMap.wdl"
-message = "CreateSampleMap.wdl:57:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62f889d0c2b79fb65c28b1d2727ae7992/JointCalling/CreateSampleMap.wdl/#L57"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/LongReadRNABenchmark/Bambu.wdl"
@@ -3579,18 +3564,8 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/DownsampleAndCollectCoverage.wdl"
-message = "DownsampleAndCollectCoverage.wdl:196:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62f889d0c2b79fb65c28b1d2727ae7992/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L196"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/Utilities/WDLs/DownsampleAndCollectCoverage.wdl"
 message = "DownsampleAndCollectCoverage.wdl:88:14: warning[UnusedInput]: unused input `input_cram_index`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62f889d0c2b79fb65c28b1d2727ae7992/Utilities/WDLs/DownsampleAndCollectCoverage.wdl/#L88"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/Utilities/WDLs/IndexCramOrBam.wdl"
-message = "IndexCramOrBam.wdl:36:8: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62f889d0c2b79fb65c28b1d2727ae7992/Utilities/WDLs/IndexCramOrBam.wdl/#L36"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/MatchFingerprints.wdl"
@@ -3601,11 +3576,6 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/MatchFingerprints.wdl"
 message = "MatchFingerprints.wdl:88:17: warning[UnusedInput]: unused input `fail_on_mismatch`"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62f889d0c2b79fb65c28b1d2727ae7992/Utilities/WDLs/MatchFingerprints.wdl/#L88"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/Utilities/WDLs/MergeSingleSampleMinimacVcfs.wdl"
-message = "MergeSingleSampleMinimacVcfs.wdl:183:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/0d6cb8e62f889d0c2b79fb65c28b1d2727ae7992/Utilities/WDLs/MergeSingleSampleMinimacVcfs.wdl/#L183"
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/Utilities/WDLs/MergeSingleSampleMinimacVcfs.wdl"
@@ -3849,23 +3819,8 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/PCA/pca_only_no_labels.wdl"
-message = "pca_only_no_labels.wdl:158:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/PCA/pca_only_no_labels.wdl/#L158"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/PCA/pca_only_no_labels.wdl"
-message = "pca_only_no_labels.wdl:247:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/PCA/pca_only_no_labels.wdl/#L247"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/PCA/pca_only_no_labels.wdl"
 message = "pca_only_no_labels.wdl:51:21: warning[UnusedInput]: unused input `vcf_indices`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/PCA/pca_only_no_labels.wdl/#L51"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/PCA/pca_only_no_labels.wdl"
-message = "pca_only_no_labels.wdl:78:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/PCA/pca_only_no_labels.wdl/#L78"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/PCA/pca_only_no_labels.wdl"
@@ -3894,16 +3849,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/ancestry/determine_hq_sites_intersection.wdl"
-message = "determine_hq_sites_intersection.wdl:181:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/determine_hq_sites_intersection.wdl/#L181"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/ancestry/determine_hq_sites_intersection.wdl"
-message = "determine_hq_sites_intersection.wdl:247:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/determine_hq_sites_intersection.wdl/#L247"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/ancestry/determine_hq_sites_intersection.wdl"
 message = "determine_hq_sites_intersection.wdl:264:14: warning[UnusedInput]: unused input `sites_only_vcf_idx`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/determine_hq_sites_intersection.wdl/#L264"
 
@@ -3919,11 +3864,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/ancestry/determine_hq_sites_intersection.wdl"
-message = "determine_hq_sites_intersection.wdl:306:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/determine_hq_sites_intersection.wdl/#L306"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/ancestry/determine_hq_sites_intersection.wdl"
 message = "determine_hq_sites_intersection.wdl:314:14: warning[UnusedInput]: unused input `vcf1_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/determine_hq_sites_intersection.wdl/#L314"
 
@@ -3931,11 +3871,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/all_of_us/ancestry/determine_hq_sites_intersection.wdl"
 message = "determine_hq_sites_intersection.wdl:316:14: warning[UnusedInput]: unused input `vcf2_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/determine_hq_sites_intersection.wdl/#L316"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/ancestry/determine_hq_sites_intersection.wdl"
-message = "determine_hq_sites_intersection.wdl:343:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/determine_hq_sites_intersection.wdl/#L343"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/ancestry/determine_hq_sites_intersection.wdl"
@@ -3964,11 +3899,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/ancestry/run_ancestry.wdl"
-message = "run_ancestry.wdl:164:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_ancestry.wdl/#L164"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/ancestry/run_ancestry.wdl"
 message = "run_ancestry.wdl:172:14: warning[UnusedInput]: unused input `input_vcf_idx`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_ancestry.wdl/#L172"
 
@@ -3976,16 +3906,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/all_of_us/ancestry/run_ancestry.wdl"
 message = "run_ancestry.wdl:174:14: warning[UnusedInput]: unused input `training_vcf_idx`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_ancestry.wdl/#L174"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/ancestry/run_ancestry.wdl"
-message = "run_ancestry.wdl:283:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_ancestry.wdl/#L283"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/ancestry/run_ancestry.wdl"
-message = "run_ancestry.wdl:380:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_ancestry.wdl/#L380"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/ancestry/run_ancestry.wdl"
@@ -4009,33 +3929,13 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/ancestry/run_sample_outlier_qc.wdl"
-message = "run_sample_outlier_qc.wdl:103:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_sample_outlier_qc.wdl/#L103"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/ancestry/run_sample_outlier_qc.wdl"
 message = "run_sample_outlier_qc.wdl:18:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_sample_outlier_qc.wdl/#L18"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/ancestry/run_sample_outlier_qc.wdl"
-message = "run_sample_outlier_qc.wdl:190:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_sample_outlier_qc.wdl/#L190"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl"
-message = "run_sample_outlier_qc_plotting.wdl:103:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl/#L103"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl"
 message = "run_sample_outlier_qc_plotting.wdl:111:14: warning[UnusedInput]: unused input `aou_demographics_tsv`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl/#L111"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl"
-message = "run_sample_outlier_qc_plotting.wdl:147:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl/#L147"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl"
@@ -4046,11 +3946,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl"
 message = "run_sample_outlier_qc_plotting.wdl:155:14: warning[UnusedInput]: unused input `aou_demographics_tsv`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl/#L155"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl"
-message = "run_sample_outlier_qc_plotting.wdl:249:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/ancestry/run_sample_outlier_qc_plotting.wdl/#L249"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/ancestry/vds_to_vcf.wdl"
@@ -4239,23 +4134,8 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/mitochondria/mt_coverage_merge.wdl"
-message = "mt_coverage_merge.wdl:121:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/mitochondria/mt_coverage_merge.wdl/#L121"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/mitochondria/mt_coverage_merge.wdl"
 message = "mt_coverage_merge.wdl:17:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/mitochondria/mt_coverage_merge.wdl/#L17"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/mitochondria/mt_coverage_merge.wdl"
-message = "mt_coverage_merge.wdl:220:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/mitochondria/mt_coverage_merge.wdl/#L220"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/mitochondria/mt_coverage_merge.wdl"
-message = "mt_coverage_merge.wdl:270:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/mitochondria/mt_coverage_merge.wdl/#L270"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/mitochondria/mt_coverage_merge.wdl"
@@ -4266,16 +4146,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/all_of_us/mitochondria/mt_coverage_merge.wdl"
 message = "mt_coverage_merge.wdl:282:16: warning[UnusedInput]: unused input `output_bucket`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/mitochondria/mt_coverage_merge.wdl/#L282"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/mitochondria/mt_coverage_merge.wdl"
-message = "mt_coverage_merge.wdl:333:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/mitochondria/mt_coverage_merge.wdl/#L333"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/mitochondria/mt_coverage_merge.wdl"
-message = "mt_coverage_merge.wdl:391:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/mitochondria/mt_coverage_merge.wdl/#L391"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/mitochondria/subworkflows_and_tasks/AlignAndCallR1_v2_5_Single.wdl"
@@ -4624,11 +4494,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/pgx/CyriusStarAlleleCalling.wdl"
-message = "CyriusStarAlleleCalling.wdl:80:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/pgx/CyriusStarAlleleCalling.wdl/#L80"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/pgx/CyriusStarAlleleCalling.wdl"
 message = "CyriusStarAlleleCalling.wdl:92:14: warning[UnusedInput]: unused input `input_cram_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/pgx/CyriusStarAlleleCalling.wdl/#L92"
 
@@ -4641,11 +4506,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/all_of_us/pgx/StargazerFromJointVCF.wdl"
 message = "StargazerFromJointVCF.wdl:106:14: warning[UnusedInput]: unused input `inputVCFindex`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/pgx/StargazerFromJointVCF.wdl/#L106"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/pgx/StargazerFromJointVCF.wdl"
-message = "StargazerFromJointVCF.wdl:124:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/pgx/StargazerFromJointVCF.wdl/#L124"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/pgx/StargazerFromJointVCF.wdl"
@@ -4684,23 +4544,8 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/rna_seq/AggregateSusieWorkflow.wdl"
-message = "AggregateSusieWorkflow.wdl:32:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/AggregateSusieWorkflow.wdl/#L32"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/rna_seq/AggregateSusieWorkflow.wdl"
 message = "AggregateSusieWorkflow.wdl:56:14: warning[UnusedInput]: unused input `AnnotationVEPIndex`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/AggregateSusieWorkflow.wdl/#L56"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/rna_seq/AggregateSusieWorkflow.wdl"
-message = "AggregateSusieWorkflow.wdl:78:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/AggregateSusieWorkflow.wdl/#L78"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/rna_seq/CalculatePhenotypeGroups.wdl"
-message = "CalculatePhenotypeGroups.wdl:28:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/CalculatePhenotypeGroups.wdl/#L28"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/rna_seq/CalculatePhenotypeGroups.wdl"
@@ -4711,11 +4556,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/all_of_us/rna_seq/CalculatePhenotypeGroups.wdl"
 message = "CalculatePhenotypeGroups.wdl:46:12: warning[UnusedDeclaration]: unused declaration `pipeline_version`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/CalculatePhenotypeGroups.wdl/#L46"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/rna_seq/aggregate_rsem_results.wdl"
-message = "aggregate_rsem_results.wdl:54:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/aggregate_rsem_results.wdl/#L54"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/rna_seq/aggregate_rsem_results.wdl"
@@ -4758,16 +4598,6 @@ message = "aggregate_rsem_results.wdl:65:10: warning[UnusedCall]: unused call `r
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/aggregate_rsem_results.wdl/#L65"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/rna_seq/leafcutter_bam_to_junc.wdl"
-message = "leafcutter_bam_to_junc.wdl:30:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/leafcutter_bam_to_junc.wdl/#L30"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/rna_seq/leafcutter_cluster.wdl"
-message = "leafcutter_cluster.wdl:65:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/leafcutter_cluster.wdl/#L65"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/rna_seq/markduplicates.wdl"
 message = "markduplicates.wdl:1:1: error: a WDL document must start with a version statement"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/markduplicates.wdl/#L1"
@@ -4804,11 +4634,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/rna_seq/susieR_workflow.wdl"
-message = "susieR_workflow.wdl:123:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/susieR_workflow.wdl/#L123"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/rna_seq/susieR_workflow.wdl"
 message = "susieR_workflow.wdl:180:16: warning[UnusedInput]: unused input `OutputPrefix`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/susieR_workflow.wdl/#L180"
 
@@ -4821,11 +4646,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/all_of_us/rna_seq/susieR_workflow.wdl"
 message = "susieR_workflow.wdl:31:14: warning[UnusedInput]: unused input `GenotypeDosageIndex`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/susieR_workflow.wdl/#L31"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/all_of_us/rna_seq/susieR_workflow.wdl"
-message = "susieR_workflow.wdl:76:14: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/all_of_us/rna_seq/susieR_workflow.wdl/#L76"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/all_of_us/rna_seq/susieR_workflow.wdl"
@@ -6669,28 +6489,8 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/wdl/build_indices/BuildIndices.wdl"
-message = "BuildIndices.wdl:256:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/pipelines/wdl/build_indices/BuildIndices.wdl/#L256"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/wdl/build_indices/BuildIndices.wdl"
-message = "BuildIndices.wdl:426:9: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/pipelines/wdl/build_indices/BuildIndices.wdl/#L426"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/wdl/build_indices/BuildIndices.wdl"
 message = "BuildIndices.wdl:436:12: warning[UnusedInput]: unused input `gtf_annotation_version`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/pipelines/wdl/build_indices/BuildIndices.wdl/#L436"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/wdl/build_indices/BuildIndices.wdl"
-message = "BuildIndices.wdl:490:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/pipelines/wdl/build_indices/BuildIndices.wdl/#L490"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/pipelines/wdl/build_indices/BuildIndices.wdl"
-message = "BuildIndices.wdl:579:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/pipelines/wdl/build_indices/BuildIndices.wdl/#L579"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/pipelines/wdl/dna_seq/germline/joint_genotyping/JointGenotyping.wdl"
@@ -7078,11 +6878,6 @@ message = "AggregatedBamQC.wdl:60:7: warning[UnnecessaryFunctionCall]: unnecessa
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/AggregatedBamQC.wdl/#L60"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/Alignment.wdl"
-message = "Alignment.wdl:119:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/Alignment.wdl/#L119"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/BamProcessing.wdl"
 message = "BamProcessing.wdl:127:10: warning[UnusedInput]: unused input `input_bam_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/BamProcessing.wdl/#L127"
@@ -7113,11 +6908,6 @@ message = "BamProcessing.wdl:416:10: warning[UnusedInput]: unused input `ref_fas
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/BamProcessing.wdl/#L416"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/BamProcessing.wdl"
-message = "BamProcessing.wdl:53:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/BamProcessing.wdl/#L53"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/CheckContaminationSomatic.wdl"
 message = "CheckContaminationSomatic.wdl:10:14: warning[UnusedInput]: unused input `tumor_crai_or_bai`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/CheckContaminationSomatic.wdl/#L10"
@@ -7141,11 +6931,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/tasks/wdl/CheckContaminationSomatic.wdl"
 message = "CheckContaminationSomatic.wdl:8:14: warning[UnusedInput]: unused input `reference_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/CheckContaminationSomatic.wdl/#L8"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/CopyFilesFromCloudToCloud.wdl"
-message = "CopyFilesFromCloudToCloud.wdl:71:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/CopyFilesFromCloudToCloud.wdl/#L71"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/CreateCountMatrix.wdl"
@@ -7201,11 +6986,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/tasks/wdl/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:148:32: error: expected string, but found integer"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/GermlineVariantDiscovery.wdl/#L148"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/GermlineVariantDiscovery.wdl"
-message = "GermlineVariantDiscovery.wdl:165:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/GermlineVariantDiscovery.wdl/#L165"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/GermlineVariantDiscovery.wdl"
@@ -7269,11 +7049,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/GermlineVariantDiscovery.wdl"
-message = "GermlineVariantDiscovery.wdl:381:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/GermlineVariantDiscovery.wdl/#L381"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:391:10: warning[UnusedInput]: unused input `input_vcf_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/GermlineVariantDiscovery.wdl/#L391"
 
@@ -7299,18 +7074,8 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/GermlineVariantDiscovery.wdl"
-message = "GermlineVariantDiscovery.wdl:437:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/GermlineVariantDiscovery.wdl/#L437"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/GermlineVariantDiscovery.wdl"
 message = "GermlineVariantDiscovery.wdl:67:32: error: expected string, but found integer"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/GermlineVariantDiscovery.wdl/#L67"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/GermlineVariantDiscovery.wdl"
-message = "GermlineVariantDiscovery.wdl:74:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/GermlineVariantDiscovery.wdl/#L74"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/GermlineVariantDiscovery.wdl"
@@ -7401,11 +7166,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/tasks/wdl/IlluminaGenotypingArrayTasks.wdl"
 message = "IlluminaGenotypingArrayTasks.wdl:514:10: warning[UnusedInput]: unused input `input_vcf_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/IlluminaGenotypingArrayTasks.wdl/#L514"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/IlluminaGenotypingArrayTasks.wdl"
-message = "IlluminaGenotypingArrayTasks.wdl:541:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/IlluminaGenotypingArrayTasks.wdl/#L541"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/IlluminaGenotypingArrayTasks.wdl"
@@ -7619,11 +7379,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
-message = "JointGenotypingTasks.wdl:304:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L304"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:329:10: warning[UnusedInput]: unused input `sites_only_variant_filtered_vcf_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L329"
 
@@ -7641,11 +7396,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:336:10: warning[UnusedInput]: unused input `dbsnp_resource_vcf_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L336"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
-message = "JointGenotypingTasks.wdl:366:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L366"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
@@ -7671,11 +7421,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:401:10: warning[UnusedInput]: unused input `dbsnp_resource_vcf_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L401"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
-message = "JointGenotypingTasks.wdl:434:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L434"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
@@ -7719,11 +7464,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
-message = "JointGenotypingTasks.wdl:581:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L581"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:598:10: warning[UnusedInput]: unused input `input_vcf_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L598"
 
@@ -7739,16 +7479,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
-message = "JointGenotypingTasks.wdl:641:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L641"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
-message = "JointGenotypingTasks.wdl:688:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L688"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:754:10: warning[UnusedInput]: unused input `input_vcf_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L754"
 
@@ -7756,11 +7486,6 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
 message = "JointGenotypingTasks.wdl:757:10: warning[UnusedInput]: unused input `dbsnp_vcf_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L757"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
-message = "JointGenotypingTasks.wdl:859:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/JointGenotypingTasks.wdl/#L859"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/JointGenotypingTasks.wdl"
@@ -7948,16 +7673,6 @@ message = "StarAlign.wdl:550:12: warning[UnusedInput]: unused input `gex_nhash_i
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/StarAlign.wdl/#L550"
 
 [[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/StarAlign.wdl"
-message = "StarAlign.wdl:880:9: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/StarAlign.wdl/#L880"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/TerraCopyFilesFromCloudToCloud.wdl"
-message = "TerraCopyFilesFromCloudToCloud.wdl:44:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/TerraCopyFilesFromCloudToCloud.wdl/#L44"
-
-[[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/UltimaGenomicsGermlineFilteringThreshold.wdl"
 message = "UltimaGenomicsGermlineFilteringThreshold.wdl:121:14: warning[UnusedInput]: unused input `input_vcf_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/UltimaGenomicsGermlineFilteringThreshold.wdl/#L121"
@@ -8124,28 +7839,13 @@ permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb9002903
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/Utilities.wdl"
-message = "Utilities.wdl:152:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/Utilities.wdl/#L152"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/Utilities.wdl"
 message = "Utilities.wdl:167:10: warning[UnusedInput]: unused input `ref_fasta_index`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/Utilities.wdl/#L167"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/Utilities.wdl"
-message = "Utilities.wdl:183:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/Utilities.wdl/#L183"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl"
 message = "bwa-mk-index.wdl:24:16: warning[UnusedInput]: unused input `ref_name`"
 permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L24"
-
-[[diagnostics]]
-document = "broadinstitute/warp:/tasks/wdl/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl"
-message = "bwa-mk-index.wdl:48:8: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/broadinstitute/warp/blob/54032fd9003183eb90029033fd2f88d98ac9a001/tasks/wdl/accessory_workflows/build_bwa_reference/bwa-mk-index.wdl/#L48"
 
 [[diagnostics]]
 document = "broadinstitute/warp:/tasks/wdl/sample_fastq.14.wdl"
@@ -9173,11 +8873,6 @@ message = "picard.wdl:898:21: warning[UnusedInput]: unused input `vcfs_indexes`"
 permalink = "https://github.com/stjudecloud/workflows/blob/0821aba149dee1f671866673913c7eb7cf1418cd/tools/picard.wdl/#L898"
 
 [[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/tasks/alignment/task_bwa.wdl"
-message = "task_bwa.wdl:196:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/alignment/task_bwa.wdl/#L196"
-
-[[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_ivar_consensus.wdl"
 message = "task_ivar_consensus.wdl:12:18: error: type mismatch: expected type `Int`, but found type `String`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/assembly/task_ivar_consensus.wdl/#L12"
@@ -9193,29 +8888,9 @@ message = "task_ivar_consensus.wdl:9:21: error: type mismatch: expected type `In
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/assembly/task_ivar_consensus.wdl/#L9"
 
 [[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_megahit.wdl"
-message = "task_megahit.wdl:69:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/assembly/task_megahit.wdl/#L69"
-
-[[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_metaspades.wdl"
-message = "task_metaspades.wdl:39:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/assembly/task_metaspades.wdl/#L39"
-
-[[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_semibin.wdl"
 message = "task_semibin.wdl:6:10: warning[UnusedInput]: unused input `sorted_bai`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/assembly/task_semibin.wdl/#L6"
-
-[[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_skesa.wdl"
-message = "task_skesa.wdl:51:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/assembly/task_skesa.wdl/#L51"
-
-[[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/tasks/assembly/task_spades.wdl"
-message = "task_spades.wdl:81:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/assembly/task_spades.wdl/#L81"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/drug_resistance/task_resfinder.wdl"
@@ -9233,24 +8908,9 @@ message = "task_ivar_variant_call.wdl:88:23: error: type mismatch: expected type
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/gene_typing/variant_detection/task_ivar_variant_call.wdl/#L88"
 
 [[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl"
-message = "task_snippy_gene_query.wdl:69:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/gene_typing/variant_detection/task_snippy_gene_query.wdl/#L69"
-
-[[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/tasks/gene_typing/variant_detection/task_snippy_variants.wdl"
-message = "task_snippy_variants.wdl:158:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/gene_typing/variant_detection/task_snippy_variants.wdl/#L158"
-
-[[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/advanced_metrics/task_checkv.wdl"
 message = "task_checkv.wdl:9:12: warning[UnusedInput]: unused input `samplename`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/quality_control/advanced_metrics/task_checkv.wdl/#L9"
-
-[[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/tasks/quality_control/advanced_metrics/task_gambittools.wdl"
-message = "task_gambittools.wdl:67:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/quality_control/advanced_metrics/task_gambittools.wdl/#L67"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl"
@@ -9278,11 +8938,6 @@ message = "task_assembly_metrics.wdl:85:37: error: type mismatch: expected type 
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/quality_control/basic_statistics/task_assembly_metrics.wdl/#L85"
 
 [[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl"
-message = "task_cg_pipeline.wdl:102:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/quality_control/basic_statistics/task_cg_pipeline.wdl/#L102"
-
-[[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:46:20: error: type mismatch: expected type `Int`, but found type `String`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L46"
@@ -9306,11 +8961,6 @@ permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_consensus_qc.wdl"
 message = "task_consensus_qc.wdl:50:40: error: type mismatch: expected type `Float`, but found type `String`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/quality_control/basic_statistics/task_consensus_qc.wdl/#L50"
-
-[[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_quast.wdl"
-message = "task_quast.wdl:64:12: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/quality_control/basic_statistics/task_quast.wdl/#L64"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/quality_control/basic_statistics/task_readlength.wdl"
@@ -9396,11 +9046,6 @@ permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3
 document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/contamination/task_midas.wdl"
 message = "task_midas.wdl:77:44: error: type mismatch: expected type `Float`, but found type `String`"
 permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/taxon_id/contamination/task_midas.wdl/#L77"
-
-[[diagnostics]]
-document = "theiagen/public_health_bioinformatics:/tasks/taxon_id/task_gambit.wdl"
-message = "task_gambit.wdl:164:10: error: type mismatch: expected type `Int` or type `Float`, but found type `String`"
-permalink = "https://github.com/theiagen/public_health_bioinformatics/blob/3eea3193bc238ef68f0b86e466257a293f1ba514/tasks/taxon_id/task_gambit.wdl/#L164"
 
 [[diagnostics]]
 document = "theiagen/public_health_bioinformatics:/tasks/utilities/data_handling/task_arln_stats.wdl"

--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* `runtime` section key type checking (e.g. for `cpu`, `gpu`, `disks`,
+  `maxRetries`, and `returnCodes`) is now version-aware: these keys are no
+  longer type checked in WDL 1.0 documents, since they were not formally
+  typed until WDL 1.1 ([#811](https://github.com/stjude-rust-labs/sprocket/issues/811)).
+
 ## 0.22.0 - 2026-06-26
 
 #### Changed

--- a/crates/wdl-analysis/src/types/v1.rs
+++ b/crates/wdl-analysis/src/types/v1.rs
@@ -238,21 +238,31 @@ pub fn task_requirement_types(version: SupportedVersion, name: &str) -> Option<&
         ])
     });
 
+    // WDL 1.0 does not formally define the `cpu`, `gpu`, `disks`, `maxRetries`,
+    // or `return_codes`/`returnCodes` runtime keys; per the 1.0 specification,
+    // only `docker`/`container` and `memory` are given recommended type
+    // conventions. As such, type checking for the remaining keys should only
+    // apply to documents declaring `version 1.1` or later (see
+    // https://github.com/stjude-rust-labs/sprocket/issues/811).
     match name {
         TASK_REQUIREMENT_CONTAINER | TASK_REQUIREMENT_CONTAINER_ALIAS => Some(&CONTAINER_TYPES),
-        TASK_REQUIREMENT_CPU => Some(CPU_TYPES),
-        TASK_REQUIREMENT_DISKS => Some(&DISKS_TYPES),
-        TASK_REQUIREMENT_GPU => Some(GPU_TYPES),
+        TASK_REQUIREMENT_CPU if version >= SupportedVersion::V1(V1::One) => Some(CPU_TYPES),
+        TASK_REQUIREMENT_DISKS if version >= SupportedVersion::V1(V1::One) => Some(&DISKS_TYPES),
+        TASK_REQUIREMENT_GPU if version >= SupportedVersion::V1(V1::One) => Some(GPU_TYPES),
         TASK_REQUIREMENT_FPGA if version >= SupportedVersion::V1(V1::Two) => Some(FPGA_TYPES),
         TASK_REQUIREMENT_MAX_RETRIES if version >= SupportedVersion::V1(V1::Two) => {
             Some(MAX_RETRIES_TYPES)
         }
-        TASK_REQUIREMENT_MAX_RETRIES_ALIAS => Some(MAX_RETRIES_TYPES),
+        TASK_REQUIREMENT_MAX_RETRIES_ALIAS if version >= SupportedVersion::V1(V1::One) => {
+            Some(MAX_RETRIES_TYPES)
+        }
         TASK_REQUIREMENT_MEMORY => Some(MEMORY_TYPES),
         TASK_REQUIREMENT_RETURN_CODES if version >= SupportedVersion::V1(V1::Two) => {
             Some(&RETURN_CODES_TYPES)
         }
-        TASK_REQUIREMENT_RETURN_CODES_ALIAS => Some(&RETURN_CODES_TYPES),
+        TASK_REQUIREMENT_RETURN_CODES_ALIAS if version >= SupportedVersion::V1(V1::One) => {
+            Some(&RETURN_CODES_TYPES)
+        }
         _ => None,
     }
 }
@@ -997,6 +1007,30 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
         expr: &Expr<N>,
     ) {
         let expr_ty = self.evaluate_expr(expr).unwrap_or(Type::Union);
+
+        // The `cpu`, `gpu`, `disks`, `maxRetries`, and `returnCodes` keys are not
+        // formally typed until WDL 1.1 (see the WDL 1.0 specification's runtime
+        // section, which only gives recommended conventions for `docker` and
+        // `memory`). Some of these names are shared with differently-typed
+        // `hints` keys (e.g. `gpu` and `disks`), so simply letting the
+        // `task_requirement_types` lookup fail for WDL 1.0 documents isn't
+        // sufficient; doing so would incorrectly fall through to checking
+        // against the `hints` types below. Instead, skip type checking for
+        // these keys entirely when the document version is older than 1.1.
+        // See https://github.com/stjude-rust-labs/sprocket/issues/811.
+        if self.context.version() < SupportedVersion::V1(V1::One)
+            && matches!(
+                name.text(),
+                TASK_REQUIREMENT_CPU
+                    | TASK_REQUIREMENT_GPU
+                    | TASK_REQUIREMENT_DISKS
+                    | TASK_REQUIREMENT_MAX_RETRIES_ALIAS
+                    | TASK_REQUIREMENT_RETURN_CODES_ALIAS
+            )
+        {
+            return;
+        }
+
         if !self.evaluate_requirement(name, expr, &expr_ty) {
             // Always use object types for `runtime` section `inputs` and `outputs` keys as
             // only `hints` sections can use input/output hidden types

--- a/crates/wdl-analysis/tests/analysis/runtime-section-v1-0/source.diagnostics
+++ b/crates/wdl-analysis/tests/analysis/runtime-section-v1-0/source.diagnostics
@@ -1,0 +1,16 @@
+error: type mismatch: expected type `String` or type `Array[String]`, but found type `Boolean`
+   ┌─ tests/analysis/runtime-section-v1-0/source.wdl:29:17
+   │
+29 │         docker: false
+   │         ------  ^^^^^ this is type `Boolean`
+   │         │        
+   │         this expects type `String` or type `Array[String]`
+
+error: type mismatch: expected type `Int` or type `String`, but found type `Boolean`
+   ┌─ tests/analysis/runtime-section-v1-0/source.wdl:30:17
+   │
+30 │         memory: false
+   │         ------  ^^^^^ this is type `Boolean`
+   │         │        
+   │         this expects type `Int` or type `String`
+

--- a/crates/wdl-analysis/tests/analysis/runtime-section-v1-0/source.wdl
+++ b/crates/wdl-analysis/tests/analysis/runtime-section-v1-0/source.wdl
@@ -1,0 +1,37 @@
+## This is a test of type checking `runtime` keys in a WDL 1.0 document.
+##
+## WDL 1.0 does not formally define the `cpu`, `gpu`, `disks`, `maxRetries`,
+## or `returnCodes` runtime keys, so no type checking should be performed on
+## them here; only `docker` and `memory` have recommended type conventions in
+## 1.0 and should still be type checked.
+
+version 1.0
+
+task foo {
+    command <<<>>>
+
+    runtime {
+        docker: "foo/bar"
+        memory: "1GiB"
+        cpu: "1"
+        gpu: "1"
+        disks: 1
+        maxRetries: "1"
+        returnCodes: "*"
+        unsupported: false
+    }
+}
+
+task incorrect {
+    command <<<>>>
+
+    runtime {
+        docker: false
+        memory: false
+        cpu: false
+        gpu: false
+        disks: false
+        maxRetries: false
+        returnCodes: false
+    }
+}


### PR DESCRIPTION
## Summary

WDL 1.0's runtime section only gives formal type conventions for the `docker`/`container` and `memory` keys. The `cpu`, `gpu`, `disks`, `maxRetries`, and `returnCodes` keys weren't formally typed until WDL 1.1, but `wdl-analysis` was type-checking them unconditionally regardless of declared document version, producing false-positive type-mismatch diagnostics on valid WDL 1.0 documents.

## Changes

- `task_requirement_types()`: gate `cpu`, `disks`, `gpu`, and the `maxRetries`/`returnCodes` aliases to `version >= 1.1`. `docker`/`memory` remain checked at all versions.
- `evaluate_runtime_item()`: for those same keys on WDL 1.0 documents, skip type checking entirely rather than letting the lookup miss and fall through to `hints`-key type checking — `gpu` and `disks` are also valid hint key names with different expected types, so the fallthrough would otherwise produce incorrect diagnostics of its own.
- Added a regression test:
  `crates/wdl-analysis/tests/analysis/runtime-section-v1-0/`.

Closes #811.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
