### PR TITLE
fix(fuzz): remove unused import

### DIFF
--- a/fuzz/fuzz_targets/wdl_lint.rs
+++ b/fuzz/fuzz_targets/wdl_lint.rs
@@ -14,7 +14,6 @@ use tokio::runtime::Runtime;
 use url::Url;
 use wdl::analysis::Analyzer;
 use wdl::analysis::Config;
-use wdl::analysis::ResolutionContext;
 use wdl::analysis::Validator;
 use wdl::ast::SupportedVersion;
 use wdl::lint::Linter;


### PR DESCRIPTION
`wdl::analysis::ResolutionContext` is unused in the `wdl_lint` fuzz target. This was causing a warning when I ran `cargo check --workspace`, although strangely this warning [isn't emitted in CI](https://github.com/stjude-rust-labs/sprocket/actions/runs/29167086916/job/86581960563).

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).
