### PR TITLE
Honor `[format]` config in analyzer/LSP formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Added a `strongish` content digest mode (`run.task.digests = "strongish"`) that hashes file size, last modified time, and the first 10 MiB of a file's contents; this is an intermediate strategy between `weak` and `strong`, similar to Cromwell's `fingerprint` call caching strategy ([#978](https://github.com/stjude-rust-labs/sprocket/pull/978)).
 
+### Changed
+
+* `sprocket analyzer` now honors `[format]` configuration ([#986](https://github.com/stjude-rust-labs/sprocket/pull/986)).
+
 ## 0.27.0 - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following are high-level guiding principles of the Sprocket project.
 - Develop a suite of **modern development tools** that brings bioinformatics
   development on par with other modern languages (e.g.,
   [`wdl-lsp`](https://github.com/stjude-rust-labs/sprocket/tree/main/crates/wdl-lsp)).
-- Maintain an **community-focused codebase** that enables a diverse set of
+- Maintain a **community-focused codebase** that enables a diverse set of
   contributors from academic, non-profit, and commercial organizations.
 - Build on an **open, domain-tailored standard** to ensure the toolset remains
   singularly focused on unencumbered innovation within bioinformatics.

--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer type checked in WDL 1.0 documents, since they were not formally
   typed until WDL 1.1 ([#811](https://github.com/stjude-rust-labs/sprocket/issues/811)).
 
+#### Changed
+
+* Added a `format` field to `Config` so the analyzer's formatter honors `[format]`
+  configuration ([#986](https://github.com/stjude-rust-labs/sprocket/pull/986)).
+
 ## 0.22.0 - 2026-06-26
 
 #### Changed

--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -14,10 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer type checked in WDL 1.0 documents, since they were not formally
   typed until WDL 1.1 ([#811](https://github.com/stjude-rust-labs/sprocket/issues/811)).
 
-#### Changed
+### Changed
 
-* Added a `format` field to `Config` so the analyzer's formatter honors `[format]`
-  configuration ([#986](https://github.com/stjude-rust-labs/sprocket/pull/986)).
+* The analyzer's formatter now honors `[format]` configuration ([#986](https://github.com/stjude-rust-labs/sprocket/pull/986)).
 
 ## 0.22.0 - 2026-06-26
 

--- a/crates/wdl-analysis/src/config.rs
+++ b/crates/wdl-analysis/src/config.rs
@@ -14,6 +14,7 @@ use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxNode;
 
 use crate::Exceptable as _;
+use crate::FormatConfig;
 use crate::MisleadingDeclarationOrderRule;
 use crate::Rule;
 use crate::UnnecessaryFunctionCall;
@@ -59,6 +60,7 @@ impl Default for Config {
             inner: Arc::new(ConfigInner {
                 diagnostics: Default::default(),
                 fallback_version: None,
+                format: wdl_format::Config::default(),
                 ignore_filename: None,
                 all_rules: Default::default(),
                 feature_flags: FeatureFlags::default(),
@@ -77,6 +79,12 @@ impl Config {
     /// [`Config::with_fallback_version()`].
     pub fn fallback_version(&self) -> Option<SupportedVersion> {
         self.inner.fallback_version
+    }
+
+    /// Get this configuration's [`wdl_format::Config`]; see
+    /// [`Config::with_format_config()`].
+    pub fn format(&self) -> &wdl_format::Config {
+        &self.inner.format
     }
 
     /// Get this configuration's ignore filename.
@@ -141,6 +149,16 @@ impl Config {
         }
     }
 
+    /// Return a new configuration with the previous [`wdl_format::Config`]
+    /// replaced by the argument.
+    pub fn with_format_config(&self, format: FormatConfig) -> Self {
+        let mut inner = (*self.inner).clone();
+        inner.format = format;
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
     /// Return a new configuration with the previous ignore filename replaced by
     /// the argument.
     ///
@@ -192,6 +210,9 @@ struct ConfigInner {
     /// See [`Config::with_fallback_version()`]
     #[toml(FromToml with = parse_string)]
     fallback_version: Option<SupportedVersion>,
+    /// See [`Config::with_format_config()`]
+    #[toml(default, style = Header)]
+    format: wdl_format::Config,
     /// See [`Config::with_ignore_filename()`]
     ignore_filename: Option<String>,
     /// A list of all known rule identifiers.
@@ -394,5 +415,24 @@ impl DiagnosticsConfig {
             using_fallback_version: None,
             misleading_declaration_order: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn custom_format_config_round_trip() {
+        let custom_format_config = FormatConfig::default().trailing_commas(false);
+        let analysis_config = Config::default().with_format_config(custom_format_config);
+        assert_eq!(analysis_config.format(), &custom_format_config);
+    }
+
+    #[test]
+    fn no_format_config_is_default() {
+        let default_format_config = FormatConfig::default();
+        let analysis_config = Config::default();
+        assert_eq!(analysis_config.format(), &default_format_config);
     }
 }

--- a/crates/wdl-analysis/src/config.rs
+++ b/crates/wdl-analysis/src/config.rs
@@ -60,7 +60,7 @@ impl Default for Config {
             inner: Arc::new(ConfigInner {
                 diagnostics: Default::default(),
                 fallback_version: None,
-                format: wdl_format::Config::default(),
+                format: FormatConfig::default(),
                 ignore_filename: None,
                 all_rules: Default::default(),
                 feature_flags: FeatureFlags::default(),
@@ -81,9 +81,9 @@ impl Config {
         self.inner.fallback_version
     }
 
-    /// Get this configuration's [`wdl_format::Config`]; see
+    /// Get this configuration's [`FormatConfig`]; see
     /// [`Config::with_format_config()`].
-    pub fn format(&self) -> &wdl_format::Config {
+    pub fn format(&self) -> &FormatConfig {
         &self.inner.format
     }
 
@@ -149,7 +149,7 @@ impl Config {
         }
     }
 
-    /// Return a new configuration with the previous [`wdl_format::Config`]
+    /// Return a new configuration with the previous [`FormatConfig`]
     /// replaced by the argument.
     pub fn with_format_config(&self, format: FormatConfig) -> Self {
         let mut inner = (*self.inner).clone();
@@ -212,7 +212,7 @@ struct ConfigInner {
     fallback_version: Option<SupportedVersion>,
     /// See [`Config::with_format_config()`]
     #[toml(default, style = Header)]
-    format: wdl_format::Config,
+    format: FormatConfig,
     /// See [`Config::with_ignore_filename()`]
     ignore_filename: Option<String>,
     /// A list of all known rule identifiers.

--- a/crates/wdl-analysis/src/lib.rs
+++ b/crates/wdl-analysis/src/lib.rs
@@ -63,6 +63,7 @@ pub use document::Document;
 pub use rules::*;
 pub use validation::*;
 pub use visitor::*;
+pub use wdl_format::Config as FormatConfig;
 
 /// An extension trait for syntax nodes.
 pub trait Exceptable {

--- a/crates/wdl-analysis/src/queue.rs
+++ b/crates/wdl-analysis/src/queue.rs
@@ -593,7 +593,7 @@ where
                                 .ast_with_version_fallback(self.config.fallback_version())
                                 .into_v1()
                                 .and_then(|ast| {
-                                    let formatter = Formatter::default();
+                                    let formatter = Formatter::new(*self.config.format());
                                     let element = Node::Ast(ast).into_format_element();
 
                                     formatter

--- a/crates/wdl-analysis/tests/format.rs
+++ b/crates/wdl-analysis/tests/format.rs
@@ -1,0 +1,87 @@
+//! The WDL format tests.
+//!
+//! This test looks for files in `tests/format`.
+
+use std::fs;
+use std::path::Path;
+
+use anyhow::Context;
+use wdl_analysis::Analyzer;
+use wdl_analysis::Config;
+use wdl_analysis::FormatConfig;
+use wdl_analysis::path_to_uri;
+use wdl_format::Indent;
+
+/// Normalizes a result.
+fn normalize(s: &str) -> String {
+    // Just normalize line endings
+    s.replace("\r\n", "\n")
+}
+
+#[tokio::test]
+async fn spaces() {
+    let dir = Path::new("tests").join("format");
+    let two_space_wdl_path = dir.join("two_spaces.wdl");
+    let four_space_wdl_path = dir.join("four_spaces.wdl");
+
+    let two_space_wdl = fs::read_to_string(&two_space_wdl_path).expect("cannot read two space wdl");
+    let four_space_wdl =
+        fs::read_to_string(&four_space_wdl_path).expect("cannot read four space wdl");
+
+    let two_space_format_config = FormatConfig::default().indent(Indent::Spaces(2));
+    let four_space_format_config = FormatConfig::default();
+
+    // 4 => 2
+    format_wdl(
+        &four_space_wdl_path,
+        &two_space_wdl,
+        two_space_format_config,
+    )
+    .await;
+
+    // 2 => 2
+    format_wdl(&two_space_wdl_path, &two_space_wdl, two_space_format_config).await;
+
+    // 2 => 4 (default)
+    format_wdl(
+        &two_space_wdl_path,
+        &four_space_wdl,
+        four_space_format_config,
+    )
+    .await;
+
+    // 4 => 4 (default)
+    format_wdl(
+        &four_space_wdl_path,
+        &four_space_wdl,
+        four_space_format_config,
+    )
+    .await;
+}
+
+async fn format_wdl(wdl: &Path, expected: &str, format_config: FormatConfig) {
+    let config = Config::default().with_format_config(format_config);
+    let analyzer: Analyzer<()> = Analyzer::new(config, |_, _, _, _| async {});
+    let uri = path_to_uri(wdl).expect("should be valid URI");
+
+    analyzer
+        .add_document(uri.clone())
+        .await
+        .context("adding test document")
+        .expect("should add test WDL");
+
+    analyzer
+        .analyze_document((), uri.clone())
+        .await
+        .context("analyzing document")
+        .expect("should analyze WDL");
+
+    let results = analyzer
+        .format_document(uri)
+        .await
+        .context("formatting WDL")
+        .expect("couldn't collect format results");
+
+    let (_, _, formatted) = results.expect("couldn't collect results");
+    assert_eq!(normalize(&formatted), normalize(expected));
+}

--- a/crates/wdl-analysis/tests/format/four_spaces.wdl
+++ b/crates/wdl-analysis/tests/format/four_spaces.wdl
@@ -1,0 +1,10 @@
+version 1.0
+
+task hello {
+    command <<<
+    >>>
+
+    output {
+        String greeting = "Hello, World!"
+    }
+}

--- a/crates/wdl-analysis/tests/format/two_spaces.wdl
+++ b/crates/wdl-analysis/tests/format/two_spaces.wdl
@@ -1,0 +1,10 @@
+version 1.0
+
+task hello {
+  command <<<
+  >>>
+
+  output {
+    String greeting = "Hello, World!"
+  }
+}

--- a/crates/wdl-lsp/CHANGELOG.md
+++ b/crates/wdl-lsp/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added support for the `textDocument/codeLens` request on tasks/workflows with no required
   inputs ([#981](https://github.com/stjude-rust-labs/sprocket/pull/981)).
 
+### Changed
+
+* `[format]` configuration now honored when formatting documents, matching
+  `sprocket format` output ([#986](https://github.com/stjude-rust-labs/sprocket/pull/986)).
+
 ## 0.20.1 - 2026-06-26
 
 ## 0.20.0 - 2026-06-03

--- a/crates/wdl-lsp/src/server.rs
+++ b/crates/wdl-lsp/src/server.rs
@@ -46,6 +46,7 @@ use wdl_analysis::Analyzer;
 use wdl_analysis::Config as AnalysisConfig;
 use wdl_analysis::DiagnosticsConfig;
 use wdl_analysis::FeatureFlags;
+use wdl_analysis::FormatConfig;
 use wdl_analysis::IncrementalChange;
 use wdl_analysis::SourceEdit;
 use wdl_analysis::SourcePosition;
@@ -273,6 +274,9 @@ pub struct ServerOptions {
 
     /// The diagnostic baseline for suppressing known diagnostics.
     pub baseline: Option<wdl_lint::Baseline>,
+
+    /// The formatting configuration to use.
+    pub format: FormatConfig,
 }
 
 impl ServerOptions {
@@ -294,6 +298,7 @@ impl Default for ServerOptions {
             ignore_filename: None,
             feature_flags: Default::default(),
             baseline: None,
+            format: FormatConfig::default(),
         }
     }
 }
@@ -468,7 +473,8 @@ impl ServerOptions {
             ))
             .with_ignore_filename(ignore_name)
             .with_all_rules(all_rules)
-            .with_feature_flags(self.feature_flags);
+            .with_feature_flags(self.feature_flags)
+            .with_format_config(self.format);
 
         let wdl_lint_config = lint_options.config.clone();
         Analyzer::<ProgressToken>::new_with_validator(

--- a/src/commands/analyzer.rs
+++ b/src/commands/analyzer.rs
@@ -80,6 +80,7 @@ pub async fn analyzer(
                 Baseline::load_or_default(&path, baseline_is_configured)
                     .map_err(anyhow::Error::from)?
             },
+            format: config.format,
         },
         UserOptions {
             log_level: LevelFilter::from(


### PR DESCRIPTION

Closes #985.

## Summary

`sprocket format` already honors the `[format]` configuration, but the analyzer's formatting path hardcoded `Formatter::default()`, so in-editor formatting ignored `sprocket.toml [format]`. This threads the existing `[format]` config through to the analyzer's formatter, so LSP formatting matches the CLI.


Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
