### PR TITLE
feat(slurm,lsf): write job accounting dump on job completion

### DIFF
--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Added
+
+* Added a `job_accounting` configuration option (defaults to `true`) to the Slurm and LSF Apptainer backends: once a task's job reaches a terminal state, the backend gathers accounting information via `sacct`/`bjobs` and writes it to `sacct.json`/`bjobs.json` in the task's attempt directory. This is best-effort and never affects the task's own result.
+
 ## 0.17.0 - 2026-07-15
 
 #### Added

--- a/crates/wdl-engine/src/backend/lsf_apptainer.rs
+++ b/crates/wdl-engine/src/backend/lsf_apptainer.rs
@@ -662,7 +662,10 @@ impl Monitor {
                 .stdout(Stdio::piped())
                 .stderr(Stdio::piped());
 
-            trace!(?command, "spawning `bjobs` to gather job accounting information");
+            trace!(
+                ?command,
+                "spawning `bjobs` to gather job accounting information"
+            );
 
             let child = command
                 .spawn()
@@ -686,8 +689,7 @@ impl Monitor {
                 )));
             }
 
-            let records =
-                parse_accounting_output(&output.stdout).map_err(RetryError::transient)?;
+            let records = parse_accounting_output(&output.stdout).map_err(RetryError::transient)?;
             if records.is_empty() {
                 return Err(RetryError::transient(anyhow!(
                     "`bjobs` returned no accounting records for LSF job `{job_id}`"
@@ -707,6 +709,38 @@ impl Monitor {
             },
         )
         .await
+    }
+
+    /// Best-effort: gathers final accounting information for a terminated job
+    /// and writes it to [`ACCOUNTING_FILE_NAME`] in the task's attempt
+    /// directory.
+    ///
+    /// Failures are logged and otherwise ignored; this must never affect the
+    /// task's own result.
+    async fn write_job_accounting(job_id: u64, attempt_dir: &Path) {
+        let records = match Self::read_job_accounting(job_id).await {
+            Ok(records) => records,
+            Err(e) => {
+                warn!("failed to gather LSF accounting information for job `{job_id}`: {e:#}");
+                return;
+            }
+        };
+
+        let contents = match serde_json::to_vec_pretty(&records) {
+            Ok(contents) => contents,
+            Err(e) => {
+                warn!("failed to serialize LSF accounting information for job `{job_id}`: {e:#}");
+                return;
+            }
+        };
+
+        let path = attempt_dir.join(ACCOUNTING_FILE_NAME);
+        if let Err(e) = fs::write(&path, contents).await {
+            warn!(
+                path = %path.display(),
+                "failed to write LSF accounting information for job `{job_id}`: {e:#}"
+            );
+        }
     }
 
     /// Reads the current job records using `bjobs`.
@@ -1048,7 +1082,16 @@ impl TaskExecutionBackend for LsfApptainerBackend {
                 .await
                 .context("failed to acquire permit for submitting job")?;
 
-            let job = self.monitor.submit_job(backend_config, &request, crankshaft_id, &apptainer_command_path, transferer.as_ref()).await?;
+            let job = self
+                .monitor
+                .submit_job(
+                    backend_config,
+                    &request,
+                    crankshaft_id,
+                    &apptainer_command_path,
+                    transferer.as_ref(),
+                )
+                .await?;
             drop(permit);
 
             let name = job.task_name;
@@ -1092,7 +1135,12 @@ impl TaskExecutionBackend for LsfApptainerBackend {
 
                     return Ok(None);
                 }
-                result = job.completed => match result.context("failed to wait for task to complete")? {
+                result = job.completed => {
+                    if backend_config.job_accounting.unwrap_or(true) {
+                        Monitor::write_job_accounting(job_id, request.attempt_dir).await;
+                    }
+
+                    match result.context("failed to wait for task to complete")? {
                     Ok(exit_code) => {
                         // See WEXITSTATUS from wait(2) to explain the shift and masking here
                         #[cfg(unix)]
@@ -1127,6 +1175,7 @@ impl TaskExecutionBackend for LsfApptainerBackend {
 
                         return Err(e);
                     }
+                }
                 }
             };
 

--- a/crates/wdl-engine/src/backend/lsf_apptainer.rs
+++ b/crates/wdl-engine/src/backend/lsf_apptainer.rs
@@ -45,6 +45,9 @@ use tokio::select;
 use tokio::sync::Semaphore;
 use tokio::sync::oneshot;
 use tokio::time::MissedTickBehavior;
+use tokio_retry2::Retry;
+use tokio_retry2::RetryError;
+use tokio_retry2::strategy::ExponentialBackoff;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use tracing::error;
@@ -86,6 +89,34 @@ const DEFAULT_MAX_CONCURRENCY: u32 = 10;
 
 /// The length, in bytes, of the generated monitor tag.
 const MONITOR_TAG_LENGTH: usize = 10;
+
+/// The name of the file where a job's final accounting information (from
+/// `bjobs`) is written.
+const ACCOUNTING_FILE_NAME: &str = "bjobs.json";
+
+/// The fields requested from `bjobs` when gathering final accounting
+/// information for a single terminated job.
+///
+/// This is a superset of the fields used for state-polling (`bjobs -json -o
+/// "jobid stat exit_code max_mem avg_mem cpu_used ru_utime ru_stime"`,
+/// `lsf_apptainer.rs:633`), since this query is only made once per job (on
+/// termination) rather than on every monitor tick.
+///
+/// LSF has no reliably version-stable GPU/generic-resource equivalent to
+/// Slurm's `TRES` fields, so none is requested here.
+const ACCOUNTING_FIELDS: &str = "jobid stat exit_code max_mem avg_mem cpu_used ru_utime \
+     ru_stime submit_time start_time finish_time exec_host queue job_name";
+
+/// The initial delay, in milliseconds, before retrying a failed or
+/// incomplete accounting query.
+const ACCOUNTING_RETRY_INITIAL_DELAY_MS: u64 = 500;
+
+/// The maximum delay, in milliseconds, between accounting query retries.
+const ACCOUNTING_RETRY_MAX_DELAY_MS: u64 = 5_000;
+
+/// The maximum number of attempts made to gather a job's accounting
+/// information before giving up.
+const ACCOUNTING_RETRY_ATTEMPTS: usize = 5;
 
 /// Truncates an LSF job name if the size of the job name exceeds the maximum.
 ///
@@ -613,6 +644,71 @@ impl Monitor {
         debug!("LSF task monitor has shut down");
     }
 
+    /// Reads final accounting information for a single terminated job using
+    /// `bjobs`, retrying briefly since LSF's accounting data can lag behind
+    /// job termination.
+    async fn read_job_accounting(job_id: u64) -> Result<Vec<serde_json::Value>> {
+        async fn try_read(
+            job_id: u64,
+        ) -> Result<Vec<serde_json::Value>, RetryError<anyhow::Error>> {
+            let mut command = Command::new("bjobs");
+            let command = command
+                .arg("-a")
+                .arg("-json")
+                .arg("-o")
+                .arg(ACCOUNTING_FIELDS)
+                .arg(job_id.to_string())
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+
+            trace!(?command, "spawning `bjobs` to gather job accounting information");
+
+            let child = command
+                .spawn()
+                .context("failed to spawn `bjobs` command")
+                // If the system can't spawn `bjobs` at all (e.g. missing binary), retrying
+                // won't help — fail fast, matching apptainer.rs's try_pull_image.
+                .map_err(RetryError::permanent)?;
+
+            let output = child
+                .wait_with_output()
+                .await
+                .context("failed to wait for `bjobs` to exit")
+                .map_err(RetryError::permanent)?;
+            if !output.status.success() {
+                return Err(RetryError::transient(anyhow!(
+                    "`bjobs` failed: {status}: {stderr}",
+                    status = output.status,
+                    stderr = str::from_utf8(&output.stderr)
+                        .unwrap_or("<output not UTF-8>")
+                        .trim()
+                )));
+            }
+
+            let records =
+                parse_accounting_output(&output.stdout).map_err(RetryError::transient)?;
+            if records.is_empty() {
+                return Err(RetryError::transient(anyhow!(
+                    "`bjobs` returned no accounting records for LSF job `{job_id}`"
+                )));
+            }
+
+            Ok(records)
+        }
+
+        Retry::spawn_notify(
+            ExponentialBackoff::from_millis(ACCOUNTING_RETRY_INITIAL_DELAY_MS)
+                .max_delay_millis(ACCOUNTING_RETRY_MAX_DELAY_MS)
+                .take(ACCOUNTING_RETRY_ATTEMPTS),
+            || try_read(job_id),
+            move |e: &anyhow::Error, _| {
+                warn!(e = %e, "retrying `bjobs` accounting query for LSF job `{job_id}`");
+            },
+        )
+        .await
+    }
+
     /// Reads the current job records using `bjobs`.
     async fn read_job_records(search_prefix: &str) -> Result<Vec<JobRecord>> {
         /// The expected output of `bjobs`.
@@ -659,6 +755,26 @@ impl Monitor {
         .context("failed to deserialize `bjobs` output")?
         .records)
     }
+}
+
+/// Deserializes the JSON output of a `bjobs -json` accounting query (using
+/// [`ACCOUNTING_FIELDS`]) into the job's accounting records.
+///
+/// Kept separate from [`Monitor::read_job_records`] since that one is typed
+/// to the polling-specific `JobRecord` shape, while this is used only for
+/// the best-effort `bjobs.json` accounting dump and keeps each record as a
+/// generic JSON value.
+fn parse_accounting_output(output: &[u8]) -> Result<Vec<serde_json::Value>> {
+    #[derive(Deserialize)]
+    struct Output {
+        /// The output records.
+        #[serde(rename = "RECORDS")]
+        records: Vec<serde_json::Value>,
+    }
+
+    Ok(serde_json::from_slice::<Output>(output)
+        .context("failed to deserialize `bjobs` output")?
+        .records)
 }
 
 /// The experimental LSF + Apptainer backend.
@@ -1048,5 +1164,26 @@ mod tests {
         assert_eq!(name.len(), 8188);
         let name = truncate_job_name(&name);
         assert!(name.len() < LSF_JOB_NAME_MAX_LENGTH);
+    }
+
+    #[test]
+    fn parses_accounting_records() {
+        let output = br#"{"RECORDS":[{"JOBID":"12345","STAT":"DONE","MAX_MEM":"512M"}]}"#;
+        let records = parse_accounting_output(output).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["JOBID"], "12345");
+        assert_eq!(records[0]["MAX_MEM"], "512M");
+    }
+
+    #[test]
+    fn empty_records_array_parses_to_empty_vec() {
+        let output = br#"{"RECORDS":[]}"#;
+        let records = parse_accounting_output(output).unwrap();
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn invalid_json_is_an_error() {
+        assert!(parse_accounting_output(b"not json").is_err());
     }
 }

--- a/crates/wdl-engine/src/backend/slurm_apptainer.rs
+++ b/crates/wdl-engine/src/backend/slurm_apptainer.rs
@@ -825,6 +825,46 @@ impl Monitor {
         .await
     }
 
+    /// Best-effort: gathers final accounting information for a terminated job
+    /// and writes it to [`ACCOUNTING_FILE_NAME`] in the task's attempt
+    /// directory.
+    ///
+    /// Failures are logged and otherwise ignored; this must never affect the
+    /// task's own result.
+    async fn write_job_accounting(job_id: u64, attempt_dir: &Path) {
+        let output = match Self::read_job_accounting(job_id).await {
+            Ok(output) => output,
+            Err(e) => {
+                warn!("failed to gather Slurm accounting information for job `{job_id}`: {e:#}");
+                return;
+            }
+        };
+
+        let records = match parse_accounting_output(&output) {
+            Ok(records) => records,
+            Err(e) => {
+                warn!("failed to parse Slurm accounting information for job `{job_id}`: {e:#}");
+                return;
+            }
+        };
+
+        let contents = match serde_json::to_vec_pretty(&records) {
+            Ok(contents) => contents,
+            Err(e) => {
+                warn!("failed to serialize Slurm accounting information for job `{job_id}`: {e:#}");
+                return;
+            }
+        };
+
+        let path = attempt_dir.join(ACCOUNTING_FILE_NAME);
+        if let Err(e) = fs::write(&path, contents).await {
+            warn!(
+                path = %path.display(),
+                "failed to write Slurm accounting information for job `{job_id}`: {e:#}"
+            );
+        }
+    }
+
     /// Reads the current jobs using `sacct`.
     ///
     /// Returns the stdout of `sacct`.
@@ -1183,7 +1223,16 @@ impl TaskExecutionBackend for SlurmApptainerBackend {
                 .await
                 .context("failed to acquire permit for submitting job")?;
 
-            let job = self.monitor.submit_job(backend_config, &request, crankshaft_id, &apptainer_command_path, transferer.as_ref()).await?;
+            let job = self
+                .monitor
+                .submit_job(
+                    backend_config,
+                    &request,
+                    crankshaft_id,
+                    &apptainer_command_path,
+                    transferer.as_ref(),
+                )
+                .await?;
             drop(permit);
 
             let name = job.task_name;
@@ -1227,7 +1276,12 @@ impl TaskExecutionBackend for SlurmApptainerBackend {
 
                     return Ok(None);
                 }
-                result = job.completed => match result.context("failed to wait for task to complete")? {
+                result = job.completed => {
+                    if backend_config.job_accounting.unwrap_or(true) {
+                        Monitor::write_job_accounting(job_id, request.attempt_dir).await;
+                    }
+
+                    match result.context("failed to wait for task to complete")? {
                     Ok(exit_code) => {
                         let exit_status = exit_code.into_exit_status();
 
@@ -1252,6 +1306,7 @@ impl TaskExecutionBackend for SlurmApptainerBackend {
 
                         return Err(e);
                     }
+                }
                 }
             };
 

--- a/crates/wdl-engine/src/backend/slurm_apptainer.rs
+++ b/crates/wdl-engine/src/backend/slurm_apptainer.rs
@@ -785,13 +785,15 @@ impl Monitor {
             let child = command
                 .spawn()
                 .context("failed to spawn `sacct` command")
-                .map_err(RetryError::transient)?;
+                // If the system can't spawn `sacct` at all (e.g. missing binary), retrying
+                // won't help — fail fast, matching apptainer.rs's try_pull_image.
+                .map_err(RetryError::permanent)?;
 
             let output = child
                 .wait_with_output()
                 .await
                 .context("failed to wait for `sacct` to exit")
-                .map_err(RetryError::transient)?;
+                .map_err(RetryError::permanent)?;
             if !output.status.success() {
                 return Err(RetryError::transient(anyhow!(
                     "`sacct` failed: {status}: {stderr}",
@@ -865,26 +867,40 @@ impl Monitor {
 /// [`ACCOUNTING_FIELDS`]) into one JSON object per line returned — i.e., the
 /// job itself plus any job steps — keyed by field name. Values are kept as
 /// the raw strings `sacct` emits; no unit or duration parsing is performed.
+///
+/// Errors if any line has a different number of fields than
+/// [`ACCOUNTING_FIELDS`] requested, rather than silently truncating or
+/// misaligning field names with values.
 fn parse_accounting_output(output: &[u8]) -> Result<Vec<serde_json::Value>> {
     let output = str::from_utf8(output).context("`sacct` output was not UTF-8")?;
+    let expected_fields: Vec<&str> = ACCOUNTING_FIELDS.split(',').collect();
 
-    Ok(output
+    output
         .lines()
         .filter(|line| !line.trim().is_empty())
         .map(|line| {
-            let fields: serde_json::Map<String, serde_json::Value> = ACCOUNTING_FIELDS
-                .split(',')
-                .zip(line.split('|'))
+            let values: Vec<&str> = line.split('|').collect();
+            if values.len() != expected_fields.len() {
+                bail!(
+                    "`sacct` line has {actual} field(s), expected {expected}: `{line}`",
+                    actual = values.len(),
+                    expected = expected_fields.len()
+                );
+            }
+
+            let fields: serde_json::Map<String, serde_json::Value> = expected_fields
+                .iter()
+                .zip(values)
                 .map(|(name, value)| {
                     (
-                        name.to_string(),
+                        (*name).to_string(),
                         serde_json::Value::String(value.to_string()),
                     )
                 })
                 .collect();
-            serde_json::Value::Object(fields)
+            Ok(serde_json::Value::Object(fields))
         })
-        .collect())
+        .collect()
 }
 
 /// Returns `true` if the output of an accounting `sacct` query contains no
@@ -1322,5 +1338,12 @@ mod tests {
     fn populated_output_is_not_retryable() {
         let line = accounting_line(&[("JobID", "1"), ("State", "COMPLETED")]);
         assert!(!accounting_output_is_empty(format!("{line}\n").as_bytes()));
+    }
+
+    #[test]
+    fn mismatched_field_count_is_an_error() {
+        // Far fewer fields than ACCOUNTING_FIELDS expects.
+        let output = b"12345|myjob\n";
+        assert!(parse_accounting_output(output).is_err());
     }
 }

--- a/crates/wdl-engine/src/backend/slurm_apptainer.rs
+++ b/crates/wdl-engine/src/backend/slurm_apptainer.rs
@@ -40,6 +40,9 @@ use tokio::select;
 use tokio::sync::Semaphore;
 use tokio::sync::oneshot;
 use tokio::time::MissedTickBehavior;
+use tokio_retry2::Retry;
+use tokio_retry2::RetryError;
+use tokio_retry2::strategy::ExponentialBackoff;
 use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use tracing::error;
@@ -73,6 +76,34 @@ const DEFAULT_MONITOR_INTERVAL: u64 = 30;
 
 /// The default maximum concurrency for `sbatch` and `scancel` operations.
 const DEFAULT_MAX_CONCURRENCY: u32 = 10;
+
+/// The name of the file where a job's final accounting information (from
+/// `sacct`) is written.
+const ACCOUNTING_FILE_NAME: &str = "sacct.json";
+
+/// The fields requested from `sacct` when gathering final accounting
+/// information for a single terminated job.
+///
+/// This is a superset of [`JobRecord::fields`], since this query is only
+/// made once per job (on termination) rather than on every monitor tick for
+/// all currently-tracked jobs at once. Job-step lines (e.g. `.batch`,
+/// `.extern`) are intentionally not filtered out here, unlike in
+/// [`MonitorState::update_jobs`]: Slurm frequently only reports memory/IO
+/// statistics on those step lines rather than the parent job line.
+const ACCOUNTING_FIELDS: &str = "JobID,JobName,Partition,State,ExitCode,NodeList,Submit,Start,\
+     End,Elapsed,AllocCPUS,ReqMem,ReqTRES,AllocTRES,MaxRSS,MaxVMSize,AveRSS,AveVMSize,TotalCPU,\
+     UserCPU,SystemCPU,MaxDiskRead,MaxDiskWrite";
+
+/// The initial delay, in milliseconds, before retrying a failed or
+/// incomplete accounting query.
+const ACCOUNTING_RETRY_INITIAL_DELAY_MS: u64 = 500;
+
+/// The maximum delay, in milliseconds, between accounting query retries.
+const ACCOUNTING_RETRY_MAX_DELAY_MS: u64 = 5_000;
+
+/// The maximum number of attempts made to gather a job's accounting
+/// information before giving up.
+const ACCOUNTING_RETRY_ATTEMPTS: usize = 5;
 
 /// Represents a Slurm job state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -727,6 +758,71 @@ impl Monitor {
         debug!("Slurm task monitor has shut down");
     }
 
+    /// Reads final accounting information for a single terminated job using
+    /// `sacct`, retrying briefly since Slurm's accounting database can lag
+    /// behind job termination.
+    ///
+    /// Returns the raw (pipe-delimited) stdout of `sacct`.
+    async fn read_job_accounting(job_id: u64) -> Result<Vec<u8>> {
+        async fn try_read(job_id: u64) -> Result<Vec<u8>, RetryError<anyhow::Error>> {
+            let mut command = Command::new("sacct");
+            let command = command
+                .arg("-P")
+                .arg("-n")
+                .arg("--format")
+                .arg(ACCOUNTING_FIELDS)
+                .arg("-j")
+                .arg(job_id.to_string())
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+
+            trace!(
+                ?command,
+                "spawning `sacct` to gather job accounting information"
+            );
+
+            let child = command
+                .spawn()
+                .context("failed to spawn `sacct` command")
+                .map_err(RetryError::transient)?;
+
+            let output = child
+                .wait_with_output()
+                .await
+                .context("failed to wait for `sacct` to exit")
+                .map_err(RetryError::transient)?;
+            if !output.status.success() {
+                return Err(RetryError::transient(anyhow!(
+                    "`sacct` failed: {status}: {stderr}",
+                    status = output.status,
+                    stderr = str::from_utf8(&output.stderr)
+                        .unwrap_or("<output not UTF-8>")
+                        .trim()
+                )));
+            }
+
+            if accounting_output_is_empty(&output.stdout) {
+                return Err(RetryError::transient(anyhow!(
+                    "`sacct` returned no accounting records for Slurm job `{job_id}`"
+                )));
+            }
+
+            Ok(output.stdout)
+        }
+
+        Retry::spawn_notify(
+            ExponentialBackoff::from_millis(ACCOUNTING_RETRY_INITIAL_DELAY_MS)
+                .max_delay_millis(ACCOUNTING_RETRY_MAX_DELAY_MS)
+                .take(ACCOUNTING_RETRY_ATTEMPTS),
+            || try_read(job_id),
+            move |e: &anyhow::Error, _| {
+                warn!(e = %e, "retrying `sacct` accounting query for Slurm job `{job_id}`");
+            },
+        )
+        .await
+    }
+
     /// Reads the current jobs using `sacct`.
     ///
     /// Returns the stdout of `sacct`.
@@ -763,6 +859,39 @@ impl Monitor {
 
         Ok(output.stdout)
     }
+}
+
+/// Parses the pipe-delimited output of an accounting `sacct` query (using
+/// [`ACCOUNTING_FIELDS`]) into one JSON object per line returned — i.e., the
+/// job itself plus any job steps — keyed by field name. Values are kept as
+/// the raw strings `sacct` emits; no unit or duration parsing is performed.
+fn parse_accounting_output(output: &[u8]) -> Result<Vec<serde_json::Value>> {
+    let output = str::from_utf8(output).context("`sacct` output was not UTF-8")?;
+
+    Ok(output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let fields: serde_json::Map<String, serde_json::Value> = ACCOUNTING_FIELDS
+                .split(',')
+                .zip(line.split('|'))
+                .map(|(name, value)| {
+                    (
+                        name.to_string(),
+                        serde_json::Value::String(value.to_string()),
+                    )
+                })
+                .collect();
+            serde_json::Value::Object(fields)
+        })
+        .collect())
+}
+
+/// Returns `true` if the output of an accounting `sacct` query contains no
+/// records, which signals that Slurm's accounting database (`slurmdbd`)
+/// hasn't yet caught up with the job's termination.
+fn accounting_output_is_empty(output: &[u8]) -> bool {
+    output.iter().all(u8::is_ascii_whitespace)
 }
 
 /// The experimental Slurm + Apptainer backend.
@@ -1131,5 +1260,67 @@ impl TaskExecutionBackend for SlurmApptainerBackend {
             }))
         }
         .boxed()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a single `sacct`-style pipe-delimited line for [`ACCOUNTING_FIELDS`],
+    /// with all fields empty except the ones given in `overrides`.
+    fn accounting_line(overrides: &[(&str, &str)]) -> String {
+        let names: Vec<&str> = ACCOUNTING_FIELDS.split(',').collect();
+        let mut values = vec![String::new(); names.len()];
+        for (name, value) in overrides {
+            let idx = names
+                .iter()
+                .position(|n| n == name)
+                .unwrap_or_else(|| panic!("unknown accounting field `{name}`"));
+            values[idx] = (*value).to_string();
+        }
+        values.join("|")
+    }
+
+    #[test]
+    fn parses_accounting_output_into_one_record_per_line() {
+        let job_line = accounting_line(&[
+            ("JobID", "12345"),
+            ("State", "COMPLETED"),
+            ("Partition", "gpu"),
+        ]);
+        let batch_line = accounting_line(&[
+            ("JobID", "12345.batch"),
+            ("State", "COMPLETED"),
+            ("MaxRSS", "1000000K"),
+        ]);
+        let output = format!("{job_line}\n{batch_line}\n");
+
+        let records = parse_accounting_output(output.as_bytes()).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0]["JobID"], "12345");
+        assert_eq!(records[0]["Partition"], "gpu");
+        assert_eq!(records[1]["JobID"], "12345.batch");
+        assert_eq!(records[1]["MaxRSS"], "1000000K");
+    }
+
+    #[test]
+    fn blank_lines_are_ignored() {
+        let line = accounting_line(&[("JobID", "1"), ("State", "COMPLETED")]);
+        let output = format!("\n{line}\n\n");
+        let records = parse_accounting_output(output.as_bytes()).unwrap();
+        assert_eq!(records.len(), 1);
+    }
+
+    #[test]
+    fn empty_output_is_retryable() {
+        assert!(accounting_output_is_empty(b""));
+        assert!(accounting_output_is_empty(b"\n  \n"));
+    }
+
+    #[test]
+    fn populated_output_is_not_retryable() {
+        let line = accounting_line(&[("JobID", "1"), ("State", "COMPLETED")]);
+        assert!(!accounting_output_is_empty(format!("{line}\n").as_bytes()));
     }
 }

--- a/crates/wdl-engine/src/config.rs
+++ b/crates/wdl-engine/src/config.rs
@@ -2327,6 +2327,15 @@ pub struct LsfApptainerBackendConfig {
     ///
     /// Defaults to 10 concurrent operations.
     pub max_concurrency: Option<u32>,
+    /// Whether to gather LSF accounting information for a task's job via
+    /// `bjobs` once the job reaches a terminal state, writing it to
+    /// `bjobs.json` in the task's attempt directory.
+    ///
+    /// This is best-effort: failures gathering this information are logged
+    /// but never affect the task's own result.
+    ///
+    /// Defaults to `true`.
+    pub job_accounting: Option<bool>,
     /// Which queue, if any, to specify when submitting normal jobs to LSF.
     ///
     /// This may be superseded by
@@ -2555,6 +2564,15 @@ pub struct SlurmApptainerBackendConfig {
     ///
     /// Defaults to 10 concurrent operations.
     pub max_concurrency: Option<u32>,
+    /// Whether to gather Slurm accounting information for a task's job via
+    /// `sacct` once the job reaches a terminal state, writing it to
+    /// `sacct.json` in the task's attempt directory.
+    ///
+    /// This is best-effort: failures gathering this information are logged
+    /// but never affect the task's own result.
+    ///
+    /// Defaults to `true`.
+    pub job_accounting: Option<bool>,
     /// Which partition, if any, to specify when submitting normal jobs to
     /// Slurm.
     ///

--- a/docs/superpowers/plans/2026-07-21-slurm-lsf-accounting-dump.md
+++ b/docs/superpowers/plans/2026-07-21-slurm-lsf-accounting-dump.md
@@ -425,10 +425,19 @@ mod tests {
 Run: `cargo test -p wdl-engine --lib backend::slurm_apptainer::tests`
 Expected: 4 tests PASS (`parses_accounting_output_into_one_record_per_line`, `blank_lines_are_ignored`, `empty_output_is_retryable`, `populated_output_is_not_retryable`).
 
-- [ ] **Step 7: Run fmt and clippy**
+- [ ] **Step 7: Run fmt, and check (not full clippy) for compilation**
 
-Run: `cargo --locked fmt -- --check && cargo --locked clippy -p wdl-engine --tests --all-features -- --deny warnings`
-Expected: no diffs, no warnings.
+Run: `cargo --locked fmt -- --check && cargo check -p wdl-engine --tests`
+Expected: no diffs, no errors.
+
+Note: `cargo clippy --deny warnings` is expected to FAIL at this point with
+8 `dead_code` errors — every item this task adds (`ACCOUNTING_FILE_NAME`,
+`ACCOUNTING_FIELDS`, the three retry constants, `read_job_accounting`,
+`parse_accounting_output`, `accounting_output_is_empty`) has no caller
+outside the new tests until Task 3 wires `Monitor::read_job_accounting`
+and `parse_accounting_output` into `execute()`. This is expected and
+temporary — do not add `#[allow(dead_code)]`. The full clippy gate is
+Task 3's Step 5, once the caller exists.
 
 - [ ] **Step 8: Commit**
 
@@ -849,10 +858,18 @@ mod tests {
 Run: `cargo test -p wdl-engine --lib backend::lsf_apptainer::tests`
 Expected: 4 tests PASS (`job_name_truncates`, `parses_accounting_records`, `empty_records_array_parses_to_empty_vec`, `invalid_json_is_an_error`).
 
-- [ ] **Step 7: Run fmt and clippy**
+- [ ] **Step 7: Run fmt, and check (not full clippy) for compilation**
 
-Run: `cargo --locked fmt -- --check && cargo --locked clippy -p wdl-engine --tests --all-features -- --deny warnings`
-Expected: no diffs, no warnings.
+Run: `cargo --locked fmt -- --check && cargo check -p wdl-engine --tests`
+Expected: no diffs, no errors.
+
+Note: `cargo clippy --deny warnings` is expected to FAIL at this point with
+dead_code errors on the items this task adds (`ACCOUNTING_FILE_NAME`,
+`ACCOUNTING_FIELDS`, the three retry constants, `read_job_accounting`) —
+they have no caller outside the new tests until Task 5 wires
+`Monitor::read_job_accounting` into `execute()`. This is expected and
+temporary — do not add `#[allow(dead_code)]`. The full clippy gate is
+Task 5's Step 6, once the caller exists.
 
 - [ ] **Step 8: Commit**
 

--- a/docs/superpowers/plans/2026-07-21-slurm-lsf-accounting-dump.md
+++ b/docs/superpowers/plans/2026-07-21-slurm-lsf-accounting-dump.md
@@ -243,23 +243,37 @@ Replace with (adding two free functions between the closing `}` of `impl Monitor
 /// [`ACCOUNTING_FIELDS`]) into one JSON object per line returned — i.e., the
 /// job itself plus any job steps — keyed by field name. Values are kept as
 /// the raw strings `sacct` emits; no unit or duration parsing is performed.
+///
+/// Errors if any line has a different number of fields than
+/// [`ACCOUNTING_FIELDS`] requested, rather than silently truncating or
+/// misaligning field names with values.
 fn parse_accounting_output(output: &[u8]) -> Result<Vec<serde_json::Value>> {
     let output = str::from_utf8(output).context("`sacct` output was not UTF-8")?;
+    let expected_fields: Vec<&str> = ACCOUNTING_FIELDS.split(',').collect();
 
-    Ok(output
+    output
         .lines()
         .filter(|line| !line.trim().is_empty())
         .map(|line| {
-            let fields: serde_json::Map<String, serde_json::Value> = ACCOUNTING_FIELDS
-                .split(',')
-                .zip(line.split('|'))
+            let values: Vec<&str> = line.split('|').collect();
+            if values.len() != expected_fields.len() {
+                bail!(
+                    "`sacct` line has {actual} field(s), expected {expected}: `{line}`",
+                    actual = values.len(),
+                    expected = expected_fields.len()
+                );
+            }
+
+            let fields: serde_json::Map<String, serde_json::Value> = expected_fields
+                .iter()
+                .zip(values)
                 .map(|(name, value)| {
-                    (name.to_string(), serde_json::Value::String(value.to_string()))
+                    ((*name).to_string(), serde_json::Value::String(value.to_string()))
                 })
                 .collect();
-            serde_json::Value::Object(fields)
+            Ok(serde_json::Value::Object(fields))
         })
-        .collect())
+        .collect()
 }
 
 /// Returns `true` if the output of an accounting `sacct` query contains no
@@ -308,13 +322,15 @@ Replace with:
             let child = command
                 .spawn()
                 .context("failed to spawn `sacct` command")
-                .map_err(RetryError::transient)?;
+                // If the system can't spawn `sacct` at all (e.g. missing binary), retrying
+                // won't help — fail fast, matching apptainer.rs's try_pull_image.
+                .map_err(RetryError::permanent)?;
 
             let output = child
                 .wait_with_output()
                 .await
                 .context("failed to wait for `sacct` to exit")
-                .map_err(RetryError::transient)?;
+                .map_err(RetryError::permanent)?;
             if !output.status.success() {
                 return Err(RetryError::transient(anyhow!(
                     "`sacct` failed: {status}: {stderr}",
@@ -417,13 +433,20 @@ mod tests {
         let line = accounting_line(&[("JobID", "1"), ("State", "COMPLETED")]);
         assert!(!accounting_output_is_empty(format!("{line}\n").as_bytes()));
     }
+
+    #[test]
+    fn mismatched_field_count_is_an_error() {
+        // Far fewer fields than ACCOUNTING_FIELDS expects.
+        let output = b"12345|myjob\n";
+        assert!(parse_accounting_output(output).is_err());
+    }
 }
 ```
 
 - [ ] **Step 6: Run the tests to verify they pass**
 
 Run: `cargo test -p wdl-engine --lib backend::slurm_apptainer::tests`
-Expected: 4 tests PASS (`parses_accounting_output_into_one_record_per_line`, `blank_lines_are_ignored`, `empty_output_is_retryable`, `populated_output_is_not_retryable`).
+Expected: 5 tests PASS (`parses_accounting_output_into_one_record_per_line`, `blank_lines_are_ignored`, `empty_output_is_retryable`, `populated_output_is_not_retryable`, `mismatched_field_count_is_an_error`).
 
 - [ ] **Step 7: Run fmt, and check (not full clippy) for compilation**
 
@@ -752,13 +775,15 @@ Replace with:
             let child = command
                 .spawn()
                 .context("failed to spawn `bjobs` command")
-                .map_err(RetryError::transient)?;
+                // If the system can't spawn `bjobs` at all (e.g. missing binary), retrying
+                // won't help — fail fast, matching apptainer.rs's try_pull_image.
+                .map_err(RetryError::permanent)?;
 
             let output = child
                 .wait_with_output()
                 .await
                 .context("failed to wait for `bjobs` to exit")
-                .map_err(RetryError::transient)?;
+                .map_err(RetryError::permanent)?;
             if !output.status.success() {
                 return Err(RetryError::transient(anyhow!(
                     "`bjobs` failed: {status}: {stderr}",

--- a/docs/superpowers/plans/2026-07-21-slurm-lsf-accounting-dump.md
+++ b/docs/superpowers/plans/2026-07-21-slurm-lsf-accounting-dump.md
@@ -1,0 +1,1043 @@
+# Slurm/LSF Job Accounting Dump Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** After a Slurm or LSF job finishes (successfully or not), gather accounting information via `sacct`/`bjobs` and write it as JSON into the task's attempt directory, opt-out via config.
+
+**Architecture:** Each backend gets one new best-effort, retried call to `sacct`/`bjobs` at the point its existing completion oneshot resolves (not on user-initiated cancellation), writing a JSON file next to the task's existing `stdout`/`stderr`/`command` files. A new `job_accounting: Option<bool>` config field (default `true`) gates the whole thing off per backend.
+
+**Tech Stack:** Rust, `tokio-retry2` (already a dependency, already used the same way in `backend/apptainer.rs`), `serde_json` (already a dependency).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-21-slurm-lsf-accounting-dump-design.md` — read it before starting; this plan implements it directly.
+- The accounting dump must never change a task's exit code or turn a successful/failed result into a different outcome — all failures in this new code path are logged (`warn!`) and swallowed.
+- Only gathered on the job's normal completion-oneshot arm (`slurm_apptainer.rs:1085`, `lsf_apptainer.rs:979`), never on the cancellation branches.
+- No new dependencies — `tokio-retry2` and `serde_json` are already direct dependencies of the `wdl-engine` crate (`crates/wdl-engine/Cargo.toml:40-41,48`).
+- Follow the existing `Retry::spawn_notify` + `ExponentialBackoff` + `RetryError::transient`/`RetryError::permanent` pattern from `crates/wdl-engine/src/backend/apptainer.rs:327-345,402-465` — do not write a bespoke retry loop.
+- Run `cargo --locked fmt -- --check` and `cargo --locked clippy --workspace --tests --all-features -- --deny warnings` before considering any task done (matches `.github/workflows/CI.yml:37,65`).
+
+---
+
+## File Structure
+
+- Modify: `crates/wdl-engine/src/config.rs` — add `job_accounting: Option<bool>` to `SlurmApptainerBackendConfig` and `LsfApptainerBackendConfig`.
+- Modify: `jsonschemas/sprocket.toml.json` — regenerated, not hand-edited.
+- Modify: `crates/wdl-engine/src/backend/slurm_apptainer.rs` — new consts, `Monitor::read_job_accounting`, `Monitor::write_job_accounting`, `parse_accounting_output`, `accounting_output_is_empty`, a new `#[cfg(test)] mod tests`, and one gated call added to `execute()`.
+- Modify: `crates/wdl-engine/src/backend/lsf_apptainer.rs` — same shape: new consts, `Monitor::read_job_accounting`, `Monitor::write_job_accounting`, `parse_accounting_output`, new tests added to the existing `#[cfg(test)] mod tests` (`lsf_apptainer.rs:1041-1052`), and one gated call added to `execute()`.
+- Modify: `crates/wdl-engine/CHANGELOG.md` — one `Unreleased` entry covering both backends.
+
+---
+
+### Task 1: Add `job_accounting` config option to both backends
+
+**Files:**
+- Modify: `crates/wdl-engine/src/config.rs:2545-2561` (`SlurmApptainerBackendConfig`)
+- Modify: `crates/wdl-engine/src/config.rs:2317-2330` (`LsfApptainerBackendConfig`)
+- Modify: `jsonschemas/sprocket.toml.json` (regenerated)
+- Test: `src/config.rs:1111-1140` (existing `public_schema_up_to_date` / `schema_matches_config` tests — no new test code needed, just must keep passing)
+
+**Interfaces:**
+- Produces: `SlurmApptainerBackendConfig.job_accounting: Option<bool>` and `LsfApptainerBackendConfig.job_accounting: Option<bool>`, both read via `.unwrap_or(true)` at the call site (Tasks 3 and 5 consume this).
+
+- [ ] **Step 1: Add the field to `SlurmApptainerBackendConfig`**
+
+In `crates/wdl-engine/src/config.rs`, find:
+
+```rust
+    /// The maximum number of concurrent Slurm operations the backend will
+    /// perform.
+    ///
+    /// This controls the maximum concurrent number of `sbatch` processes the
+    /// backend will spawn to queue tasks.
+    ///
+    /// Defaults to 10 concurrent operations.
+    pub max_concurrency: Option<u32>,
+    /// Which partition, if any, to specify when submitting normal jobs to
+    /// Slurm.
+```
+
+Insert a new field directly after `max_concurrency` and before the `default_slurm_partition` doc comment:
+
+```rust
+    /// The maximum number of concurrent Slurm operations the backend will
+    /// perform.
+    ///
+    /// This controls the maximum concurrent number of `sbatch` processes the
+    /// backend will spawn to queue tasks.
+    ///
+    /// Defaults to 10 concurrent operations.
+    pub max_concurrency: Option<u32>,
+    /// Whether to gather Slurm accounting information for a task's job via
+    /// `sacct` once the job reaches a terminal state, writing it to
+    /// `sacct.json` in the task's attempt directory.
+    ///
+    /// This is best-effort: failures gathering this information are logged
+    /// but never affect the task's own result.
+    ///
+    /// Defaults to `true`.
+    pub job_accounting: Option<bool>,
+    /// Which partition, if any, to specify when submitting normal jobs to
+    /// Slurm.
+```
+
+- [ ] **Step 2: Add the same field to `LsfApptainerBackendConfig`**
+
+In the same file, find:
+
+```rust
+    /// The maximum number of concurrent LSF operations the backend will
+    /// perform.
+    ///
+    /// This controls the maximum concurrent number of `bsub` processes the
+    /// backend will spawn to queue tasks.
+    ///
+    /// Defaults to 10 concurrent operations.
+    pub max_concurrency: Option<u32>,
+    /// Which queue, if any, to specify when submitting normal jobs to LSF.
+```
+
+Insert:
+
+```rust
+    /// The maximum number of concurrent LSF operations the backend will
+    /// perform.
+    ///
+    /// This controls the maximum concurrent number of `bsub` processes the
+    /// backend will spawn to queue tasks.
+    ///
+    /// Defaults to 10 concurrent operations.
+    pub max_concurrency: Option<u32>,
+    /// Whether to gather LSF accounting information for a task's job via
+    /// `bjobs` once the job reaches a terminal state, writing it to
+    /// `bjobs.json` in the task's attempt directory.
+    ///
+    /// This is best-effort: failures gathering this information are logged
+    /// but never affect the task's own result.
+    ///
+    /// Defaults to `true`.
+    pub job_accounting: Option<bool>,
+    /// Which queue, if any, to specify when submitting normal jobs to LSF.
+```
+
+- [ ] **Step 3: Regenerate the JSON schema**
+
+Run:
+
+```bash
+cargo run --quiet -- config schema > jsonschemas/sprocket.toml.json
+```
+
+- [ ] **Step 4: Verify the schema and config tests pass**
+
+Run: `cargo test -p sprocket --lib config::test`
+Expected: `public_schema_up_to_date` and `schema_matches_config` both PASS (they will fail with a diff if step 3 was skipped or the field text doesn't match).
+
+- [ ] **Step 5: Verify the crate still builds**
+
+Run: `cargo check -p wdl-engine -p sprocket`
+Expected: no errors (the field is unused so far — that's fine, it's a public struct field, not a local variable, so there's no dead-code warning).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/wdl-engine/src/config.rs jsonschemas/sprocket.toml.json
+git commit -m "feat(config): add job_accounting option to slurm/lsf backends"
+```
+
+---
+
+### Task 2: Slurm accounting fetch/parse (pure functions + tests)
+
+**Files:**
+- Modify: `crates/wdl-engine/src/backend/slurm_apptainer.rs`
+- Test: same file, new `#[cfg(test)] mod tests` block at the end
+
+**Interfaces:**
+- Consumes: nothing new from other tasks.
+- Produces: `Monitor::read_job_accounting(job_id: u64) -> Result<Vec<u8>>` (async), `parse_accounting_output(output: &[u8]) -> Result<Vec<serde_json::Value>>`, `accounting_output_is_empty(output: &[u8]) -> bool`, `ACCOUNTING_FIELDS: &str`, `ACCOUNTING_FILE_NAME: &str`. Task 3 calls `Monitor::read_job_accounting` and `parse_accounting_output`.
+
+- [ ] **Step 1: Add the new imports**
+
+In `crates/wdl-engine/src/backend/slurm_apptainer.rs`, find:
+
+```rust
+use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
+```
+
+Replace with:
+
+```rust
+use tokio::time::MissedTickBehavior;
+use tokio_retry2::Retry;
+use tokio_retry2::RetryError;
+use tokio_retry2::strategy::ExponentialBackoff;
+use tokio_util::sync::CancellationToken;
+```
+
+- [ ] **Step 2: Add the new constants**
+
+Find:
+
+```rust
+/// The default maximum concurrency for `sbatch` and `scancel` operations.
+const DEFAULT_MAX_CONCURRENCY: u32 = 10;
+```
+
+Insert directly after it:
+
+```rust
+/// The default maximum concurrency for `sbatch` and `scancel` operations.
+const DEFAULT_MAX_CONCURRENCY: u32 = 10;
+
+/// The name of the file where a job's final accounting information (from
+/// `sacct`) is written.
+const ACCOUNTING_FILE_NAME: &str = "sacct.json";
+
+/// The fields requested from `sacct` when gathering final accounting
+/// information for a single terminated job.
+///
+/// This is a superset of [`JobRecord::fields`], since this query is only
+/// made once per job (on termination) rather than on every monitor tick for
+/// all currently-tracked jobs at once. Job-step lines (e.g. `.batch`,
+/// `.extern`) are intentionally not filtered out here, unlike in
+/// [`MonitorState::update_jobs`]: Slurm frequently only reports memory/IO
+/// statistics on those step lines rather than the parent job line.
+const ACCOUNTING_FIELDS: &str = "JobID,JobName,Partition,State,ExitCode,NodeList,Submit,Start,\
+     End,Elapsed,AllocCPUS,ReqMem,ReqTRES,AllocTRES,MaxRSS,MaxVMSize,AveRSS,AveVMSize,TotalCPU,\
+     UserCPU,SystemCPU,MaxDiskRead,MaxDiskWrite";
+
+/// The initial delay, in milliseconds, before retrying a failed or
+/// incomplete accounting query.
+const ACCOUNTING_RETRY_INITIAL_DELAY_MS: u64 = 500;
+
+/// The maximum delay, in milliseconds, between accounting query retries.
+const ACCOUNTING_RETRY_MAX_DELAY_MS: u64 = 5_000;
+
+/// The maximum number of attempts made to gather a job's accounting
+/// information before giving up.
+const ACCOUNTING_RETRY_ATTEMPTS: usize = 5;
+```
+
+- [ ] **Step 3: Add `parse_accounting_output` and `accounting_output_is_empty`**
+
+Find the end of the `impl Monitor` block:
+
+```rust
+        Ok(output.stdout)
+    }
+}
+
+/// Represents a submitted Slurm job.
+```
+
+Replace with (adding two free functions between the closing `}` of `impl Monitor` and the `SubmittedJob` struct — note `SubmittedJob` is defined earlier in the file than `impl Monitor`, so in the actual file this insertion point is the `}` that closes `impl Monitor` at line 766, immediately before the `SlurmApptainerBackend` struct doc comment):
+
+```rust
+        Ok(output.stdout)
+    }
+}
+
+/// Parses the pipe-delimited output of an accounting `sacct` query (using
+/// [`ACCOUNTING_FIELDS`]) into one JSON object per line returned — i.e., the
+/// job itself plus any job steps — keyed by field name. Values are kept as
+/// the raw strings `sacct` emits; no unit or duration parsing is performed.
+fn parse_accounting_output(output: &[u8]) -> Result<Vec<serde_json::Value>> {
+    let output = str::from_utf8(output).context("`sacct` output was not UTF-8")?;
+
+    Ok(output
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| {
+            let fields: serde_json::Map<String, serde_json::Value> = ACCOUNTING_FIELDS
+                .split(',')
+                .zip(line.split('|'))
+                .map(|(name, value)| {
+                    (name.to_string(), serde_json::Value::String(value.to_string()))
+                })
+                .collect();
+            serde_json::Value::Object(fields)
+        })
+        .collect())
+}
+
+/// Returns `true` if the output of an accounting `sacct` query contains no
+/// records, which signals that Slurm's accounting database (`slurmdbd`)
+/// hasn't yet caught up with the job's termination.
+fn accounting_output_is_empty(output: &[u8]) -> bool {
+    output.iter().all(u8::is_ascii_whitespace)
+}
+```
+
+- [ ] **Step 4: Add `Monitor::read_job_accounting`**
+
+Find (this is the same `read_jobs` function whose end you just edited around in Step 3 — add this new method directly before it, still inside `impl Monitor`):
+
+```rust
+    /// Reads the current jobs using `sacct`.
+    ///
+    /// Returns the stdout of `sacct`.
+    async fn read_jobs(jobs: &str) -> Result<Vec<u8>> {
+```
+
+Replace with:
+
+```rust
+    /// Reads final accounting information for a single terminated job using
+    /// `sacct`, retrying briefly since Slurm's accounting database can lag
+    /// behind job termination.
+    ///
+    /// Returns the raw (pipe-delimited) stdout of `sacct`.
+    async fn read_job_accounting(job_id: u64) -> Result<Vec<u8>> {
+        async fn try_read(job_id: u64) -> Result<Vec<u8>, RetryError<anyhow::Error>> {
+            let mut command = Command::new("sacct");
+            let command = command
+                .arg("-P")
+                .arg("-n")
+                .arg("--format")
+                .arg(ACCOUNTING_FIELDS)
+                .arg("-j")
+                .arg(job_id.to_string())
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+
+            trace!(?command, "spawning `sacct` to gather job accounting information");
+
+            let child = command
+                .spawn()
+                .context("failed to spawn `sacct` command")
+                .map_err(RetryError::transient)?;
+
+            let output = child
+                .wait_with_output()
+                .await
+                .context("failed to wait for `sacct` to exit")
+                .map_err(RetryError::transient)?;
+            if !output.status.success() {
+                return Err(RetryError::transient(anyhow!(
+                    "`sacct` failed: {status}: {stderr}",
+                    status = output.status,
+                    stderr = str::from_utf8(&output.stderr)
+                        .unwrap_or("<output not UTF-8>")
+                        .trim()
+                )));
+            }
+
+            if accounting_output_is_empty(&output.stdout) {
+                return Err(RetryError::transient(anyhow!(
+                    "`sacct` returned no accounting records for Slurm job `{job_id}`"
+                )));
+            }
+
+            Ok(output.stdout)
+        }
+
+        Retry::spawn_notify(
+            ExponentialBackoff::from_millis(ACCOUNTING_RETRY_INITIAL_DELAY_MS)
+                .max_delay_millis(ACCOUNTING_RETRY_MAX_DELAY_MS)
+                .take(ACCOUNTING_RETRY_ATTEMPTS),
+            || try_read(job_id),
+            |e: &anyhow::Error, _| {
+                warn!(e = %e, "retrying `sacct` accounting query for Slurm job `{job_id}`");
+            },
+        )
+        .await
+    }
+
+    /// Reads the current jobs using `sacct`.
+    ///
+    /// Returns the stdout of `sacct`.
+    async fn read_jobs(jobs: &str) -> Result<Vec<u8>> {
+```
+
+- [ ] **Step 5: Write the failing tests**
+
+Add at the end of `crates/wdl-engine/src/backend/slurm_apptainer.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a single `sacct`-style pipe-delimited line for [`ACCOUNTING_FIELDS`],
+    /// with all fields empty except the ones given in `overrides`.
+    fn accounting_line(overrides: &[(&str, &str)]) -> String {
+        let names: Vec<&str> = ACCOUNTING_FIELDS.split(',').collect();
+        let mut values = vec![String::new(); names.len()];
+        for (name, value) in overrides {
+            let idx = names
+                .iter()
+                .position(|n| n == name)
+                .unwrap_or_else(|| panic!("unknown accounting field `{name}`"));
+            values[idx] = (*value).to_string();
+        }
+        values.join("|")
+    }
+
+    #[test]
+    fn parses_accounting_output_into_one_record_per_line() {
+        let job_line = accounting_line(&[
+            ("JobID", "12345"),
+            ("State", "COMPLETED"),
+            ("Partition", "gpu"),
+        ]);
+        let batch_line = accounting_line(&[
+            ("JobID", "12345.batch"),
+            ("State", "COMPLETED"),
+            ("MaxRSS", "1000000K"),
+        ]);
+        let output = format!("{job_line}\n{batch_line}\n");
+
+        let records = parse_accounting_output(output.as_bytes()).unwrap();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0]["JobID"], "12345");
+        assert_eq!(records[0]["Partition"], "gpu");
+        assert_eq!(records[1]["JobID"], "12345.batch");
+        assert_eq!(records[1]["MaxRSS"], "1000000K");
+    }
+
+    #[test]
+    fn blank_lines_are_ignored() {
+        let line = accounting_line(&[("JobID", "1"), ("State", "COMPLETED")]);
+        let output = format!("\n{line}\n\n");
+        let records = parse_accounting_output(output.as_bytes()).unwrap();
+        assert_eq!(records.len(), 1);
+    }
+
+    #[test]
+    fn empty_output_is_retryable() {
+        assert!(accounting_output_is_empty(b""));
+        assert!(accounting_output_is_empty(b"\n  \n"));
+    }
+
+    #[test]
+    fn populated_output_is_not_retryable() {
+        let line = accounting_line(&[("JobID", "1"), ("State", "COMPLETED")]);
+        assert!(!accounting_output_is_empty(format!("{line}\n").as_bytes()));
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test -p wdl-engine --lib backend::slurm_apptainer::tests`
+Expected: 4 tests PASS (`parses_accounting_output_into_one_record_per_line`, `blank_lines_are_ignored`, `empty_output_is_retryable`, `populated_output_is_not_retryable`).
+
+- [ ] **Step 7: Run fmt and clippy**
+
+Run: `cargo --locked fmt -- --check && cargo --locked clippy -p wdl-engine --tests --all-features -- --deny warnings`
+Expected: no diffs, no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/wdl-engine/src/backend/slurm_apptainer.rs
+git commit -m "feat(slurm): add sacct accounting fetch and parsing"
+```
+
+---
+
+### Task 3: Wire the Slurm accounting dump into `execute()`
+
+**Files:**
+- Modify: `crates/wdl-engine/src/backend/slurm_apptainer.rs:1085-1111` (inside `execute()`)
+
+**Interfaces:**
+- Consumes: `Monitor::read_job_accounting` and `parse_accounting_output` (Task 2), `SlurmApptainerBackendConfig.job_accounting` (Task 1).
+- Produces: `Monitor::write_job_accounting(job_id: u64, attempt_dir: &Path)` (async, returns `()`), used only within this file.
+
+- [ ] **Step 1: Add `Monitor::write_job_accounting`**
+
+In `crates/wdl-engine/src/backend/slurm_apptainer.rs`, find the end of `Monitor::read_job_accounting` you added in Task 2 (the closing of the outer function, right before `read_jobs`):
+
+```rust
+        Retry::spawn_notify(
+            ExponentialBackoff::from_millis(ACCOUNTING_RETRY_INITIAL_DELAY_MS)
+                .max_delay_millis(ACCOUNTING_RETRY_MAX_DELAY_MS)
+                .take(ACCOUNTING_RETRY_ATTEMPTS),
+            || try_read(job_id),
+            |e: &anyhow::Error, _| {
+                warn!(e = %e, "retrying `sacct` accounting query for Slurm job `{job_id}`");
+            },
+        )
+        .await
+    }
+
+    /// Reads the current jobs using `sacct`.
+```
+
+Insert a new method between them:
+
+```rust
+        Retry::spawn_notify(
+            ExponentialBackoff::from_millis(ACCOUNTING_RETRY_INITIAL_DELAY_MS)
+                .max_delay_millis(ACCOUNTING_RETRY_MAX_DELAY_MS)
+                .take(ACCOUNTING_RETRY_ATTEMPTS),
+            || try_read(job_id),
+            |e: &anyhow::Error, _| {
+                warn!(e = %e, "retrying `sacct` accounting query for Slurm job `{job_id}`");
+            },
+        )
+        .await
+    }
+
+    /// Best-effort: gathers final accounting information for a terminated job
+    /// and writes it to [`ACCOUNTING_FILE_NAME`] in the task's attempt
+    /// directory.
+    ///
+    /// Failures are logged and otherwise ignored; this must never affect the
+    /// task's own result.
+    async fn write_job_accounting(job_id: u64, attempt_dir: &Path) {
+        let output = match Self::read_job_accounting(job_id).await {
+            Ok(output) => output,
+            Err(e) => {
+                warn!("failed to gather Slurm accounting information for job `{job_id}`: {e:#}");
+                return;
+            }
+        };
+
+        let records = match parse_accounting_output(&output) {
+            Ok(records) => records,
+            Err(e) => {
+                warn!("failed to parse Slurm accounting information for job `{job_id}`: {e:#}");
+                return;
+            }
+        };
+
+        let contents = match serde_json::to_vec_pretty(&records) {
+            Ok(contents) => contents,
+            Err(e) => {
+                warn!(
+                    "failed to serialize Slurm accounting information for job `{job_id}`: {e:#}"
+                );
+                return;
+            }
+        };
+
+        let path = attempt_dir.join(ACCOUNTING_FILE_NAME);
+        if let Err(e) = fs::write(&path, contents).await {
+            warn!(
+                path = %path.display(),
+                "failed to write Slurm accounting information for job `{job_id}`: {e:#}"
+            );
+        }
+    }
+
+    /// Reads the current jobs using `sacct`.
+```
+
+- [ ] **Step 2: Call it from `execute()`, gated by config**
+
+Find:
+
+```rust
+                result = job.completed => match result.context("failed to wait for task to complete")? {
+                    Ok(exit_code) => {
+                        let exit_status = exit_code.into_exit_status();
+```
+
+Replace with:
+
+```rust
+                result = job.completed => {
+                    if backend_config.job_accounting.unwrap_or(true) {
+                        Monitor::write_job_accounting(job_id, request.attempt_dir).await;
+                    }
+
+                    match result.context("failed to wait for task to complete")? {
+                    Ok(exit_code) => {
+                        let exit_status = exit_code.into_exit_status();
+```
+
+Then find the end of that same `match` (it currently closes the `select!` arm directly):
+
+```rust
+                        return Err(e);
+                    }
+                }
+            };
+```
+
+Replace with (adding the extra closing brace for the new `{ ... }` block wrapping the `match`):
+
+```rust
+                        return Err(e);
+                    }
+                }
+                }
+            };
+```
+
+- [ ] **Step 3: Run `cargo fmt` to fix indentation**
+
+Run: `cargo --locked fmt -p wdl-engine`
+
+This is expected to reformat the block from Steps 1-2 into consistent indentation — inspect the diff afterward and confirm the braces still match Rust's structure (one `match` nested inside one `if`-guarded block, itself the body of the `result = job.completed =>` arm).
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo check -p wdl-engine`
+Expected: no errors. (`job_id` and `request` are already in scope at this point in `execute()` — `job_id` from `let job_id = job.id;` earlier, `request` is the function parameter.)
+
+- [ ] **Step 5: Run clippy**
+
+Run: `cargo --locked clippy -p wdl-engine --tests --all-features -- --deny warnings`
+Expected: no warnings.
+
+- [ ] **Step 6: Manual verification (no live Slurm cluster in CI)**
+
+This module has no CLI-mocking test harness (module doc: "currently tested by hand"). If you have access to a Slurm cluster with the `slurm_apptainer` backend configured (see `test-configs/slurm-apptainer-engine.toml`), run a task through `sprocket run` and confirm `sacct.json` appears in the task's attempt directory (`<run_dir>/.../attempts/<n>/sacct.json`) with a non-empty JSON array. If no cluster is available, skip this step and note it in the PR description.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/wdl-engine/src/backend/slurm_apptainer.rs
+git commit -m "feat(slurm): write sacct accounting dump on job completion"
+```
+
+---
+
+### Task 4: LSF accounting fetch/parse (pure functions + tests)
+
+**Files:**
+- Modify: `crates/wdl-engine/src/backend/lsf_apptainer.rs`
+- Test: same file, existing `#[cfg(test)] mod tests` block (`lsf_apptainer.rs:1041-1052`)
+
+**Interfaces:**
+- Consumes: nothing new from other tasks.
+- Produces: `Monitor::read_job_accounting(job_id: u64) -> Result<Vec<serde_json::Value>>` (async), `parse_accounting_output(output: &[u8]) -> Result<Vec<serde_json::Value>>`, `ACCOUNTING_FIELDS: &str`, `ACCOUNTING_FILE_NAME: &str`. Task 5 calls `Monitor::read_job_accounting`.
+
+- [ ] **Step 1: Add the new imports**
+
+In `crates/wdl-engine/src/backend/lsf_apptainer.rs`, find:
+
+```rust
+use tokio::time::MissedTickBehavior;
+use tokio_util::sync::CancellationToken;
+```
+
+Replace with:
+
+```rust
+use tokio::time::MissedTickBehavior;
+use tokio_retry2::Retry;
+use tokio_retry2::RetryError;
+use tokio_retry2::strategy::ExponentialBackoff;
+use tokio_util::sync::CancellationToken;
+```
+
+- [ ] **Step 2: Add the new constants**
+
+Find the LSF equivalent of the Slurm monitor-interval/concurrency constants (search for `MONITOR_TAG_LENGTH` or the constant block near the top of the file — insert immediately after whichever default-concurrency constant already exists there, in the same style as Task 2 Step 2 for Slurm):
+
+```rust
+/// The name of the file where a job's final accounting information (from
+/// `bjobs`) is written.
+const ACCOUNTING_FILE_NAME: &str = "bjobs.json";
+
+/// The fields requested from `bjobs` when gathering final accounting
+/// information for a single terminated job.
+///
+/// This is a superset of the fields used for state-polling (`bjobs -json -o
+/// "jobid stat exit_code max_mem avg_mem cpu_used ru_utime ru_stime"`,
+/// `lsf_apptainer.rs:633`), since this query is only made once per job (on
+/// termination) rather than on every monitor tick.
+///
+/// LSF has no reliably version-stable GPU/generic-resource equivalent to
+/// Slurm's `TRES` fields, so none is requested here.
+const ACCOUNTING_FIELDS: &str = "jobid stat exit_code max_mem avg_mem cpu_used ru_utime \
+     ru_stime submit_time start_time finish_time exec_host queue job_name";
+
+/// The initial delay, in milliseconds, before retrying a failed or
+/// incomplete accounting query.
+const ACCOUNTING_RETRY_INITIAL_DELAY_MS: u64 = 500;
+
+/// The maximum delay, in milliseconds, between accounting query retries.
+const ACCOUNTING_RETRY_MAX_DELAY_MS: u64 = 5_000;
+
+/// The maximum number of attempts made to gather a job's accounting
+/// information before giving up.
+const ACCOUNTING_RETRY_ATTEMPTS: usize = 5;
+```
+
+- [ ] **Step 3: Add `parse_accounting_output`**
+
+Find the end of `read_job_records` (the closing `}` of that function, still inside `impl Monitor`):
+
+```rust
+        Ok(serde_json::from_str::<Output>(
+            str::from_utf8(&output.stdout).map_err(|_| anyhow!("`bjobs` output was not UTF-8"))?,
+        )
+        .context("failed to deserialize `bjobs` output")?
+        .records)
+    }
+}
+```
+
+Replace with:
+
+```rust
+        Ok(serde_json::from_str::<Output>(
+            str::from_utf8(&output.stdout).map_err(|_| anyhow!("`bjobs` output was not UTF-8"))?,
+        )
+        .context("failed to deserialize `bjobs` output")?
+        .records)
+    }
+}
+
+/// Deserializes the JSON output of a `bjobs -json` accounting query (using
+/// [`ACCOUNTING_FIELDS`]) into the job's accounting records.
+///
+/// Kept separate from [`Monitor::read_job_records`] since that one is typed
+/// to the polling-specific `JobRecord` shape, while this is used only for
+/// the best-effort `bjobs.json` accounting dump and keeps each record as a
+/// generic JSON value.
+fn parse_accounting_output(output: &[u8]) -> Result<Vec<serde_json::Value>> {
+    #[derive(Deserialize)]
+    struct Output {
+        /// The output records.
+        #[serde(rename = "RECORDS")]
+        records: Vec<serde_json::Value>,
+    }
+
+    Ok(serde_json::from_slice::<Output>(output)
+        .context("failed to deserialize `bjobs` output")?
+        .records)
+}
+```
+
+- [ ] **Step 4: Add `Monitor::read_job_accounting`**
+
+Find (still inside `impl Monitor`, directly before `read_job_records`):
+
+```rust
+    /// Reads the current job records using `bjobs`.
+    async fn read_job_records(search_prefix: &str) -> Result<Vec<JobRecord>> {
+```
+
+Replace with:
+
+```rust
+    /// Reads final accounting information for a single terminated job using
+    /// `bjobs`, retrying briefly since LSF's accounting data can lag behind
+    /// job termination.
+    async fn read_job_accounting(job_id: u64) -> Result<Vec<serde_json::Value>> {
+        async fn try_read(
+            job_id: u64,
+        ) -> Result<Vec<serde_json::Value>, RetryError<anyhow::Error>> {
+            let mut command = Command::new("bjobs");
+            let command = command
+                .arg("-a")
+                .arg("-json")
+                .arg("-o")
+                .arg(ACCOUNTING_FIELDS)
+                .arg(job_id.to_string())
+                .stdin(Stdio::null())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+
+            trace!(?command, "spawning `bjobs` to gather job accounting information");
+
+            let child = command
+                .spawn()
+                .context("failed to spawn `bjobs` command")
+                .map_err(RetryError::transient)?;
+
+            let output = child
+                .wait_with_output()
+                .await
+                .context("failed to wait for `bjobs` to exit")
+                .map_err(RetryError::transient)?;
+            if !output.status.success() {
+                return Err(RetryError::transient(anyhow!(
+                    "`bjobs` failed: {status}: {stderr}",
+                    status = output.status,
+                    stderr = str::from_utf8(&output.stderr)
+                        .unwrap_or("<output not UTF-8>")
+                        .trim()
+                )));
+            }
+
+            let records =
+                parse_accounting_output(&output.stdout).map_err(RetryError::transient)?;
+            if records.is_empty() {
+                return Err(RetryError::transient(anyhow!(
+                    "`bjobs` returned no accounting records for LSF job `{job_id}`"
+                )));
+            }
+
+            Ok(records)
+        }
+
+        Retry::spawn_notify(
+            ExponentialBackoff::from_millis(ACCOUNTING_RETRY_INITIAL_DELAY_MS)
+                .max_delay_millis(ACCOUNTING_RETRY_MAX_DELAY_MS)
+                .take(ACCOUNTING_RETRY_ATTEMPTS),
+            || try_read(job_id),
+            |e: &anyhow::Error, _| {
+                warn!(e = %e, "retrying `bjobs` accounting query for LSF job `{job_id}`");
+            },
+        )
+        .await
+    }
+
+    /// Reads the current job records using `bjobs`.
+    async fn read_job_records(search_prefix: &str) -> Result<Vec<JobRecord>> {
+```
+
+- [ ] **Step 5: Write the failing tests**
+
+Find the existing test module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn job_name_truncates() {
+        let name = "é".repeat(LSF_JOB_NAME_MAX_LENGTH);
+        assert_eq!(name.len(), 8188);
+        let name = truncate_job_name(&name);
+        assert!(name.len() < LSF_JOB_NAME_MAX_LENGTH);
+    }
+}
+```
+
+Replace with:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn job_name_truncates() {
+        let name = "é".repeat(LSF_JOB_NAME_MAX_LENGTH);
+        assert_eq!(name.len(), 8188);
+        let name = truncate_job_name(&name);
+        assert!(name.len() < LSF_JOB_NAME_MAX_LENGTH);
+    }
+
+    #[test]
+    fn parses_accounting_records() {
+        let output = br#"{"RECORDS":[{"JOBID":"12345","STAT":"DONE","MAX_MEM":"512M"}]}"#;
+        let records = parse_accounting_output(output).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["JOBID"], "12345");
+        assert_eq!(records[0]["MAX_MEM"], "512M");
+    }
+
+    #[test]
+    fn empty_records_array_parses_to_empty_vec() {
+        let output = br#"{"RECORDS":[]}"#;
+        let records = parse_accounting_output(output).unwrap();
+        assert!(records.is_empty());
+    }
+
+    #[test]
+    fn invalid_json_is_an_error() {
+        assert!(parse_accounting_output(b"not json").is_err());
+    }
+}
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `cargo test -p wdl-engine --lib backend::lsf_apptainer::tests`
+Expected: 4 tests PASS (`job_name_truncates`, `parses_accounting_records`, `empty_records_array_parses_to_empty_vec`, `invalid_json_is_an_error`).
+
+- [ ] **Step 7: Run fmt and clippy**
+
+Run: `cargo --locked fmt -- --check && cargo --locked clippy -p wdl-engine --tests --all-features -- --deny warnings`
+Expected: no diffs, no warnings.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/wdl-engine/src/backend/lsf_apptainer.rs
+git commit -m "feat(lsf): add bjobs accounting fetch and parsing"
+```
+
+---
+
+### Task 5: Wire the LSF accounting dump into `execute()`, changelog, final verification
+
+**Files:**
+- Modify: `crates/wdl-engine/src/backend/lsf_apptainer.rs:979-1015` (inside `execute()`)
+- Modify: `crates/wdl-engine/CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: `Monitor::read_job_accounting` (Task 4), `LsfApptainerBackendConfig.job_accounting` (Task 1).
+- Produces: `Monitor::write_job_accounting(job_id: u64, attempt_dir: &Path)` (async, returns `()`), used only within this file.
+
+- [ ] **Step 1: Add `Monitor::write_job_accounting`**
+
+In `crates/wdl-engine/src/backend/lsf_apptainer.rs`, find the end of `Monitor::read_job_accounting` (added in Task 4), right before `read_job_records`:
+
+```rust
+        Retry::spawn_notify(
+            ExponentialBackoff::from_millis(ACCOUNTING_RETRY_INITIAL_DELAY_MS)
+                .max_delay_millis(ACCOUNTING_RETRY_MAX_DELAY_MS)
+                .take(ACCOUNTING_RETRY_ATTEMPTS),
+            || try_read(job_id),
+            |e: &anyhow::Error, _| {
+                warn!(e = %e, "retrying `bjobs` accounting query for LSF job `{job_id}`");
+            },
+        )
+        .await
+    }
+
+    /// Reads the current job records using `bjobs`.
+```
+
+Insert a new method between them:
+
+```rust
+        Retry::spawn_notify(
+            ExponentialBackoff::from_millis(ACCOUNTING_RETRY_INITIAL_DELAY_MS)
+                .max_delay_millis(ACCOUNTING_RETRY_MAX_DELAY_MS)
+                .take(ACCOUNTING_RETRY_ATTEMPTS),
+            || try_read(job_id),
+            |e: &anyhow::Error, _| {
+                warn!(e = %e, "retrying `bjobs` accounting query for LSF job `{job_id}`");
+            },
+        )
+        .await
+    }
+
+    /// Best-effort: gathers final accounting information for a terminated job
+    /// and writes it to [`ACCOUNTING_FILE_NAME`] in the task's attempt
+    /// directory.
+    ///
+    /// Failures are logged and otherwise ignored; this must never affect the
+    /// task's own result.
+    async fn write_job_accounting(job_id: u64, attempt_dir: &Path) {
+        let records = match Self::read_job_accounting(job_id).await {
+            Ok(records) => records,
+            Err(e) => {
+                warn!("failed to gather LSF accounting information for job `{job_id}`: {e:#}");
+                return;
+            }
+        };
+
+        let contents = match serde_json::to_vec_pretty(&records) {
+            Ok(contents) => contents,
+            Err(e) => {
+                warn!("failed to serialize LSF accounting information for job `{job_id}`: {e:#}");
+                return;
+            }
+        };
+
+        let path = attempt_dir.join(ACCOUNTING_FILE_NAME);
+        if let Err(e) = fs::write(&path, contents).await {
+            warn!(
+                path = %path.display(),
+                "failed to write LSF accounting information for job `{job_id}`: {e:#}"
+            );
+        }
+    }
+
+    /// Reads the current job records using `bjobs`.
+```
+
+- [ ] **Step 2: Call it from `execute()`, gated by config**
+
+Find:
+
+```rust
+                result = job.completed => match result.context("failed to wait for task to complete")? {
+                    Ok(exit_code) => {
+                        // See WEXITSTATUS from wait(2) to explain the shift and masking here
+```
+
+Replace with:
+
+```rust
+                result = job.completed => {
+                    if backend_config.job_accounting.unwrap_or(true) {
+                        Monitor::write_job_accounting(job_id, request.attempt_dir).await;
+                    }
+
+                    match result.context("failed to wait for task to complete")? {
+                    Ok(exit_code) => {
+                        // See WEXITSTATUS from wait(2) to explain the shift and masking here
+```
+
+Then find the end of that same `match`:
+
+```rust
+                        return Err(e);
+                    }
+                }
+            };
+```
+
+Replace with:
+
+```rust
+                        return Err(e);
+                    }
+                }
+                }
+            };
+```
+
+- [ ] **Step 3: Run `cargo fmt` to fix indentation**
+
+Run: `cargo --locked fmt -p wdl-engine`
+
+Inspect the diff afterward, same as Task 3 Step 3.
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cargo check -p wdl-engine`
+Expected: no errors.
+
+- [ ] **Step 5: Add the changelog entry**
+
+In `crates/wdl-engine/CHANGELOG.md`, find:
+
+```markdown
+## Unreleased
+
+## 0.17.0 - 2026-07-15
+```
+
+Replace with:
+
+```markdown
+## Unreleased
+
+#### Added
+
+* Added a `job_accounting` configuration option (defaults to `true`) to the Slurm and LSF Apptainer backends: once a task's job reaches a terminal state, the backend gathers accounting information via `sacct`/`bjobs` and writes it to `sacct.json`/`bjobs.json` in the task's attempt directory. This is best-effort and never affects the task's own result.
+
+## 0.17.0 - 2026-07-15
+```
+
+- [ ] **Step 6: Run the full test suite and lints**
+
+Run:
+
+```bash
+cargo test -p wdl-engine --lib backend::
+cargo test -p sprocket --lib config::test
+cargo --locked fmt -- --check
+cargo --locked clippy --workspace --tests --all-features -- --deny warnings
+```
+
+Expected: all PASS, no fmt diff, no clippy warnings.
+
+- [ ] **Step 7: Manual verification (no live LSF cluster in CI)**
+
+Same caveat as Task 3 Step 6 — if you have access to an LSF cluster with the `lsf_apptainer` backend configured, run a task and confirm `bjobs.json` appears in the attempt directory with a non-empty JSON array. Otherwise skip and note it in the PR description.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add crates/wdl-engine/src/backend/lsf_apptainer.rs crates/wdl-engine/CHANGELOG.md
+git commit -m "feat(lsf): write bjobs accounting dump on job completion"
+```

--- a/docs/superpowers/specs/2026-07-21-slurm-lsf-accounting-dump-design.md
+++ b/docs/superpowers/specs/2026-07-21-slurm-lsf-accounting-dump-design.md
@@ -36,6 +36,27 @@ and `slurm_apptainer.rs:1013-1021`). Writing one more file there follows the
 existing pattern exactly, needs no schema migration, and works identically
 whether or not the sprocket binary's DB is even in play.
 
+## Configuration
+
+Each backend's config struct gets a new `job_accounting: bool` field,
+opt-out, defaulting to `true`, following the existing `cleanup` field on
+`DockerBackendConfig` (`config.rs:1516-1529`) as the pattern: a
+`default_*_job_accounting() -> bool { true }` function referenced via
+`#[toml(default = ...)]` / `#[schemars(default = "...")]`.
+
+```toml
+[backend.slurm_apptainer]
+job_accounting = false  # opt out; defaults to true
+
+[backend.lsf_apptainer]
+job_accounting = false  # opt out; defaults to true
+```
+
+Added to `SlurmApptainerBackendConfig` (`config.rs:2545`) and
+`LsfApptainerBackendConfig` (`config.rs:2317`). When `false`, the backend
+skips the extra `sacct`/`bjobs` call and the JSON file entirely — no
+behavior change beyond that from today.
+
 ## Trigger point
 
 Both backends have the same `execute()` shape: after submitting the job, they
@@ -104,6 +125,8 @@ silent mismatch with the Slurm side.
 
 ## Error handling
 
+- If `job_accounting` is `false`, skip the extra call and file write
+  entirely — not treated as an error, just a no-op.
 - Spawn failure, non-zero exit, or non-UTF8 output from the extra
   `sacct`/`bjobs` call: log `warn!` with the error, skip writing the file.
 - Parse/deserialize failure on otherwise-successful output: same — `warn!`

--- a/docs/superpowers/specs/2026-07-21-slurm-lsf-accounting-dump-design.md
+++ b/docs/superpowers/specs/2026-07-21-slurm-lsf-accounting-dump-design.md
@@ -123,12 +123,36 @@ LSF has no reliably version-stable GPU/generic-resource equivalent to
 Slurm's `TRES` fields, so none is included — this is a known gap, not a
 silent mismatch with the Slurm side.
 
+## Retrying on accounting lag
+
+Slurm's `slurmdbd` (and LSF's accounting backend) can take a few seconds to
+catch up after a job terminates, particularly for the `.batch` step's
+memory/IO stats. Rather than write a bespoke retry loop, reuse
+`tokio_retry2`, already a workspace dependency and already used for exactly
+this shape of problem in `backend/apptainer.rs:327-345` (`Retry::spawn_notify`
+with an `ExponentialBackoff` strategy, logging a `warn!` on each failed
+attempt via the notify callback).
+
+The accounting fetch is retried when:
+- the `sacct`/`bjobs` invocation itself fails (spawn error, non-zero exit,
+  non-UTF8 output), or
+- the invocation succeeds but returns zero matching records for the job
+  (the signal that the accounting DB hasn't caught up yet).
+
+Backoff parameters are intentionally much shorter than the image-pull retry
+(which budgets up to 60s for registry flakiness) since this is short-lived DB
+propagation lag, not network flakiness: `ExponentialBackoff::from_millis(500)
+.max_delay_millis(5_000).take(5)` — a handful of attempts capped at a few
+seconds each, a few seconds of total worst-case added latency after job
+completion.
+
 ## Error handling
 
 - If `job_accounting` is `false`, skip the extra call and file write
   entirely — not treated as an error, just a no-op.
-- Spawn failure, non-zero exit, or non-UTF8 output from the extra
-  `sacct`/`bjobs` call: log `warn!` with the error, skip writing the file.
+- If all retries are exhausted (command keeps failing, or the accounting DB
+  never returns records within the retry budget): log a `warn!`, skip
+  writing the file.
 - Parse/deserialize failure on otherwise-successful output: same — `warn!`
   and skip.
 - None of the above ever change the `TaskExecutionResult` or cause the task
@@ -141,4 +165,7 @@ docs say "tested by hand"; `lsf_apptainer.rs:1041-1052` has exactly one
 plain `#[test]` unit test as the only existing precedent). Add unit tests
 that feed canned `sacct`/`bjobs` output text through the new parsing
 function and assert the resulting JSON shape, following that same pattern.
-No mocking framework, no integration harness.
+Also unit test the "should this be retried" predicate (empty output vs. a
+populated record set) directly, since that's the one piece of new decision
+logic; the retry/backoff mechanics themselves come from `tokio_retry2` and
+don't need re-testing. No mocking framework, no integration harness.

--- a/docs/superpowers/specs/2026-07-21-slurm-lsf-accounting-dump-design.md
+++ b/docs/superpowers/specs/2026-07-21-slurm-lsf-accounting-dump-design.md
@@ -1,0 +1,121 @@
+# Slurm/LSF job accounting dump
+
+## Context
+
+The `slurm_apptainer` backend already shells out to `sacct` to poll job state
+(`crates/wdl-engine/src/backend/slurm_apptainer.rs:733-765`), and the `sacct`
+output is already parsed into a `JobRecord` that includes CPU-time and
+virtual-memory fields (`slurm_apptainer.rs:262-283`). Once a job reaches a
+terminal state, those fields are used for exactly one `debug!` log line
+(`slurm_apptainer.rs:463-474`) and then discarded. The `lsf_apptainer` backend
+has the identical shape: `bjobs -json` polling
+(`crates/wdl-engine/src/backend/lsf_apptainer.rs:616-660`) parses memory/CPU
+fields into a `JobRecord` (`lsf_apptainer.rs:163-190`) that are likewise only
+logged (`lsf_apptainer.rs:317-328`) and dropped.
+
+We want to stop throwing this away. After a Slurm or LSF job finishes
+(successfully or not), gather as much accounting information as `sacct`/
+`bjobs` will give us and make it available for later inspection, without
+requiring the sprocket binary's SQLite layer or any new dependency.
+
+## Why a file, not the database
+
+`wdl-engine` (where these backends live) is storage-agnostic by design — it
+has no dependency on the `sprocket` binary's SQLite `tasks` table
+(`migrations/20251108201315_initial.up.sql:116-139`) or its `Database` trait
+(`src/system/v1/db.rs`). The only channel backends have to the outside world
+is `crankshaft`'s `Event` enum, which is a fixed vocabulary from an external
+crates.io dependency (`crankshaft = "0.10.0"` in `Cargo.toml:49`, not a
+workspace member) — `TaskCompleted`/`TaskFailed` have no slot for arbitrary
+metadata, and extending them would mean forking an upstream crate.
+
+Both backends already write several per-attempt files directly to
+`request.attempt_dir` (`command`, `stdout`, `stderr`, `apptainer_command`,
+`slurm.stdout`/`slurm.stderr` — see `crates/wdl-engine/src/backend.rs:227-253`
+and `slurm_apptainer.rs:1013-1021`). Writing one more file there follows the
+existing pattern exactly, needs no schema migration, and works identically
+whether or not the sprocket binary's DB is even in play.
+
+## Trigger point
+
+Both backends have the same `execute()` shape: after submitting the job, they
+`tokio::select!` on cancellation vs. the job's completion oneshot
+(`slurm_apptainer.rs:1070-1111`, analogous LSF code). The accounting dump is
+gathered **only** on the completion-oneshot arm (`Ok(exit_code)` or
+`Err(e)`) — i.e., only when the job reached a terminal state on its own
+(completed, failed, timed out, OOM-killed, etc.). It is **not** gathered on
+the cancellation branches (`task_token.cancelled()` / `token.cancelled()`,
+which call `scancel`/`bkill` and return early) — a user-initiated cancellation
+is out of scope for "the job finished."
+
+The dump is best-effort: if the extra `sacct`/`bjobs` call fails (binary
+missing, job already purged from the accounting DB, non-UTF8 output, etc.),
+log a `warn!` and skip writing the file. It must never change the task's own
+exit code or turn a successful/failed task result into a different outcome.
+
+## Slurm: fields and format
+
+A dedicated call, separate from the existing multi-job polling call (which
+stays as-is, since it's tuned for polling many jobs cheaply in one shot):
+
+```
+sacct -P -n --format=<fields> -j <job_id>
+```
+
+Unlike the polling call, this one does **not** filter out job-step lines
+(the existing polling code skips any job id containing `.`,
+`slurm_apptainer.rs:413`). Slurm frequently only reports memory/IO stats on
+the `.batch`/`.extern` step lines rather than the parent job line, so all
+lines returned for the job id are kept.
+
+Field list:
+
+```
+JobID,JobName,Partition,State,ExitCode,NodeList,Submit,Start,End,Elapsed,
+AllocCPUS,ReqMem,ReqTRES,AllocTRES,MaxRSS,MaxVMSize,AveRSS,AveVMSize,
+TotalCPU,UserCPU,SystemCPU,MaxDiskRead,MaxDiskWrite
+```
+
+(`ReqTRES`/`AllocTRES` capture GPU/generic-resource allocation.)
+
+Each `sacct` line is parsed into a JSON object keyed by field name (values
+kept as the raw strings `sacct` emits — no unit/duration parsing). The full
+set of lines for the job is written as a JSON array to
+`attempt_dir/sacct.json`.
+
+## LSF: fields and format
+
+The existing polling call already asks for JSON output
+(`bjobs -json -o "..."`, `lsf_apptainer.rs:626-636`) and already deserializes
+a `RECORDS` array. For the completion dump, widen the `-o` field list for a
+single-job call and write the `RECORDS` array straight to
+`attempt_dir/bjobs.json` — no custom parsing needed, since it's already JSON.
+
+Field list:
+
+```
+jobid stat exit_code max_mem avg_mem cpu_used ru_utime ru_stime
+submit_time start_time finish_time exec_host queue job_name
+```
+
+LSF has no reliably version-stable GPU/generic-resource equivalent to
+Slurm's `TRES` fields, so none is included — this is a known gap, not a
+silent mismatch with the Slurm side.
+
+## Error handling
+
+- Spawn failure, non-zero exit, or non-UTF8 output from the extra
+  `sacct`/`bjobs` call: log `warn!` with the error, skip writing the file.
+- Parse/deserialize failure on otherwise-successful output: same — `warn!`
+  and skip.
+- None of the above ever change the `TaskExecutionResult` or cause the task
+  to be reported as failed.
+
+## Testing
+
+Neither backend has any live-cluster test infrastructure today (both module
+docs say "tested by hand"; `lsf_apptainer.rs:1041-1052` has exactly one
+plain `#[test]` unit test as the only existing precedent). Add unit tests
+that feed canned `sacct`/`bjobs` output text through the new parsing
+function and assert the resulting JSON shape, following that same pattern.
+No mocking framework, no integration harness.

--- a/docs/superpowers/specs/2026-07-21-slurm-lsf-accounting-dump-design.md
+++ b/docs/superpowers/specs/2026-07-21-slurm-lsf-accounting-dump-design.md
@@ -38,11 +38,19 @@ whether or not the sprocket binary's DB is even in play.
 
 ## Configuration
 
-Each backend's config struct gets a new `job_accounting: bool` field,
-opt-out, defaulting to `true`, following the existing `cleanup` field on
-`DockerBackendConfig` (`config.rs:1516-1529`) as the pattern: a
-`default_*_job_accounting() -> bool { true }` function referenced via
-`#[toml(default = ...)]` / `#[schemars(default = "...")]`.
+Each backend's config struct gets a new `job_accounting: Option<bool>` field,
+opt-out, defaulting to `true` when absent. Both `SlurmApptainerBackendConfig`
+(`config.rs:2545`) and `LsfApptainerBackendConfig` (`config.rs:2317`) derive
+`Default`, so a plain `bool` field with a `#[toml(default = ...)]` attribute
+(the pattern `DockerBackendConfig.cleanup` uses, `config.rs:1516-1529`) would
+be inconsistent: TOML deserialization would default it to `true`, but a bare
+`Default::default()` call would give `false`, since `DockerBackendConfig`
+doesn't derive `Default` at all and doesn't hit that conflict. These two
+structs already have an established convention for exactly this situation —
+`interval: Option<u64>` and `max_concurrency: Option<u32>`, both defaulted at
+the call site via `.unwrap_or(DEFAULT_CONST)` (`slurm_apptainer.rs:802`,
+`809`) — so `job_accounting` follows that instead: `Option<bool>`, resolved
+via `backend_config.job_accounting.unwrap_or(true)` where it's read.
 
 ```toml
 [backend.slurm_apptainer]
@@ -52,10 +60,8 @@ job_accounting = false  # opt out; defaults to true
 job_accounting = false  # opt out; defaults to true
 ```
 
-Added to `SlurmApptainerBackendConfig` (`config.rs:2545`) and
-`LsfApptainerBackendConfig` (`config.rs:2317`). When `false`, the backend
-skips the extra `sacct`/`bjobs` call and the JSON file entirely — no
-behavior change beyond that from today.
+When `false`, the backend skips the extra `sacct`/`bjobs` call and the JSON
+file entirely — no behavior change beyond that from today.
 
 ## Trigger point
 

--- a/jsonschemas/sprocket.toml.json
+++ b/jsonschemas/sprocket.toml.json
@@ -691,6 +691,13 @@
               "format": "uint32",
               "minimum": 0
             },
+            "job_accounting": {
+              "description": "Whether to gather LSF accounting information for a task's job via\n`bjobs` once the job reaches a terminal state, writing it to\n`bjobs.json` in the task's attempt directory.\n\nThis is best-effort: failures gathering this information are logged\nbut never affect the task's own result.\n\nDefaults to `true`.",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
             "default_lsf_queue": {
               "description": "Which queue, if any, to specify when submitting normal jobs to LSF.\n\nThis may be superseded by\n[`short_task_lsf_queue`][Self::short_task_lsf_queue],\n[`gpu_lsf_queue`][Self::gpu_lsf_queue], or\n[`fpga_lsf_queue`][Self::fpga_lsf_queue] for corresponding tasks.",
               "anyOf": [
@@ -780,6 +787,13 @@
               ],
               "format": "uint32",
               "minimum": 0
+            },
+            "job_accounting": {
+              "description": "Whether to gather Slurm accounting information for a task's job via\n`sacct` once the job reaches a terminal state, writing it to\n`sacct.json` in the task's attempt directory.\n\nThis is best-effort: failures gathering this information are logged\nbut never affect the task's own result.\n\nDefaults to `true`.",
+              "type": [
+                "boolean",
+                "null"
+              ]
             },
             "default_slurm_partition": {
               "description": "Which partition, if any, to specify when submitting normal jobs to\nSlurm.\n\nThis may be superseded by\n[`short_task_slurm_partition`][Self::short_task_slurm_partition],\n[`gpu_slurm_partition`][Self::gpu_slurm_partition], or\n[`fpga_slurm_partition`][Self::fpga_slurm_partition] for corresponding\ntasks.",


### PR DESCRIPTION
## Summary
- After a Slurm or LSF job finishes on its own (completed, failed, timed out, OOM-killed, etc. — not on user-initiated cancellation), the `slurm_apptainer`/`lsf_apptainer` backends now gather accounting information via `sacct`/`bjobs` and write it as JSON (`sacct.json`/`bjobs.json`) into the task's attempt directory, alongside the existing `stdout`/`stderr`/`command` files.
- The fetch retries briefly (up to 5 attempts, 500ms–5s exponential backoff, reusing the `tokio-retry2` pattern already used for Apptainer image pulls) since Slurm's/LSF's accounting databases can lag behind job termination.
- New `job_accounting: Option<bool>` config field on both backends, default `true`, opt-out.
- Entirely best-effort: any failure in the new code path only logs a `warn!` and never affects the task's own result.
- Design doc: `docs/superpowers/specs/2026-07-21-slurm-lsf-accounting-dump-design.md`
- Implementation plan: `docs/superpowers/plans/2026-07-21-slurm-lsf-accounting-dump.md`

## Test plan
- [x] `cargo test -p wdl-engine --lib backend::` — all passing except one pre-existing, unrelated failure (`example_task_shellchecks`, missing `shellcheck` binary in this environment)
- [x] `cargo test -p sprocket --lib config::test` — schema and config tests passing
- [x] `cargo --locked fmt -- --check`
- [x] `cargo --locked clippy --workspace --tests --all-features -- --deny warnings`
- [ ] Manual verification against a live Slurm/LSF cluster (not available in this environment — noted as a gap for a maintainer with cluster access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)