### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.28.0 - 2026-07-15
+
 ### Added
 
 * Added server-management commands under `sprocket dev server` ([#915](https://github.com/stjude-rust-labs/sprocket/pull/915)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6407,7 +6407,7 @@ dependencies = [
 
 [[package]]
 name = "wdl"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -6425,7 +6425,7 @@ dependencies = [
 
 [[package]]
 name = "wdl-analysis"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -6467,7 +6467,7 @@ dependencies = [
 
 [[package]]
 name = "wdl-ast"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "approx",
  "codespan-reporting",
@@ -6484,7 +6484,7 @@ dependencies = [
 
 [[package]]
 name = "wdl-diagnostics"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -6497,7 +6497,7 @@ dependencies = [
 
 [[package]]
 name = "wdl-doc"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "ammonia",
  "anyhow",
@@ -6525,7 +6525,7 @@ dependencies = [
 
 [[package]]
 name = "wdl-engine"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -6580,7 +6580,7 @@ dependencies = [
 
 [[package]]
 name = "wdl-format"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6595,7 +6595,7 @@ dependencies = [
 
 [[package]]
 name = "wdl-grammar"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -6610,7 +6610,7 @@ dependencies = [
 
 [[package]]
 name = "wdl-lint"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -6644,7 +6644,7 @@ dependencies = [
 
 [[package]]
 name = "wdl-lsp"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "async-lsp",
@@ -6672,7 +6672,7 @@ dependencies = [
 
 [[package]]
 name = "wdl-modules"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "async-trait",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,8 +134,8 @@ utoipa = { version = "5.4.0", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum", "vendored"] }
 uuid = { version = "1.20.0", features = ["serde", "v4"] }
 walkdir = "2.5.0"
-wdl = { version = "0.23.2", path = "crates/wdl", features = ["engine", "lint", "lsp", "doc", "diagnostics"] }
-wdl-modules = { version = "0.2.1", path = "crates/wdl-modules", features = ["git-resolver"] }
+wdl = { version = "0.23.3", path = "crates/wdl", features = ["engine", "lint", "lsp", "doc", "diagnostics"] }
+wdl-modules = { version = "0.3.0", path = "crates/wdl-modules", features = ["git-resolver"] }
 which = "8.0.0"
 whoami = "2.1.0"
 windows-sys = "0.61"
@@ -164,7 +164,7 @@ new_without_default = "allow"
 
 [package]
 name = "sprocket"
-version = "0.27.0"
+version = "0.28.0"
 description = "A command line tool for working with Workflow Description Language (WDL) documents"
 authors.workspace = true
 license.workspace = true

--- a/crates/gauntlet/Cargo.toml
+++ b/crates/gauntlet/Cargo.toml
@@ -22,7 +22,7 @@ tokio.workspace = true
 toml-spanner = { workspace = true }
 tracing.workspace = true
 tracing-subscriber.workspace = true
-wdl = { path = "../wdl", version = "0.23.2", features = ["analysis"] }
+wdl = { path = "../wdl", version = "0.23.3", features = ["analysis"] }
 
 [lints]
 workspace = true

--- a/crates/sprocket-py/Cargo.toml
+++ b/crates/sprocket-py/Cargo.toml
@@ -15,8 +15,8 @@ readme = "../../python/README.md"
 
 [dependencies]
 pyo3.workspace = true
-wdl-diagnostics = { path = "../wdl-diagnostics", version = "0.1.4", features = ["unstable-python"] }
-wdl-grammar = { path = "../wdl-grammar", version = "0.24.0", features = ["unstable-python"] }
+wdl-diagnostics = { path = "../wdl-diagnostics", version = "0.1.5", features = ["unstable-python"] }
+wdl-grammar = { path = "../wdl-grammar", version = "0.25.0", features = ["unstable-python"] }
 
 [lints]
 workspace = true

--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.23.0 - 2026-07-15
+
 #### Added
 
 * Analysis resolves symbolic module imports (`import owner/module/path`, including the wildcard `import * from owner/module` and selected-member `import { a, b } from owner/module` forms) through a `wdl-modules` `Resolver`, materializing them to concrete files during analysis ([#872](https://github.com/stjude-rust-labs/sprocket/pull/872)).

--- a/crates/wdl-analysis/Cargo.toml
+++ b/crates/wdl-analysis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-analysis"
-version = "0.22.0"
+version = "0.23.0"
 rust-version.workspace = true
 license.workspace = true
 edition.workspace = true
@@ -36,10 +36,10 @@ toml-spanner = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-wdl-ast = { path = "../wdl-ast", version = "0.25.0" }
-wdl-format = { path = "../wdl-format", version = "0.19.0" }
-wdl-grammar = { path = "../wdl-grammar", version = "0.24.0" }
-wdl-modules = { path = "../wdl-modules", version = "0.2.1" }
+wdl-ast = { path = "../wdl-ast", version = "0.26.0" }
+wdl-format = { path = "../wdl-format", version = "0.20.0" }
+wdl-grammar = { path = "../wdl-grammar", version = "0.25.0" }
+wdl-modules = { path = "../wdl-modules", version = "0.3.0" }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/crates/wdl-ast/CHANGELOG.md
+++ b/crates/wdl-ast/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.26.0 - 2026-07-15
+
 #### Added
 
 * Added the `unstable-python` feature flag, which enables APIs related to Sprocket's Python bindings ([#941](https://github.com/stjude-rust-labs/sprocket/pull/941)).

--- a/crates/wdl-ast/Cargo.toml
+++ b/crates/wdl-ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-ast"
-version = "0.25.0"
+version = "0.26.0"
 description = "An abstract syntax tree for Workflow Description Language (WDL) documents"
 authors.workspace = true
 rust-version.workspace = true
@@ -23,7 +23,7 @@ paste = { workspace = true }
 rowan = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
-wdl-grammar = { path = "../wdl-grammar", version = "0.24.0" }
+wdl-grammar = { path = "../wdl-grammar", version = "0.25.0" }
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/wdl-diagnostics/CHANGELOG.md
+++ b/crates/wdl-diagnostics/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.1.5 - 2026-07-15
+
 #### Added
 
 * Added the `unstable-python` feature flag, which enables APIs related to Sprocket's Python bindings ([#941](https://github.com/stjude-rust-labs/sprocket/pull/941)).

--- a/crates/wdl-diagnostics/Cargo.toml
+++ b/crates/wdl-diagnostics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-diagnostics"
-version = "0.1.4"
+version = "0.1.5"
 description = "Utilities for reporting diagnostics in the wdl-* family of crates"
 license.workspace = true
 edition.workspace = true
@@ -24,8 +24,8 @@ clap.workspace = true
 codespan-reporting.workspace = true
 pyo3 = { workspace = true, optional = true, features = ["anyhow"] }
 schemars.workspace = true
-wdl-ast = { path = "../wdl-ast", version = "0.25.0" }
-wdl-engine = { path = "../wdl-engine", version = "0.16.0", optional = true }
+wdl-ast = { path = "../wdl-ast", version = "0.26.0" }
+wdl-engine = { path = "../wdl-engine", version = "0.17.0", optional = true }
 
 [lints]
 workspace = true

--- a/crates/wdl-doc/CHANGELOG.md
+++ b/crates/wdl-doc/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.15.3 - 2026-07-15
+
 ## 0.15.2 - 2026-06-26
 
 ## 0.15.1 - 2026-06-03

--- a/crates/wdl-doc/Cargo.toml
+++ b/crates/wdl-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-doc"
-version = "0.15.2"
+version = "0.15.3"
 description = "Documentation generator for Workflow Description Language (WDL) documents."
 rust-version.workspace = true
 license.workspace = true
@@ -21,8 +21,8 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
-wdl-analysis = { path = "../wdl-analysis", version = "0.22.0" }
-wdl-ast = { path = "../wdl-ast", version = "0.25.0" }
+wdl-analysis = { path = "../wdl-analysis", version = "0.23.0" }
+wdl-ast = { path = "../wdl-ast", version = "0.26.0" }
 which.workspace = true
 
 [dev-dependencies]
@@ -35,7 +35,7 @@ thirtyfour.workspace = true
 tower-http = { workspace = true, features = ["fs"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
-wdl-analysis = { path = "../wdl-analysis", version = "0.22.0" }
+wdl-analysis = { path = "../wdl-analysis", version = "0.23.0" }
 
 [lints]
 workspace = true

--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.17.0 - 2026-07-15
+
 #### Added
 
 * Added a `strongish` content digest mode (`run.task.digests = "strongish"`) that hashes file size, last modified time, and the first 10 MiB of a file's contents; this is an intermediate strategy between `weak` and `strong`, similar to Cromwell's `fingerprint` call caching strategy ([#978](https://github.com/stjude-rust-labs/sprocket/pull/978)).

--- a/crates/wdl-engine/Cargo.toml
+++ b/crates/wdl-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-engine"
-version = "0.16.0"
+version = "0.17.0"
 description = "Execution engine for Workflow Description Language (WDL) documents."
 rust-version.workspace = true
 license.workspace = true
@@ -51,9 +51,9 @@ toml-spanner = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
 walkdir = { workspace = true }
-wdl-analysis = { version = "0.22.0", path = "../wdl-analysis" }
-wdl-ast = { version = "0.25.0", path = "../wdl-ast" }
-wdl-grammar = { version = "0.24.0", path = "../wdl-grammar" }
+wdl-analysis = { version = "0.23.0", path = "../wdl-analysis" }
+wdl-ast = { version = "0.26.0", path = "../wdl-ast" }
+wdl-grammar = { version = "0.25.0", path = "../wdl-grammar" }
 
 [dev-dependencies]
 approx = { workspace = true }

--- a/crates/wdl-format/CHANGELOG.md
+++ b/crates/wdl-format/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.20.0 - 2026-07-15
+
 ## 0.19.0 - 2026-06-26
 
 #### Changed

--- a/crates/wdl-format/Cargo.toml
+++ b/crates/wdl-format/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-format"
-version = "0.19.0"
+version = "0.20.0"
 description = "Formatting of WDL (Workflow Description Language) documents"
 license.workspace = true
 edition.workspace = true
@@ -14,7 +14,7 @@ nonempty.workspace = true
 schemars.workspace = true
 thiserror.workspace = true
 toml-spanner.workspace = true
-wdl-ast = { path = "../wdl-ast", version = "0.25.0" }
+wdl-ast = { path = "../wdl-ast", version = "0.26.0" }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/crates/wdl-grammar/CHANGELOG.md
+++ b/crates/wdl-grammar/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.25.0 - 2026-07-15
+
 #### Added
 
 * Added the `unstable-python` feature flag, which enables APIs related to Sprocket's Python bindings ([#941](https://github.com/stjude-rust-labs/sprocket/pull/941)).

--- a/crates/wdl-grammar/Cargo.toml
+++ b/crates/wdl-grammar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-grammar"
-version = "0.24.0"
+version = "0.25.0"
 description = "A parse tree for Workflow Description Language (WDL) documents"
 authors.workspace = true
 rust-version.workspace = true

--- a/crates/wdl-lint/CHANGELOG.md
+++ b/crates/wdl-lint/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.25.0 - 2026-07-15
+
 #### Added
 
 * Added `BashSetSyntax` lint rule to enforce consistent [bash set](https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html)

--- a/crates/wdl-lint/Cargo.toml
+++ b/crates/wdl-lint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-lint"
-version = "0.24.1"
+version = "0.25.0"
 description = "Lint rules for Workflow Description Language (WDL) documents"
 rust-version.workspace = true
 authors.workspace = true
@@ -31,8 +31,8 @@ thiserror = { workspace = true }
 toml-spanner = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
-wdl-analysis = { path = "../wdl-analysis", version = "0.22.0" }
-wdl-ast = { path = "../wdl-ast", version = "0.25.0" }
+wdl-analysis = { path = "../wdl-analysis", version = "0.23.0" }
+wdl-ast = { path = "../wdl-ast", version = "0.26.0" }
 
 [dev-dependencies]
 codespan-reporting = { workspace = true }
@@ -41,7 +41,7 @@ pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }
-wdl-modules = { path = "../wdl-modules", version = "0.2.0" }
+wdl-modules = { path = "../wdl-modules", version = "0.3.0" }
 
 [lints]
 workspace = true

--- a/crates/wdl-lsp/CHANGELOG.md
+++ b/crates/wdl-lsp/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.21.0 - 2026-07-15
+
 ### Added
 
 * Added support for the `textDocument/codeLens` request on tasks/workflows with no required

--- a/crates/wdl-lsp/Cargo.toml
+++ b/crates/wdl-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-lsp"
-version = "0.20.1"
+version = "0.21.0"
 description = "Language Server Protocol implementation for WDL"
 license.workspace = true
 rust-version.workspace = true
@@ -26,9 +26,9 @@ tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
-wdl-analysis = { path = "../wdl-analysis", version = "0.22.0" }
-wdl-ast = { path = "../wdl-ast", version = "0.25.0" }
-wdl-lint = { path = "../wdl-lint", version = "0.24.1" }
+wdl-analysis = { path = "../wdl-analysis", version = "0.23.0" }
+wdl-ast = { path = "../wdl-ast", version = "0.26.0" }
+wdl-lint = { path = "../wdl-lint", version = "0.25.0" }
 
 [dev-dependencies]
 blake3 = { workspace = true }

--- a/crates/wdl-modules/CHANGELOG.md
+++ b/crates/wdl-modules/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.3.0 - 2026-07-15
+
 ## 0.2.1 - 2026-06-26
 
 #### Changed

--- a/crates/wdl-modules/Cargo.toml
+++ b/crates/wdl-modules/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl-modules"
-version = "0.2.1"
+version = "0.3.0"
 description = "Implementation of the WDL module specification"
 authors.workspace = true
 rust-version.workspace = true
@@ -56,7 +56,7 @@ toml-spanner = { workspace = true, optional = true }
 tracing = { workspace = true, optional = true }
 unicode-normalization = { workspace = true }
 url = { workspace = true, features = ["serde"] }
-wdl-grammar = { path = "../wdl-grammar", version = "0.24.0" }
+wdl-grammar = { path = "../wdl-grammar", version = "0.25.0" }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/wdl/CHANGELOG.md
+++ b/crates/wdl/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 0.23.3 - 2026-07-15
+
 ## 0.23.2 - 2026-06-26
 
 ## 0.23.1 - 2026-06-03

--- a/crates/wdl/Cargo.toml
+++ b/crates/wdl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wdl"
-version = "0.23.2"
+version = "0.23.3"
 authors.workspace = true
 description = "Lexing, parsing, validation, linting, documentation, analysis, and execution for Workflow Description Language (WDL) documents"
 rust-version.workspace = true
@@ -37,15 +37,15 @@ lint = ["dep:wdl-lint"]
 lsp = ["dep:wdl-lsp"]
 
 [dependencies]
-wdl-analysis = { path = "../wdl-analysis", version = "0.22.0", optional = true }
-wdl-ast = { path = "../wdl-ast", version = "0.25.0", optional = true }
-wdl-diagnostics = { path = "../wdl-diagnostics", version = "0.1.4", optional = true }
-wdl-doc = { path = "../wdl-doc", version = "0.15.2", optional = true }
-wdl-engine = { path = "../wdl-engine", version = "0.16.0", optional = true }
-wdl-format = { path = "../wdl-format", version = "0.19.0", optional = true }
-wdl-grammar = { path = "../wdl-grammar", version = "0.24.0", optional = true }
-wdl-lint = { path = "../wdl-lint", version = "0.24.1", optional = true }
-wdl-lsp = { path = "../wdl-lsp", version = "0.20.1", optional = true }
+wdl-analysis = { path = "../wdl-analysis", version = "0.23.0", optional = true }
+wdl-ast = { path = "../wdl-ast", version = "0.26.0", optional = true }
+wdl-diagnostics = { path = "../wdl-diagnostics", version = "0.1.5", optional = true }
+wdl-doc = { path = "../wdl-doc", version = "0.15.3", optional = true }
+wdl-engine = { path = "../wdl-engine", version = "0.17.0", optional = true }
+wdl-format = { path = "../wdl-format", version = "0.20.0", optional = true }
+wdl-grammar = { path = "../wdl-grammar", version = "0.25.0", optional = true }
+wdl-lint = { path = "../wdl-lint", version = "0.25.0", optional = true }
+wdl-lsp = { path = "../wdl-lsp", version = "0.21.0", optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
Replacement for #959, which got stuck with a stale head after release-plz force-pushed the branch (PR head never advanced past the failing gauntlet checks). This PR points at the current branch tip `b89234d5`, which includes the #1011 gauntlet fix. Merging it lands the version bumps on `main` and triggers the release.