### PR TITLE
chore: bump `crossbeam-epoch`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,9 +1120,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
To silence the deny CI, yet again...

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
