### PR TITLE
Contextualize stdlib hover/completion to document's WDL version

### DIFF
--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* LSP hover and completion for standard library functions are now version-aware:
+  functions and polymorphic signatures whose minimum WDL version exceeds the
+  document's declared version are no longer offered in completion or shown on
+  hover ([#1005](https://github.com/stjude-rust-labs/sprocket/pull/1005)).
+
 ## 0.23.0 - 2026-07-15
 
 #### Added
@@ -25,10 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `maxRetries`, and `returnCodes`) is now version-aware: these keys are no
   longer type checked in WDL 1.0 documents, since they were not formally
   typed until WDL 1.1 ([#811](https://github.com/stjude-rust-labs/sprocket/issues/811)).
-* LSP hover and completion for standard library functions are now version-aware:
-  functions and polymorphic signatures whose minimum WDL version exceeds the
-  document's declared version are no longer offered in completion or shown on
-  hover ([#1005](https://github.com/stjude-rust-labs/sprocket/pull/1005)).
 
 ### Changed
 

--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * LSP hover and completion for standard library functions are now version-aware:
   functions and polymorphic signatures whose minimum WDL version exceeds the
   document's declared version are no longer offered in completion or shown on
-  hover ([#<pr-number>](https://github.com/stjude-rust-labs/sprocket/pull/<pr-number>)).
+  hover ([#1005](https://github.com/stjude-rust-labs/sprocket/pull/1005)).
 
 ### Changed
 

--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `maxRetries`, and `returnCodes`) is now version-aware: these keys are no
   longer type checked in WDL 1.0 documents, since they were not formally
   typed until WDL 1.1 ([#811](https://github.com/stjude-rust-labs/sprocket/issues/811)).
+* LSP hover and completion for standard library functions are now version-aware:
+  functions and polymorphic signatures whose minimum WDL version exceeds the
+  document's declared version are no longer offered in completion or shown on
+  hover ([#<pr-number>](https://github.com/stjude-rust-labs/sprocket/pull/<pr-number>)).
 
 ### Changed
 

--- a/crates/wdl-analysis/src/handlers/completions.rs
+++ b/crates/wdl-analysis/src/handlers/completions.rs
@@ -197,7 +197,7 @@ pub fn completion(
                     if let Some(scope) = scope {
                         add_scope_completions(scope, &mut items);
                     }
-                    add_stdlib_completions(&mut items);
+                    add_stdlib_completions(document.version(), &mut items);
                     add_struct_completions(document, scope, &mut items);
                     add_enum_type_completions(document, scope, &mut items);
                     add_namespace_completions(document, &mut items);
@@ -210,7 +210,7 @@ pub fn completion(
                     if let Some(scope) = scope {
                         add_scope_completions(scope, &mut items);
                     }
-                    add_stdlib_completions(&mut items);
+                    add_stdlib_completions(document.version(), &mut items);
                     add_struct_completions(document, scope, &mut items);
                     add_enum_type_completions(document, scope, &mut items);
                     add_namespace_completions(document, &mut items);
@@ -224,7 +224,7 @@ pub fn completion(
                     if let Some(scope) = scope {
                         add_scope_completions(scope, &mut items);
                     }
-                    add_stdlib_completions(&mut items);
+                    add_stdlib_completions(document.version(), &mut items);
                     add_struct_completions(document, scope, &mut items);
                     add_enum_type_completions(document, scope, &mut items);
                     break;
@@ -763,9 +763,15 @@ fn add_scope_completions(scope: ScopeRef<'_>, items: &mut Vec<CompletionItem>) {
     }
 }
 
-/// Adds completions for all WDL standard library functions.
-fn add_stdlib_completions(items: &mut Vec<CompletionItem>) {
-    for (name, func) in STDLIB.functions() {
+/// Adds completions for all WDL standard library functions appropriate for the
+/// specified `version`.
+fn add_stdlib_completions(version: Option<SupportedVersion>, items: &mut Vec<CompletionItem>) {
+    // The None case (un-analyzed document) has no meaningful stdlib context;
+    // nothing to add.
+    let Some(v) = version else {
+        return;
+    };
+    for (name, func) in STDLIB.functions().filter(|(_, f)| f.minimum_version() <= v) {
         match func {
             Function::Monomorphic(m) => {
                 let sig = m.signature();
@@ -784,7 +790,7 @@ fn add_stdlib_completions(items: &mut Vec<CompletionItem>) {
                 })
             }
             Function::Polymorphic(p) => {
-                for sig in p.signatures() {
+                for sig in p.signatures().iter().filter(|s| s.minimum_version() <= v) {
                     let params = TypeParameters::new(sig.type_parameters());
                     let detail = Some(format!("{name}{}", sig.display(&params)));
                     let docs = sig.definition().and_then(|d| make_md_docs(d.to_string()));

--- a/crates/wdl-analysis/src/handlers/hover.rs
+++ b/crates/wdl-analysis/src/handlers/hover.rs
@@ -463,9 +463,11 @@ fn resolve_hover_by_context(
             }
 
             if let Some(func) = STDLIB.function(call_expr.target().text()) {
-                let content =
-                    get_function_hover_content(document.version(), call_expr.target().text(), func);
-                return Ok(Some(content));
+                return Ok(get_function_hover_content(
+                    document.version(),
+                    call_expr.target().text(),
+                    func,
+                ));
             }
         }
 
@@ -526,21 +528,18 @@ fn find_global_hover_in_doc(document: &Document, token: &SyntaxToken) -> Result<
 ///
 /// This includes all overloaded signatures appropriate for the specified
 /// `version` and the documentation from the WDL specification.
+///
+/// Returns `None` if the document has no supported version or the function is
+/// unavailable in that version.
 fn get_function_hover_content(
     version: Option<SupportedVersion>,
     name: &str,
     func: &Function,
-) -> String {
-    let Some(v) = version else {
-        // The None case (un-analyzed document) has no meaningful stdlib content.
-        return String::from("");
-    };
+) -> Option<String> {
+    let v = version?;
 
     if func.minimum_version() > v {
-        // Return completely empty hover text for either unsupported monomorphic
-        // functions or polymorphic functions whose variants are all unsupported
-        // (`minimum_version` folds across all variants of a polymorphic function).
-        return String::from("");
+        return None;
     }
 
     let (detail, docs) = match func {
@@ -572,7 +571,7 @@ fn get_function_hover_content(
             (detail, docs)
         }
     };
-    format!("{detail}\n\n{docs}")
+    Some(format!("{detail}\n\n{docs}"))
 }
 
 /// Finds documentation for a variable declaration.

--- a/crates/wdl-analysis/src/handlers/hover.rs
+++ b/crates/wdl-analysis/src/handlers/hover.rs
@@ -37,6 +37,7 @@ use wdl_ast::v1::MetadataObject;
 use wdl_ast::v1::MetadataValue;
 use wdl_ast::v1::ParameterMetadataSection;
 use wdl_ast::v1::StructDefinition;
+use wdl_grammar::SupportedVersion;
 use wdl_grammar::SyntaxElement;
 
 use crate::Document;
@@ -462,7 +463,8 @@ fn resolve_hover_by_context(
             }
 
             if let Some(func) = STDLIB.function(call_expr.target().text()) {
-                let content = get_function_hover_content(call_expr.target().text(), func);
+                let content =
+                    get_function_hover_content(document.version(), call_expr.target().text(), func);
                 return Ok(Some(content));
             }
         }
@@ -522,9 +524,25 @@ fn find_global_hover_in_doc(document: &Document, token: &SyntaxToken) -> Result<
 
 /// Generates markdown content for a standard library function's hover info.
 ///
-/// This includes all overloaded signatures and the documentation from the WDL
-/// specification.
-fn get_function_hover_content(name: &str, func: &Function) -> String {
+/// This includes all overloaded signatures appropriate for the specified
+/// `version` and the documentation from the WDL specification.
+fn get_function_hover_content(
+    version: Option<SupportedVersion>,
+    name: &str,
+    func: &Function,
+) -> String {
+    let Some(v) = version else {
+        // The None case (un-analyzed document) has no meaningful stdlib content.
+        return String::from("");
+    };
+
+    if func.minimum_version() > v {
+        // Return completely empty hover text for either unsupported monomorphic
+        // functions or polymorphic functions whose variants are all unsupported
+        // (`minimum_version` folds across all variants of a polymorphic function).
+        return String::from("");
+    }
+
     let (detail, docs) = match func {
         Function::Monomorphic(m) => {
             let sig = m.signature();
@@ -537,6 +555,7 @@ fn get_function_hover_content(name: &str, func: &Function) -> String {
             let detail = p
                 .signatures()
                 .iter()
+                .filter(|s| s.minimum_version() <= v)
                 .map(|s| {
                     let params = TypeParameters::new(s.type_parameters());
                     format!("```wdl\n{}{}\n```", name, s.display(&params))
@@ -546,7 +565,8 @@ fn get_function_hover_content(name: &str, func: &Function) -> String {
 
             let docs = p
                 .signatures()
-                .first()
+                .iter()
+                .find(|s| s.minimum_version() <= v)
                 .and_then(|s| s.definition())
                 .unwrap_or("");
             (detail, docs)

--- a/crates/wdl-lsp/tests/completions.rs
+++ b/crates/wdl-lsp/tests/completions.rs
@@ -325,9 +325,14 @@ async fn should_complete_scope_variables() {
     assert_contains(&items, "lib");
     // Stdlib function
     assert_contains(&items, "floor");
-    assert_contains(&items, "min");
     assert_contains(&items, "stdout");
     assert_contains(&items, "stderr");
+    // The following standard library functions are present in WDL version 1.3 and
+    // should appear as completions.
+    assert_contains(&items, "min");
+    assert_contains(&items, "find");
+    assert_contains(&items, "chunk");
+    assert_contains(&items, "matches");
 
     // Workflow specific keywords
     assert_contains(&items, "call");
@@ -363,6 +368,30 @@ async fn should_complete_scope_variables() {
     assert_contains(&items, "runtime");
     assert_contains(&items, "requirements");
     assert_not_contains(&items, "call");
+}
+
+#[tokio::test]
+async fn should_complete_scope_variables_v1_0_stdlib() {
+    let mut ctx = setup().await;
+
+    // Workflow scope
+    let response = completion_request(&mut ctx, "scopes_v1_0.wdl", Position::new(10, 0))
+        .await
+        .expect("request should succeed");
+    let Some(CompletionResponse::Array(items)) = response else {
+        panic!("expected a response, got none");
+    };
+
+    // Stdlib functions
+    assert_contains(&items, "floor");
+    assert_contains(&items, "stdout");
+    assert_contains(&items, "stderr");
+    // The following standard library functions are *not* present in WDL version 1.0
+    // and should *not* appear as completions.
+    assert_not_contains(&items, "min");
+    assert_not_contains(&items, "find");
+    assert_not_contains(&items, "chunk");
+    assert_not_contains(&items, "matches");
 }
 
 #[tokio::test]

--- a/crates/wdl-lsp/tests/hover.rs
+++ b/crates/wdl-lsp/tests/hover.rs
@@ -143,6 +143,76 @@ async fn should_hover_stdlib_function() {
 }
 
 #[tokio::test]
+async fn should_hover_version_filtering() {
+    let mut ctx = setup().await;
+    let wdl = "version_filtering.wdl";
+    // Position of `basename`
+    let response = hover_request(&mut ctx, wdl, Position::new(9, 19))
+        .await
+        .expect("request should succeed");
+    assert_hover_content(
+        &response,
+        "basename(path: File, <suffix: String>) -> String",
+    );
+    assert_hover_content(
+        &response,
+        "basename(path: String, <suffix: String>) -> String",
+    );
+    assert_hover_content(
+        &response,
+        "basename(path: Directory, <suffix: String>) -> String",
+    );
+    // Position of `split`
+    let response = hover_request(&mut ctx, wdl, Position::new(12, 23))
+        .await
+        .expect("request should succeed");
+    assert_hover_content(
+        &response,
+        "split(input: String, delimiter: String) -> Array[String]",
+    );
+    // Position of `contains_key`
+    let response = hover_request(&mut ctx, wdl, Position::new(16, 22))
+        .await
+        .expect("request should succeed");
+    assert_hover_content(&response, "contains_key(map: Map[K, V], key: K)");
+}
+
+#[tokio::test]
+async fn should_hover_version_filtering_v1_0() {
+    let mut ctx = setup().await;
+    let wdl = "version_filtering_v1_0.wdl";
+    // Position of `basename`
+    let response = hover_request(&mut ctx, wdl, Position::new(9, 19))
+        .await
+        .expect("request should succeed");
+    assert_hover_content(
+        &response,
+        "basename(path: File, <suffix: String>) -> String",
+    );
+    assert_hover_not_content(
+        &response,
+        "basename(path: String, <suffix: String>) -> String",
+    );
+    assert_hover_not_content(
+        &response,
+        "basename(path: Directory, <suffix: String>) -> String",
+    );
+    // Position of `split`
+    let response = hover_request(&mut ctx, wdl, Position::new(12, 23))
+        .await
+        .expect("request should succeed");
+    assert_hover_not_content(
+        &response,
+        "split(input: String, delimiter: String) -> Array[String]",
+    );
+    // Position of `contains_key`
+    let response = hover_request(&mut ctx, wdl, Position::new(16, 22))
+        .await
+        .expect("request should succeed");
+    assert_hover_not_content(&response, "contains_key(map: Map[K, V], key: K)");
+}
+
+#[tokio::test]
 async fn should_hover_struct_member_access() {
     let mut ctx = setup().await;
     // Position of `name` in `p.name`

--- a/crates/wdl-lsp/tests/hover.rs
+++ b/crates/wdl-lsp/tests/hover.rs
@@ -47,6 +47,13 @@ fn assert_hover_content(hover: &Option<Hover>, expected: &str) {
     );
 }
 
+fn assert_no_hover(hover: &Option<Hover>) {
+    assert!(
+        hover.is_none(),
+        "expected no hover response, but got `{hover:?}`"
+    );
+}
+
 async fn setup() -> TestContext {
     let mut ctx = TestContext::new("hover");
     ctx.initialize().await;
@@ -201,15 +208,12 @@ async fn should_hover_version_filtering_v1_0() {
     let response = hover_request(&mut ctx, wdl, Position::new(12, 23))
         .await
         .expect("request should succeed");
-    assert_hover_not_content(
-        &response,
-        "split(input: String, delimiter: String) -> Array[String]",
-    );
+    assert_no_hover(&response);
     // Position of `contains_key`
     let response = hover_request(&mut ctx, wdl, Position::new(16, 22))
         .await
         .expect("request should succeed");
-    assert_hover_not_content(&response, "contains_key(map: Map[K, V], key: K)");
+    assert_no_hover(&response);
 }
 
 #[tokio::test]

--- a/crates/wdl-lsp/tests/workspace/completions/scopes_v1_0.wdl
+++ b/crates/wdl-lsp/tests/workspace/completions/scopes_v1_0.wdl
@@ -1,0 +1,19 @@
+version 1.0
+
+import "lib.wdl" as lib
+
+struct Person {
+    String name
+    Int age
+}
+
+workflow scopes {
+
+}
+
+task A {
+    Int number = 1
+    command <<<
+    >>>
+
+}

--- a/crates/wdl-lsp/tests/workspace/hover/version_filtering.wdl
+++ b/crates/wdl-lsp/tests/workspace/hover/version_filtering.wdl
@@ -1,0 +1,21 @@
+version 1.3
+
+workflow main {
+    input {
+        File file
+    }
+
+    # `basename` is a polymorphic function with only one variant
+    # in WDL 1.0, two additional variants added in WDL 1.2.
+    String base = basename(file)
+
+    # `split` is a monomorphic function added in WDL 1.3.
+    Array[String] s = split("foo bar", " ")
+
+    Map[String, String] map = {}
+    # `contains_key` is a polymorphic function added in WDL 1.2.
+    Boolean b = contains_key(map, 'key')
+
+    output {
+    }
+}

--- a/crates/wdl-lsp/tests/workspace/hover/version_filtering_v1_0.wdl
+++ b/crates/wdl-lsp/tests/workspace/hover/version_filtering_v1_0.wdl
@@ -1,0 +1,21 @@
+version 1.0
+
+workflow main {
+    input {
+        File file
+    }
+
+    # `basename` is a polymorphic function with only one variant
+    # in WDL 1.0, two additional variants added in WDL 1.2.
+    String base = basename(file)
+
+    # `split` is a monomorphic function added in WDL 1.3.
+    Array[String] s = split("foo bar", " ")
+
+    Map[String, String] map = {}
+    # `contains_key` is a polymorphic function added in WDL 1.2.
+    Boolean b = contains_key(map, 'key')
+
+    output {
+    }
+}


### PR DESCRIPTION
Fixes #1004.

## Root cause

Two LSP doc handlers currently build documentation from the static `STDLIB` without consulting the document's version:

- `crates/wdl-analysis/src/handlers/completions.rs`: `add_stdlib_completions` iterated `STDLIB.functions()` and pushed a completion item for every function and polymorphic signature. It took no version argument, unlike its siblings `add_runtime_key_completions` and `add_requirements_key_completions`.
- `crates/wdl-analysis/src/handlers/hover.rs`: `get_function_hover_content` emitted all overload signatures and took docs from the first signature, with no version parameter.

## Approach

These changes thread the document's version into both handlers and filter functions and polymorphic signatures by their minimum version. Filtering per-signature (rather than only per-function) keeps the displayed signature list version-accurate: for a polymorphic function that gained overloads in a later WDL version, only the overloads available at the document's version are shown.

Note these changes filter the signature list, but *not* the documentation prose. The polymorphic version-split functions currently share a single `definition()` string across their overloads (often worded for the newest version), so the hover prose is not yet version-specific. That is a separate limitation, tracked as a related issue in #1006.

## Documents with no resolved version

`Document::version()` returns `None` only when there is no resolvable version: i.e. a document that failed to parse or wasn't fully analyzed. A present but unsupported version statement (`version draft-2`, `version 1.9`) will resolve to `Some(SupportedVersion::default())` = 1.3 in the LSP.

Side note: a document with no `version` statement at all (which the WDL spec calls `draft-2`) fails to parse and never reaches these handlers. The wording of that error was a separate concern, addressed in [#993](https://github.com/stjude-rust-labs/sprocket/pull/993).

## Testing

Version-bracketed LSP tests assert the behavior in both directions: at the file's declared version the expected signatures are present, and in a `version 1.0` variant the too-new ones are absent. They cover a mixed-version polymorphic function (`basename`), an all-too-new polymorphic function (`contains_key`), and a too-new monomorphic function (`split`). See `wdl-lsp/tests/hover.rs` and `wdl-lsp/tests/completions.rs`.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
