### PR TITLE
fix(wdl-lsp): suppress `KnownRules` for `wdl-lint` rules

### DIFF
--- a/crates/wdl-lsp/src/server.rs
+++ b/crates/wdl-lsp/src/server.rs
@@ -505,6 +505,10 @@ impl ServerOptions {
                             .map(|r| r as Box<dyn Rule>),
                     ));
                 }
+
+                // Even if linting isn't enabled, we need to make the validator aware of
+                // `wdl-lint` rules for `KnownRules`.
+                validator.extend_known_rules(wdl_lint::ALL_RULE_IDS.iter().cloned());
                 validator
             },
         )


### PR DESCRIPTION
Makes the validator aware of `wdl-lint` rule names even if linting isn't enabled, necessary after #858 

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
