### PR TITLE
perf: cache compiled regexes in string stdlib functions

### DIFF
--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* The `sub`, `find`, `matches`, and `split` standard library functions now reuse compiled regular expressions through a shared cache instead of recompiling the pattern on every call ([#988](https://github.com/stjude-rust-labs/sprocket/issues/988)).
+
 ### Added
 
 * Added a `strongish` content digest mode (`run.task.digests = "strongish"`) that hashes file size, last modified time, and the first 10 MiB of a file's contents; this is an intermediate strategy between `weak` and `strong`, similar to Cromwell's `fingerprint` call caching strategy ([#978](https://github.com/stjude-rust-labs/sprocket/pull/978)).

--- a/crates/wdl-engine/src/stdlib.rs
+++ b/crates/wdl-engine/src/stdlib.rs
@@ -4,11 +4,13 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::LazyLock;
+use std::sync::Mutex;
 
 use anyhow::Result;
 use anyhow::anyhow;
 use anyhow::bail;
 use futures::future::BoxFuture;
+use regex::Regex;
 use tempfile::TempPath;
 use wdl_analysis::stdlib::Binding;
 use wdl_analysis::types::Type;
@@ -81,6 +83,33 @@ mod write_object;
 mod write_objects;
 mod write_tsv;
 mod zip;
+
+/// A cache of compiled regular expressions keyed by their pattern string.
+///
+/// The `sub`, `find`, `matches`, and `split` standard library functions are
+/// commonly called with the same pattern for every element of an array, for
+/// example inside a scatter. Compiling a regular expression is far more
+/// expensive than matching with an already compiled one, so patterns are
+/// compiled once here and reused on later calls.
+static REGEX_CACHE: LazyLock<Mutex<HashMap<String, Regex>>> = LazyLock::new(Mutex::default);
+
+/// Compiles the given pattern into a regular expression, reusing a previously
+/// compiled one when the same pattern has already been seen.
+///
+/// Invalid patterns are not cached and their compilation error is returned to
+/// the caller, so error behavior matches compiling the pattern directly.
+fn cached_regex(pattern: &str) -> Result<Regex, regex::Error> {
+    let mut cache = REGEX_CACHE
+        .lock()
+        .expect("regex cache mutex should not be poisoned");
+    if let Some(regex) = cache.get(pattern) {
+        return Ok(regex.clone());
+    }
+
+    let regex = Regex::new(pattern)?;
+    cache.insert(pattern.to_string(), regex.clone());
+    Ok(regex)
+}
 
 /// Ensures that the given path, when joined with the given base directory, is a
 /// local path.
@@ -461,5 +490,38 @@ mod test {
                 ),
             }
         }
+    }
+
+    /// Verifies that a valid pattern compiles and that asking for the same
+    /// pattern again returns a working regex from the cache.
+    #[test]
+    fn cached_regex_reuses_valid_patterns() {
+        let first = cached_regex(r"\d+").expect("valid pattern should compile");
+        assert!(first.is_match("abc123"));
+
+        let second = cached_regex(r"\d+").expect("cached pattern should be returned");
+        assert!(second.is_match("456"));
+
+        assert!(
+            REGEX_CACHE
+                .lock()
+                .expect("regex cache mutex should not be poisoned")
+                .contains_key(r"\d+"),
+            "the pattern should be stored in the cache"
+        );
+    }
+
+    /// Verifies that an invalid pattern keeps returning a compilation error and
+    /// is not stored in the cache.
+    #[test]
+    fn cached_regex_rejects_invalid_patterns() {
+        assert!(cached_regex("(").is_err());
+        assert!(
+            !REGEX_CACHE
+                .lock()
+                .expect("regex cache mutex should not be poisoned")
+                .contains_key("("),
+            "an invalid pattern should not be cached"
+        );
     }
 }

--- a/crates/wdl-engine/src/stdlib/find.rs
+++ b/crates/wdl-engine/src/stdlib/find.rs
@@ -1,6 +1,5 @@
 //! Implements the `find` function from the WDL standard library.
 
-use regex::Regex;
 use wdl_analysis::types::Optional;
 use wdl_analysis::types::PrimitiveType;
 use wdl_analysis::types::Type;
@@ -33,7 +32,7 @@ fn find(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .coerce_argument(1, PrimitiveType::String)
         .unwrap_string();
 
-    let regex = Regex::new(pattern.as_str())
+    let regex = super::cached_regex(pattern.as_str())
         .map_err(|e| function_call_failed(FUNCTION_NAME, &e, context.arguments[1].span))?;
 
     match regex.find(input.as_str()) {

--- a/crates/wdl-engine/src/stdlib/matches.rs
+++ b/crates/wdl-engine/src/stdlib/matches.rs
@@ -1,6 +1,5 @@
 //! Implements the `matches` function from the WDL standard library.
 
-use regex::Regex;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
@@ -29,7 +28,7 @@ fn matches(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .coerce_argument(1, PrimitiveType::String)
         .unwrap_string();
 
-    let regex = Regex::new(pattern.as_str())
+    let regex = super::cached_regex(pattern.as_str())
         .map_err(|e| function_call_failed(FUNCTION_NAME, &e, context.arguments[1].span))?;
     Ok(regex.is_match(input.as_str()).into())
 }

--- a/crates/wdl-engine/src/stdlib/split.rs
+++ b/crates/wdl-engine/src/stdlib/split.rs
@@ -1,6 +1,5 @@
 //! Implements the `split` function from the WDL standard library.
 
-use regex::Regex;
 use wdl_analysis::stdlib::STDLIB as ANALYSIS_STDLIB;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
@@ -33,7 +32,7 @@ fn split(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .coerce_argument(1, PrimitiveType::String)
         .unwrap_string();
 
-    let regex = Regex::new(delimiter.as_str())
+    let regex = super::cached_regex(delimiter.as_str())
         .map_err(|e| function_call_failed(FUNCTION_NAME, &e, context.arguments[1].span))?;
 
     let elements = regex

--- a/crates/wdl-engine/src/stdlib/sub.rs
+++ b/crates/wdl-engine/src/stdlib/sub.rs
@@ -2,7 +2,6 @@
 
 use std::borrow::Cow;
 
-use regex::Regex;
 use wdl_analysis::types::PrimitiveType;
 use wdl_ast::Diagnostic;
 
@@ -93,7 +92,7 @@ fn sub(context: CallContext<'_>) -> Result<Value, Diagnostic> {
         .coerce_argument(2, PrimitiveType::String)
         .unwrap_string();
 
-    let regex = Regex::new(pattern.as_str())
+    let regex = super::cached_regex(pattern.as_str())
         .map_err(|e| function_call_failed(FUNCTION_NAME, &e, context.arguments[1].span))?;
     let converted = convert_replacement(replacement.as_str());
     match regex.replace_all(input.as_str(), converted.as_ref()) {


### PR DESCRIPTION
Closes #988.

The `sub`, `find`, `matches`, and `split` stdlib functions each called `Regex::new` on every invocation. These run per element inside scatters and array operations, so the same pattern ends up recompiled thousands of times in a workflow that uses one of them on every row of an input. Compiling a regex is a lot more expensive than matching with one that already exists.

### What changed

I added a small shared cache in `stdlib.rs`, a `LazyLock<Mutex<HashMap<String, Regex>>>` with a `cached_regex` helper, following the same shape as the digest memoization the issue pointed at. The four functions now call `super::cached_regex(...)` instead of `Regex::new(...)`. A `Regex` is cheap to clone since it is reference counted internally, so callers get their own handle without recompiling.

Invalid patterns are not inserted into the cache and their compilation error is returned to the caller exactly as before, so the error path is unchanged.

### Tests

Added two unit tests covering the cache: valid patterns compile and get reused, invalid patterns keep returning an error and are not cached. Existing `sub`/`find`/`matches`/`split` tests still pass.

```
cargo test -p wdl-engine --lib stdlib::
test result: ok. 68 passed; 0 failed
```

`cargo clippy -p wdl-engine` is clean and the code is formatted with the repo's nightly rustfmt config. I also added a CHANGELOG entry under Unreleased.