### PR TITLE
feat(wdl-lsp): basic `textDocument/codeLens` support in WDL

### DIFF
--- a/crates/wdl-analysis/src/analyzer.rs
+++ b/crates/wdl-analysis/src/analyzer.rs
@@ -24,6 +24,7 @@ use line_index::WideLineCol;
 use lsp_types::CallHierarchyIncomingCall;
 use lsp_types::CallHierarchyItem;
 use lsp_types::CallHierarchyOutgoingCall;
+use lsp_types::CodeLens;
 use lsp_types::CompletionResponse;
 use lsp_types::DocumentSymbolResponse;
 use lsp_types::FoldingRange;
@@ -49,6 +50,7 @@ use crate::queue::AddRequest;
 use crate::queue::AnalysisQueue;
 use crate::queue::AnalyzeRequest;
 use crate::queue::CallHierarchyRequest;
+use crate::queue::CodeLensRequest;
 use crate::queue::CompletionRequest;
 use crate::queue::DocumentSymbolRequest;
 use crate::queue::FindAllReferencesRequest;
@@ -739,6 +741,28 @@ where
             anyhow!(
                 "failed to receive find all references response from analysis queue because the \
                  client channel has closed"
+            )
+        })
+    }
+
+    /// Get all code lenses in a document.
+    pub async fn code_lens(&self, document: Url) -> Result<Option<Vec<CodeLens>>> {
+        let (tx, rx) = oneshot::channel();
+        self.sender
+            .send(Request::CodeLens(CodeLensRequest {
+                document,
+                completed: tx,
+            }))
+            .map_err(|_| {
+                anyhow!(
+                    "failed to send codelens request to analysis queue because the channel has \
+                     closed"
+                )
+            })?;
+
+        rx.await.map_err(|_| {
+            anyhow!(
+                "failed to send codelens request to analysis queue because the channel has closed"
             )
         })
     }

--- a/crates/wdl-analysis/src/document.rs
+++ b/crates/wdl-analysis/src/document.rs
@@ -669,6 +669,14 @@ impl Callable<'_> {
             Callable::Task(t) => t.span(),
         }
     }
+
+    /// Get the inputs of the callable.
+    pub fn inputs(&self) -> &IndexMap<String, Input> {
+        match self {
+            Callable::Workflow(w) => w.inputs(),
+            Callable::Task(t) => t.inputs(),
+        }
+    }
 }
 
 /// Represents analysis data about a WDL document.
@@ -978,6 +986,14 @@ impl Document {
         }
 
         None
+    }
+
+    /// Get all callable targets in the document.
+    pub fn callables(&self) -> impl Iterator<Item = Callable<'_>> {
+        self.workflow()
+            .map(Callable::Workflow)
+            .into_iter()
+            .chain(self.tasks().map(Callable::Task))
     }
 
     /// Gets the structs in the document.

--- a/crates/wdl-analysis/src/handlers.rs
+++ b/crates/wdl-analysis/src/handlers.rs
@@ -9,6 +9,7 @@ use crate::document::ScopeRef;
 use crate::types::v1::EvaluationContext;
 
 mod call_hierarchy;
+mod code_lens;
 mod common;
 mod completions;
 mod document_symbol;
@@ -24,6 +25,7 @@ pub(crate) mod snippets;
 mod workspace_symbol;
 
 pub use call_hierarchy::*;
+pub use code_lens::*;
 pub use completions::*;
 pub use document_symbol::*;
 pub use find_all_references::*;

--- a/crates/wdl-analysis/src/handlers/code_lens.rs
+++ b/crates/wdl-analysis/src/handlers/code_lens.rs
@@ -1,0 +1,93 @@
+//! Handlers for code lens requests.
+//!
+//! This module implements the LSP `textDocument/codeLens` functionality for
+//! WDL files.
+//!
+//! See: [LSP Specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeLens)
+
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use line_index::TextSize;
+use lsp_types::CodeLens;
+use lsp_types::Command;
+use lsp_types::Range;
+use url::Url;
+use wdl_grammar::SyntaxNode;
+
+use crate::graph::DocumentGraph;
+use crate::graph::ParseState;
+use crate::handlers::common::position;
+
+/// A `sprocket run` command, to be run on an LSP client.
+#[derive(Debug)]
+pub struct RunCommand {
+    /// The source document URI.
+    pub source: String,
+    /// The target to run.
+    pub target: String,
+}
+
+impl From<RunCommand> for Command {
+    fn from(command: RunCommand) -> Self {
+        Command {
+            title: format!("Run '{}'", command.target),
+            command: "sprocket.run".to_string(),
+            arguments: Some(vec![command.source.into(), command.target.into()]),
+        }
+    }
+}
+
+/// Computes the [`CodeLens`]es for the given document, if applicable.
+///
+/// Implementation of [`textDocument/codeLens`]
+///
+/// [`textDocument/codeLens`]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_codeLens
+pub fn code_lens(graph: &DocumentGraph, document_uri: &Url) -> Result<Option<Vec<CodeLens>>> {
+    let index = graph
+        .get_index(document_uri)
+        .ok_or_else(|| anyhow!("document `{uri}` not found in graph", uri = document_uri))?;
+
+    let node = graph.get(index);
+    let (_, lines) = match node.parse_state() {
+        ParseState::Parsed { lines, root, .. } => {
+            (SyntaxNode::new_root(root.clone()), lines.clone())
+        }
+        _ => bail!("document `{uri}` has not been parsed", uri = document_uri),
+    };
+
+    let Some(analysis_doc) = node.document() else {
+        bail!("document analysis data not available for `{document_uri}`");
+    };
+
+    let mut lenses = Vec::new();
+    for target in analysis_doc.callables() {
+        if target.inputs().values().any(|i| i.required()) {
+            continue;
+        }
+
+        let start_offset = TextSize::from(target.name_span().start() as u32);
+        let end_offset = TextSize::from(target.name_span().end() as u32);
+
+        lenses.push(CodeLens {
+            range: Range {
+                start: position(&lines, start_offset)?,
+                end: position(&lines, end_offset)?,
+            },
+            command: Some(
+                RunCommand {
+                    source: document_uri.to_string(),
+                    target: target.name().to_string(),
+                }
+                .into(),
+            ),
+            data: None,
+        });
+    }
+
+    if lenses.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(lenses))
+    }
+}

--- a/crates/wdl-analysis/src/queue.rs
+++ b/crates/wdl-analysis/src/queue.rs
@@ -17,6 +17,7 @@ use indexmap::IndexSet;
 use lsp_types::CallHierarchyIncomingCall;
 use lsp_types::CallHierarchyItem;
 use lsp_types::CallHierarchyOutgoingCall;
+use lsp_types::CodeLens;
 use lsp_types::CompletionResponse;
 use lsp_types::DocumentSymbolResponse;
 use lsp_types::FoldingRange;
@@ -70,6 +71,8 @@ pub enum Request<Context> {
     Analyze(AnalyzeRequest<Context>),
     /// A request to get all callers of a symbol.
     CallHierarchy(CallHierarchyRequest),
+    /// A request to get all code lenses in a document.
+    CodeLens(CodeLensRequest),
     /// A request to remove documents from the graph.
     Remove(RemoveRequest),
     /// A request to process a document's incremental change.
@@ -136,6 +139,14 @@ pub struct CallHierarchyRequest {
     pub encoding: SourcePositionEncoding,
     /// The sender for completing the request.
     pub completed: oneshot::Sender<Option<Vec<CallHierarchyItem>>>,
+}
+
+/// Represents a request to get the code lenses for a document.
+pub struct CodeLensRequest {
+    /// The document to search.
+    pub document: Url,
+    /// The sender for completing the request.
+    pub completed: oneshot::Sender<Option<Vec<CodeLens>>>,
 }
 
 /// Represents a request to remove documents from the document graph.
@@ -447,6 +458,34 @@ where
                             error!(
                                 "error occurred while completing the call hierarchy request: \
                                  {err:?}"
+                            );
+                            completed.send(None).ok();
+                        }
+                    }
+                }
+                Request::CodeLens(CodeLensRequest {
+                    document,
+                    completed,
+                }) => {
+                    let start = Instant::now();
+                    debug!(
+                        "received request for code lenses in {document}",
+                        document = document
+                    );
+
+                    let graph = self.graph.read();
+                    match handlers::code_lens(&graph, &document) {
+                        Ok(result) => {
+                            debug!(
+                                "code lens request completed in {elapsed:?}",
+                                elapsed = start.elapsed()
+                            );
+
+                            completed.send(result).ok();
+                        }
+                        Err(err) => {
+                            error!(
+                                "error occurred while completing the code lens request: {err:?}"
                             );
                             completed.send(None).ok();
                         }

--- a/crates/wdl-lsp/CHANGELOG.md
+++ b/crates/wdl-lsp/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+* Added support for the `textDocument/codeLens` request on tasks/workflows with no required
+  inputs ([#981](https://github.com/stjude-rust-labs/sprocket/pull/981)).
+
 ## 0.20.1 - 2026-06-26
 
 ## 0.20.0 - 2026-06-03

--- a/crates/wdl-lsp/src/server.rs
+++ b/crates/wdl-lsp/src/server.rs
@@ -522,6 +522,11 @@ enum Notification {
 #[derive(Debug)]
 #[allow(clippy::enum_variant_names, clippy::missing_docs_in_private_items)]
 enum Request {
+    /// `textDocument/codeLens`
+    CodeLens {
+        params: CodeLensParams,
+        tx: RequestResponseSender<Option<Vec<CodeLens>>>,
+    },
     /// `textDocument/completion`
     Completion {
         params: CompletionParams,
@@ -816,6 +821,10 @@ impl<S: 'static> Server<S> {
                     }
                 },
                 Message::Request(request) => match request {
+                    Request::CodeLens { params, tx } => {
+                        let state = state.read().await;
+                        Self::code_lens(params, tx, &state).await
+                    }
                     Request::Completion { params, tx } => {
                         let state = state.read().await;
                         Self::completion(params, tx, &state).await
@@ -896,6 +905,22 @@ impl<S: 'static> Server<S> {
                 },
             }
         }
+    }
+
+    /// `textDocument/codeLens` request handler.
+    async fn code_lens(
+        params: CodeLensParams,
+        tx: RequestResponseSender<Option<Vec<CodeLens>>>,
+        state: &ServerState<S>,
+    ) {
+        let result = state
+            .config
+            .analyzer
+            .code_lens(params.text_document.uri)
+            .await
+            .map_err(|e| ResponseError::new(ErrorCode::INTERNAL_ERROR, e));
+
+        let _ = tx.send(result);
     }
 
     /// `textDocument/completion` request handler.
@@ -1668,6 +1693,10 @@ impl<S: 'static> LanguageServer for Server<S> {
                     inlay_hint_provider: Some(OneOf::Left(true)),
                     call_hierarchy_provider: Some(CallHierarchyServerCapability::Simple(true)),
                     folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
+                    // TODO(serial): Actually advertise code lens support when extensions are
+                    // updated code_lens_provider: Some(CodeLensOptions {
+                    //     resolve_provider: Some(false),
+                    // }),
                     ..Default::default()
                 },
                 server_info: Some(info),
@@ -1691,6 +1720,13 @@ impl<S: 'static> LanguageServer for Server<S> {
 
             Ok(())
         })
+    }
+
+    fn code_lens(
+        &mut self,
+        params: CodeLensParams,
+    ) -> BoxFuture<'static, Result<Option<Vec<CodeLens>>, Self::Error>> {
+        self.request(move |tx| Message::Request(Request::CodeLens { params, tx }))
     }
 
     fn semantic_tokens_full(

--- a/crates/wdl-lsp/tests/code_lens.rs
+++ b/crates/wdl-lsp/tests/code_lens.rs
@@ -1,0 +1,120 @@
+//! Integration tests for the `textDocument/codeLens` request.
+
+pub mod common;
+
+use async_lsp::lsp_types::CodeLens;
+use async_lsp::lsp_types::CodeLensParams;
+use async_lsp::lsp_types::Command;
+use async_lsp::lsp_types::Position;
+use async_lsp::lsp_types::Range;
+use async_lsp::lsp_types::TextDocumentIdentifier;
+use async_lsp::lsp_types::request::CodeLensRequest;
+use common::TestContext;
+
+async fn code_lens_request(
+    ctx: &mut TestContext,
+    path: &str,
+) -> async_lsp::Result<Option<Vec<CodeLens>>> {
+    ctx.request::<CodeLensRequest>(CodeLensParams {
+        text_document: TextDocumentIdentifier {
+            uri: ctx.doc_uri(path),
+        },
+        work_done_progress_params: Default::default(),
+        partial_result_params: Default::default(),
+    })
+    .await
+}
+
+async fn setup() -> TestContext {
+    let mut ctx = TestContext::new("code_lens");
+    ctx.initialize().await;
+    ctx
+}
+
+fn assert_code_lenses(response: Vec<CodeLens>, mut expected: Vec<CodeLens>) {
+    for actual in response {
+        let matched = expected.iter().position(|expected| {
+            expected.range == actual.range
+                && expected.command == actual.command
+                && expected.data == actual.data
+        });
+
+        if let Some(index) = matched {
+            expected.remove(index);
+        } else {
+            panic!("unexpected code lens returned: {actual:?}");
+        }
+    }
+
+    assert!(
+        expected.is_empty(),
+        "some expected items were not returned: {expected:?}"
+    );
+}
+
+#[tokio::test]
+async fn should_generate_code_lenses_for_wdl_targets() {
+    let mut ctx = setup().await;
+    let Some(response) = code_lens_request(&mut ctx, "example.wdl")
+        .await
+        .expect("request should succeed")
+    else {
+        panic!("response should contain entries");
+    };
+
+    let expected = vec![
+        CodeLens {
+            range: Range {
+                start: Position {
+                    line: 2,
+                    character: 5,
+                },
+                end: Position {
+                    line: 2,
+                    character: 14,
+                },
+            },
+            command: Some(Command {
+                title: "Run 'say_hello'".to_string(),
+                command: String::from("sprocket.run"),
+                arguments: Some(vec![
+                    ctx.doc_uri("example.wdl").to_string().into(),
+                    "say_hello".into(),
+                ]),
+            }),
+            data: None,
+        },
+        CodeLens {
+            range: Range {
+                start: Position {
+                    line: 8,
+                    character: 9,
+                },
+                end: Position {
+                    line: 8,
+                    character: 23,
+                },
+            },
+            command: Some(Command {
+                title: "Run 'wrap_say_hello'".to_string(),
+                command: String::from("sprocket.run"),
+                arguments: Some(vec![
+                    ctx.doc_uri("example.wdl").to_string().into(),
+                    "wrap_say_hello".into(),
+                ]),
+            }),
+            data: None,
+        },
+    ];
+
+    assert_code_lenses(response, expected);
+}
+
+#[tokio::test]
+async fn should_ignore_wdl_targets_with_inputs() {
+    let mut ctx = setup().await;
+    let response = code_lens_request(&mut ctx, "example2.wdl")
+        .await
+        .expect("request should succeed");
+    assert!(response.is_none(), "response should be empty: {response:?}");
+}

--- a/crates/wdl-lsp/tests/workspace/code_lens/example.wdl
+++ b/crates/wdl-lsp/tests/workspace/code_lens/example.wdl
@@ -1,0 +1,11 @@
+version 1.1
+
+task say_hello {
+    command {
+        echo "Hello, world!"
+    }
+}
+
+workflow wrap_say_hello {
+    call say_hello
+}

--- a/crates/wdl-lsp/tests/workspace/code_lens/example2.wdl
+++ b/crates/wdl-lsp/tests/workspace/code_lens/example2.wdl
@@ -1,0 +1,11 @@
+version 1.3
+
+task greet {
+    input {
+        String name
+    }
+
+    command <<<
+        echo "Hello, ~{name}!"
+    >>>
+}


### PR DESCRIPTION
This adds *very* basic code lens support to WDL tasks/workflows.

For editors that support it, we'll generate "Run 'foo'" code lenses for targets with no required inputs:

<img width="255" height="176" alt="image" src="https://github.com/user-attachments/assets/ca6c8d82-6c4d-45cf-81cc-41f8f1097216" />

I split this out of my code lens support in sprocket test YAMLs branch (which will come next) to keep things small. Until that's in, I don't have the server advertising code lens support in the capabilities.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
