### PR TITLE
fix(ci): remove `matchUpdateTypes` from renovate pep621 rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -89,13 +89,9 @@
       ]
     },
     {
-      "description": "Group all Python minor and patch updates into one PR",
+      "description": "Group all Python updates into one PR",
       "matchManagers": [
         "pep621"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch"
       ],
       "groupName": "python updates",
       "rangeStrategy": "bump",


### PR DESCRIPTION
Attempts to fix #1000.

`matchUpdateTypes` and `rangeStrategy` are incompatible. Since `rangeStrategy` is necessary (PEP 621 doesn't have a lockfile), this removes the `matchUpdateTypes` field.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).
