### PR TITLE
fix: vendor OpenSSL for the `x86_64-apple-darwin` release build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,6 +3373,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.6.1+3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3380,6 +3389,7 @@ checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/wdl-modules/Cargo.toml
+++ b/crates/wdl-modules/Cargo.toml
@@ -58,6 +58,16 @@ unicode-normalization = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 wdl-grammar = { path = "../wdl-grammar", version = "0.25.0" }
 
+# The `x86_64-apple-darwin` binary is cross-compiled from an `arm64` runner,
+# where the only system OpenSSL available is `arm64`. Building OpenSSL from
+# source (vendored) for this target removes the dependency on an
+# architecture-matched system copy. `openssl-sys` is a single node in the
+# dependency graph, so vendoring applies to the whole x86_64 macOS build,
+# including the `ssh2`/`libssh2-sys` path. The native `aarch64-apple-darwin`
+# build is unaffected and continues to use the system OpenSSL.
+[target.'cfg(all(target_os = "macos", target_arch = "x86_64"))'.dependencies]
+git2 = { workspace = true, optional = true, features = ["https", "ssh", "vendored-openssl"] }
+
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }


### PR DESCRIPTION
The `Release Sprocket` workflow failed on the `build_artifacts_mac (x86_64-apple-darwin)` job, leaving the v0.28.0 release without an Intel-Mac binary. The `x86_64-apple-darwin` target is cross-compiled from an `arm64` runner, and now that the binary links `git2` (and therefore `openssl-sys`), the linker rejects Homebrew's `arm64` OpenSSL against the `x86_64` target.

Enabling `vendored-openssl` for the `x86_64-apple-darwin` target builds OpenSSL from source, so the cross-compile no longer needs an architecture-matched system copy. `openssl-sys` is a single node in the dependency graph, so this also covers the `ssh2`/`libssh2-sys` path. The native `aarch64-apple-darwin` build, Linux, and Windows are unaffected, and no workflow change is needed.

Verified locally by cross-compiling the `x86_64-apple-darwin` release binary: it links cleanly and produces a Mach-O `x86_64` executable with no dynamic OpenSSL linkage.

Before submitting this PR, please make sure:

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).