### PR TITLE
chore(gauntlet): bump `wilds-wdl-library`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,9 +59,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.3"
+version = "4.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
+checksum = "dc6d763210e2eb7670d1a5183a08bebefa3f97db2a738a684f2ce00bd49f681d"
 dependencies = [
  "cssparser",
  "html5ever",

--- a/crates/gauntlet/Arena.toml
+++ b/crates/gauntlet/Arena.toml
@@ -1,6 +1,6 @@
 [repositories."getwilds/wilds-wdl-library"]
 identifier = "getwilds/wilds-wdl-library"
-commit_hash = "404b3b6b4138b43ba33d08edbde6510a39be5a27"
+commit_hash = "659d5802cc65695b211ae9b72d9095524b33734b"
 
 [repositories."stjudecloud/workflows"]
 identifier = "stjudecloud/workflows"
@@ -9,4167 +9,4547 @@ commit_hash = "f421780da5596243cf6d8ffc341b3d3ba2c23c13"
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annotsv/testrun.wdl"
 message = "testrun.wdl:54:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annotsv/testrun.wdl/#L54"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annotsv/testrun.wdl/#L54"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annotsv/testrun.wdl"
 message = "testrun.wdl:57:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annotsv/testrun.wdl/#L57"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annotsv/testrun.wdl/#L57"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annotsv/testrun.wdl"
 message = "testrun.wdl:69:40: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annotsv/testrun.wdl/#L69"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annotsv/testrun.wdl/#L69"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annotsv/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `annotsv_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annotsv/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annotsv/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annotsv/testrun.wdl"
 message = "testrun.wdl:83:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annotsv/testrun.wdl/#L83"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annotsv/testrun.wdl/#L83"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annotsv/testrun.wdl"
 message = "testrun.wdl:98:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annotsv/testrun.wdl/#L98"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annotsv/testrun.wdl/#L98"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annotsv/ww-annotsv.wdl"
 message = "ww-annotsv.wdl:27:3: note[ParameterMetaMatched]: parameter metadata in task `annotsv_annotate` is out of order"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annotsv/ww-annotsv.wdl/#L27"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annotsv/ww-annotsv.wdl/#L27"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annotsv/ww-annotsv.wdl"
 message = "ww-annotsv.wdl:65:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annotsv/ww-annotsv.wdl/#L65"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annotsv/ww-annotsv.wdl/#L65"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annotsv/ww-annotsv.wdl"
 message = "ww-annotsv.wdl:76:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annotsv/ww-annotsv.wdl/#L76"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annotsv/ww-annotsv.wdl/#L76"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annotsv/ww-annotsv.wdl"
 message = "ww-annotsv.wdl:77:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annotsv/ww-annotsv.wdl/#L77"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annotsv/ww-annotsv.wdl/#L77"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annotsv/ww-annotsv.wdl"
 message = "ww-annotsv.wdl:80:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annotsv/ww-annotsv.wdl/#L80"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annotsv/ww-annotsv.wdl/#L80"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annotsv/ww-annotsv.wdl"
 message = "ww-annotsv.wdl:81:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annotsv/ww-annotsv.wdl/#L81"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annotsv/ww-annotsv.wdl/#L81"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annovar/testrun.wdl"
 message = "testrun.wdl:115:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annovar/testrun.wdl/#L115"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annovar/testrun.wdl/#L115"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annovar/testrun.wdl"
 message = "testrun.wdl:126:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annovar/testrun.wdl/#L126"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annovar/testrun.wdl/#L126"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annovar/testrun.wdl"
 message = "testrun.wdl:59:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annovar/testrun.wdl/#L59"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annovar/testrun.wdl/#L59"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annovar/testrun.wdl"
 message = "testrun.wdl:67:43: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annovar/testrun.wdl/#L67"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annovar/testrun.wdl/#L67"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annovar/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `annovar_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annovar/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annovar/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annovar/testrun.wdl"
 message = "testrun.wdl:74:39: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annovar/testrun.wdl/#L74"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annovar/testrun.wdl/#L74"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annovar/testrun.wdl"
 message = "testrun.wdl:94:45: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annovar/testrun.wdl/#L94"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annovar/testrun.wdl/#L94"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-annovar/ww-annovar.wdl"
 message = "ww-annovar.wdl:51:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-annovar/ww-annovar.wdl/#L51"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-annovar/ww-annovar.wdl/#L51"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/testrun.wdl"
 message = "testrun.wdl:118:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/testrun.wdl/#L118"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/testrun.wdl/#L118"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/testrun.wdl"
 message = "testrun.wdl:5:10: note[MetaSections]: workflow `aws_sso_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/testrun.wdl/#L5"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/testrun.wdl/#L5"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:145:109: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L145"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L145"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:145:118: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L145"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L145"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:145:45: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L145"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L145"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:222:40: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L222"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L222"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:222:87: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L222"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L222"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:222:96: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L222"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L222"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:223:109: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L223"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L223"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:223:118: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L223"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L223"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:223:45: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L223"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L223"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:234:15: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L234"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L234"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:234:36: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L234"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L234"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:234:54: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L234"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L234"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:61:40: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L61"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L61"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:61:87: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L61"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L61"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:61:96: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L61"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L61"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:62:109: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L62"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L62"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:62:118: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L62"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L62"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:62:45: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L62"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L62"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:73:15: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L73"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L73"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-aws-sso/ww-aws-sso.wdl"
 message = "ww-aws-sso.wdl:81:45: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-aws-sso/ww-aws-sso.wdl/#L81"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-aws-sso/ww-aws-sso.wdl/#L81"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bcftools/testrun.wdl"
 message = "testrun.wdl:126:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bcftools/testrun.wdl/#L126"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bcftools/testrun.wdl/#L126"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bcftools/testrun.wdl"
 message = "testrun.wdl:61:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bcftools/testrun.wdl/#L61"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bcftools/testrun.wdl/#L61"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bcftools/testrun.wdl"
 message = "testrun.wdl:67:16: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bcftools/testrun.wdl/#L67"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bcftools/testrun.wdl/#L67"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bcftools/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `bcftools_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bcftools/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bcftools/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bcftools/ww-bcftools.wdl"
 message = "ww-bcftools.wdl:100:52: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bcftools/ww-bcftools.wdl/#L100"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bcftools/ww-bcftools.wdl/#L100"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bcftools/ww-bcftools.wdl"
 message = "ww-bcftools.wdl:154:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bcftools/ww-bcftools.wdl/#L154"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bcftools/ww-bcftools.wdl/#L154"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bcftools/ww-bcftools.wdl"
 message = "ww-bcftools.wdl:169:17: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bcftools/ww-bcftools.wdl/#L169"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bcftools/ww-bcftools.wdl/#L169"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bcftools/ww-bcftools.wdl"
 message = "ww-bcftools.wdl:61:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bcftools/ww-bcftools.wdl/#L61"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bcftools/ww-bcftools.wdl/#L61"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bcftools/ww-bcftools.wdl"
 message = "ww-bcftools.wdl:99:46: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bcftools/ww-bcftools.wdl/#L99"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bcftools/ww-bcftools.wdl/#L99"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedparse/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `bedparse_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedparse/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedparse/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedparse/ww-bedparse.wdl"
 message = "ww-bedparse.wdl:48:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedparse/ww-bedparse.wdl/#L48"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedparse/ww-bedparse.wdl/#L48"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedparse/ww-bedparse.wdl"
 message = "ww-bedparse.wdl:54:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedparse/ww-bedparse.wdl/#L54"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedparse/ww-bedparse.wdl/#L54"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedparse/ww-bedparse.wdl"
 message = "ww-bedparse.wdl:55:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedparse/ww-bedparse.wdl/#L55"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedparse/ww-bedparse.wdl/#L55"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedparse/ww-bedparse.wdl"
 message = "ww-bedparse.wdl:56:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedparse/ww-bedparse.wdl/#L56"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedparse/ww-bedparse.wdl/#L56"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedtools/testrun.wdl"
 message = "testrun.wdl:161:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedtools/testrun.wdl/#L161"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedtools/testrun.wdl/#L161"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedtools/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `bedtools_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedtools/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedtools/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedtools/testrun.wdl"
 message = "testrun.wdl:91:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedtools/testrun.wdl/#L91"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedtools/testrun.wdl/#L91"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedtools/ww-bedtools.wdl"
 message = "ww-bedtools.wdl:111:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedtools/ww-bedtools.wdl/#L111"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedtools/ww-bedtools.wdl/#L111"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedtools/ww-bedtools.wdl"
 message = "ww-bedtools.wdl:112:24: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedtools/ww-bedtools.wdl/#L112"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedtools/ww-bedtools.wdl/#L112"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedtools/ww-bedtools.wdl"
 message = "ww-bedtools.wdl:177:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedtools/ww-bedtools.wdl/#L177"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedtools/ww-bedtools.wdl/#L177"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedtools/ww-bedtools.wdl"
 message = "ww-bedtools.wdl:198:24: note[DeprecatedPlaceholder]: use of the deprecated `${}` placeholder option"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedtools/ww-bedtools.wdl/#L198"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedtools/ww-bedtools.wdl/#L198"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedtools/ww-bedtools.wdl"
 message = "ww-bedtools.wdl:47:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedtools/ww-bedtools.wdl/#L47"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedtools/ww-bedtools.wdl/#L47"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie/testrun.wdl"
 message = "testrun.wdl:12:10: note[MetaSections]: workflow `bowtie_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie/testrun.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie/testrun.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie/ww-bowtie.wdl"
 message = "ww-bowtie.wdl:115:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie/ww-bowtie.wdl/#L115"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie/ww-bowtie.wdl/#L115"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie/ww-bowtie.wdl"
 message = "ww-bowtie.wdl:44:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie/ww-bowtie.wdl/#L44"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie/ww-bowtie.wdl/#L44"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie2/testrun.wdl"
 message = "testrun.wdl:12:10: note[MetaSections]: workflow `bowtie2_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie2/testrun.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie2/testrun.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie2/ww-bowtie2.wdl"
 message = "ww-bowtie2.wdl:101:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie2/ww-bowtie2.wdl/#L101"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie2/ww-bowtie2.wdl/#L101"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie2/ww-bowtie2.wdl"
 message = "ww-bowtie2.wdl:102:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie2/ww-bowtie2.wdl/#L102"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie2/ww-bowtie2.wdl/#L102"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie2/ww-bowtie2.wdl"
 message = "ww-bowtie2.wdl:128:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie2/ww-bowtie2.wdl/#L128"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie2/ww-bowtie2.wdl/#L128"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie2/ww-bowtie2.wdl"
 message = "ww-bowtie2.wdl:155:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie2/ww-bowtie2.wdl/#L155"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie2/ww-bowtie2.wdl/#L155"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie2/ww-bowtie2.wdl"
 message = "ww-bowtie2.wdl:156:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie2/ww-bowtie2.wdl/#L156"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie2/ww-bowtie2.wdl/#L156"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie2/ww-bowtie2.wdl"
 message = "ww-bowtie2.wdl:157:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie2/ww-bowtie2.wdl/#L157"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie2/ww-bowtie2.wdl/#L157"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie2/ww-bowtie2.wdl"
 message = "ww-bowtie2.wdl:168:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie2/ww-bowtie2.wdl/#L168"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie2/ww-bowtie2.wdl/#L168"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie2/ww-bowtie2.wdl"
 message = "ww-bowtie2.wdl:169:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie2/ww-bowtie2.wdl/#L169"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie2/ww-bowtie2.wdl/#L169"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie2/ww-bowtie2.wdl"
 message = "ww-bowtie2.wdl:170:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie2/ww-bowtie2.wdl/#L170"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie2/ww-bowtie2.wdl/#L170"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie2/ww-bowtie2.wdl"
 message = "ww-bowtie2.wdl:178:25: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie2/ww-bowtie2.wdl/#L178"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie2/ww-bowtie2.wdl/#L178"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bowtie2/ww-bowtie2.wdl"
 message = "ww-bowtie2.wdl:44:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bowtie2/ww-bowtie2.wdl/#L44"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bowtie2/ww-bowtie2.wdl/#L44"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bwa/testrun.wdl"
 message = "testrun.wdl:12:10: note[MetaSections]: workflow `bwa_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bwa/testrun.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bwa/testrun.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bwa/testrun.wdl"
 message = "testrun.wdl:156:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bwa/testrun.wdl/#L156"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bwa/testrun.wdl/#L156"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bwa/testrun.wdl"
 message = "testrun.wdl:85:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bwa/testrun.wdl/#L85"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bwa/testrun.wdl/#L85"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bwa/testrun.wdl"
 message = "testrun.wdl:91:16: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bwa/testrun.wdl/#L91"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bwa/testrun.wdl/#L91"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bwa/testrun.wdl"
 message = "testrun.wdl:92:16: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bwa/testrun.wdl/#L92"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bwa/testrun.wdl/#L92"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bwa/ww-bwa.wdl"
 message = "ww-bwa.wdl:118:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bwa/ww-bwa.wdl/#L118"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bwa/ww-bwa.wdl/#L118"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bwa/ww-bwa.wdl"
 message = "ww-bwa.wdl:44:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bwa/ww-bwa.wdl/#L44"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bwa/ww-bwa.wdl/#L44"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/testrun.wdl"
 message = "testrun.wdl:27:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/testrun.wdl/#L27"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/testrun.wdl/#L27"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/testrun.wdl"
 message = "testrun.wdl:9:10: note[MetaSections]: workflow `cellbender_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/testrun.wdl/#L9"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/testrun.wdl/#L9"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:11:10: note[MetaSections]: workflow `cellbender_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/testrun_hpc.wdl/#L11"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/testrun_hpc.wdl/#L11"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:27:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/testrun_hpc.wdl/#L27"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/testrun_hpc.wdl/#L27"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/ww-cellbender.wdl"
 message = "ww-cellbender.wdl:14:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/ww-cellbender.wdl/#L14"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/ww-cellbender.wdl/#L14"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/ww-cellbender.wdl"
 message = "ww-cellbender.wdl:56:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/ww-cellbender.wdl/#L56"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/ww-cellbender.wdl/#L56"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/ww-cellbender.wdl"
 message = "ww-cellbender.wdl:74:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/ww-cellbender.wdl/#L74"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/ww-cellbender.wdl/#L74"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/ww-cellbender.wdl"
 message = "ww-cellbender.wdl:79:15: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/ww-cellbender.wdl/#L79"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/ww-cellbender.wdl/#L79"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/ww-cellbender.wdl"
 message = "ww-cellbender.wdl:82:13: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/ww-cellbender.wdl/#L82"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/ww-cellbender.wdl/#L82"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/ww-cellbender.wdl"
 message = "ww-cellbender.wdl:84:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/ww-cellbender.wdl/#L84"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/ww-cellbender.wdl/#L84"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/ww-cellbender.wdl"
 message = "ww-cellbender.wdl:85:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/ww-cellbender.wdl/#L85"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/ww-cellbender.wdl/#L85"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/ww-cellbender.wdl"
 message = "ww-cellbender.wdl:86:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/ww-cellbender.wdl/#L86"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/ww-cellbender.wdl/#L86"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellbender/ww-cellbender.wdl"
 message = "ww-cellbender.wdl:93:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellbender/ww-cellbender.wdl/#L93"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellbender/ww-cellbender.wdl/#L93"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/testrun.wdl"
 message = "testrun.wdl:101:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/testrun.wdl/#L101"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/testrun.wdl/#L101"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/testrun.wdl"
 message = "testrun.wdl:144:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/testrun.wdl/#L144"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/testrun.wdl/#L144"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `cellranger_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/testrun.wdl"
 message = "testrun.wdl:85:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/testrun.wdl/#L85"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/testrun.wdl/#L85"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:103:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/testrun_hpc.wdl/#L103"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/testrun_hpc.wdl/#L103"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:13:10: note[MetaSections]: workflow `cellranger_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/testrun_hpc.wdl/#L13"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/testrun_hpc.wdl/#L13"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:143:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/testrun_hpc.wdl/#L143"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/testrun_hpc.wdl/#L143"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:87:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/testrun_hpc.wdl/#L87"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/testrun_hpc.wdl/#L87"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:105:14: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L105"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L105"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:105:8: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L105"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L105"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:106:14: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L106"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L106"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:106:8: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L106"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L106"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:10:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L10"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L10"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:124:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L124"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L124"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:125:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L125"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L125"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:191:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L191"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L191"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:214:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L214"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L214"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:233:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L233"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L233"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:236:7: note[ShellCheck]: Not following: /app/lmod/lmod/init/bash was not specified as input (see shellcheck -x)."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L236"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L236"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:240:21: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L240"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L240"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:241:21: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L241"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L241"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:281:14: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L281"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L281"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:282:14: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L282"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L282"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:359:3: note[ExpectedRuntimeKeys]: the following runtime key is recommended by the WDL 1.0 specification: `docker`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L359"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L359"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:369:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L369"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L369"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:392:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L392"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L392"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:413:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L413"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L413"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:418:7: note[ShellCheck]: Not following: /app/lmod/lmod/init/bash was not specified as input (see shellcheck -x)."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L418"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L418"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:422:21: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L422"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L422"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:423:21: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L423"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L423"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:42:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L42"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L42"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:463:14: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L463"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L463"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:464:14: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L464"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L464"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:552:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L552"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L552"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:575:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L575"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L575"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:61:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L61"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L61"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:64:15: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L64"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L64"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:64:21: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L64"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L64"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:65:15: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L65"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L65"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cellranger/ww-cellranger.wdl"
 message = "ww-cellranger.wdl:65:21: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cellranger/ww-cellranger.wdl/#L65"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cellranger/ww-cellranger.wdl/#L65"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/testrun.wdl"
 message = "testrun.wdl:51:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/testrun.wdl/#L51"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/testrun.wdl/#L51"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/testrun.wdl"
 message = "testrun.wdl:52:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/testrun.wdl/#L52"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/testrun.wdl/#L52"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/testrun.wdl"
 message = "testrun.wdl:53:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/testrun.wdl/#L53"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/testrun.wdl/#L53"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/testrun.wdl"
 message = "testrun.wdl:54:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/testrun.wdl/#L54"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/testrun.wdl/#L54"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/testrun.wdl"
 message = "testrun.wdl:55:17: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/testrun.wdl/#L55"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/testrun.wdl/#L55"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/testrun.wdl"
 message = "testrun.wdl:56:17: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/testrun.wdl/#L56"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/testrun.wdl/#L56"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/testrun.wdl"
 message = "testrun.wdl:9:10: note[MetaSections]: workflow `clair3_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/testrun.wdl/#L9"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/testrun.wdl/#L9"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:106:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L106"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L106"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:107:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L107"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L107"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:108:17: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L108"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L108"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:109:17: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L109"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L109"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:54:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L54"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L54"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:55:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L55"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L55"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:72:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L72"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L72"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:75:16: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L75"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L75"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:76:16: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L76"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L76"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:79:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L79"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L79"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:80:20: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L80"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L80"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:81:21: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L81"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L81"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:83:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L83"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L83"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:84:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L84"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L84"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `cnvkit_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:121:5: note[MatchingOutputMeta]: `outputs` section of `meta` for the task `run_cnvkit` is out of order"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L121"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L121"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:166:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L166"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L166"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:172:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L172"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L172"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:173:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L173"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L173"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:174:21: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L174"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L174"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:175:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L175"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L175"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:181:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L181"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L181"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:182:21: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L182"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L182"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:183:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L183"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L183"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:189:27: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L189"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L189"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:28:3: note[ParameterMetaMatched]: parameter metadata in task `create_reference` is out of order"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L28"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L28"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:53:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L53"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L53"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:62:16: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L62"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L62"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:62:22: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L62"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L62"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:63:16: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L63"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L63"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:63:22: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L63"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L63"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:83:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L83"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L83"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:85:19: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L85"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L85"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:86:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L86"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L86"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:87:17: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L87"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L87"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:94:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L94"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L94"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:97:17: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L97"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L97"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/testrun.wdl"
 message = "testrun.wdl:118:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/testrun.wdl/#L118"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/testrun.wdl/#L118"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/testrun.wdl"
 message = "testrun.wdl:11:10: note[MetaSections]: workflow `colabfold_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/testrun.wdl/#L11"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/testrun.wdl/#L11"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/testrun.wdl"
 message = "testrun.wdl:68:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/testrun.wdl/#L68"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/testrun.wdl/#L68"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/testrun.wdl"
 message = "testrun.wdl:74:14: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/testrun.wdl/#L74"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/testrun.wdl/#L74"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/ww-colabfold.wdl"
 message = "ww-colabfold.wdl:131:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/ww-colabfold.wdl/#L131"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/ww-colabfold.wdl/#L131"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/ww-colabfold.wdl"
 message = "ww-colabfold.wdl:141:12: note[ShellCheck]: Declare and assign separately to avoid masking return values."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/ww-colabfold.wdl/#L141"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/ww-colabfold.wdl/#L141"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/ww-colabfold.wdl"
 message = "ww-colabfold.wdl:142:12: note[ShellCheck]: Declare and assign separately to avoid masking return values."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/ww-colabfold.wdl/#L142"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/ww-colabfold.wdl/#L142"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/ww-colabfold.wdl"
 message = "ww-colabfold.wdl:145:14: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/ww-colabfold.wdl/#L145"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/ww-colabfold.wdl/#L145"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/ww-colabfold.wdl"
 message = "ww-colabfold.wdl:149:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/ww-colabfold.wdl/#L149"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/ww-colabfold.wdl/#L149"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/ww-colabfold.wdl"
 message = "ww-colabfold.wdl:154:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/ww-colabfold.wdl/#L154"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/ww-colabfold.wdl/#L154"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/ww-colabfold.wdl"
 message = "ww-colabfold.wdl:158:20: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/ww-colabfold.wdl/#L158"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/ww-colabfold.wdl/#L158"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/ww-colabfold.wdl"
 message = "ww-colabfold.wdl:159:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/ww-colabfold.wdl/#L159"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/ww-colabfold.wdl/#L159"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/ww-colabfold.wdl"
 message = "ww-colabfold.wdl:43:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/ww-colabfold.wdl/#L43"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/ww-colabfold.wdl/#L43"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/ww-colabfold.wdl"
 message = "ww-colabfold.wdl:51:12: note[ShellCheck]: Declare and assign separately to avoid masking return values."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/ww-colabfold.wdl/#L51"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/ww-colabfold.wdl/#L51"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/ww-colabfold.wdl"
 message = "ww-colabfold.wdl:52:12: note[ShellCheck]: Declare and assign separately to avoid masking return values."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/ww-colabfold.wdl/#L52"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/ww-colabfold.wdl/#L52"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-colabfold/ww-colabfold.wdl"
 message = "ww-colabfold.wdl:79:9: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-colabfold/ww-colabfold.wdl/#L79"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-colabfold/ww-colabfold.wdl/#L79"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-consensus/testrun.wdl"
 message = "testrun.wdl:103:7: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-consensus/testrun.wdl/#L103"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-consensus/testrun.wdl/#L103"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-consensus/testrun.wdl"
 message = "testrun.wdl:119:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-consensus/testrun.wdl/#L119"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-consensus/testrun.wdl/#L119"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-consensus/testrun.wdl"
 message = "testrun.wdl:75:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-consensus/testrun.wdl/#L75"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-consensus/testrun.wdl/#L75"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-consensus/testrun.wdl"
 message = "testrun.wdl:78:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-consensus/testrun.wdl/#L78"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-consensus/testrun.wdl/#L78"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-consensus/testrun.wdl"
 message = "testrun.wdl:7:10: note[MetaSections]: workflow `consensus_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-consensus/testrun.wdl/#L7"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-consensus/testrun.wdl/#L7"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-consensus/testrun.wdl"
 message = "testrun.wdl:85:28: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-consensus/testrun.wdl/#L85"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-consensus/testrun.wdl/#L85"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-consensus/testrun.wdl"
 message = "testrun.wdl:95:7: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-consensus/testrun.wdl/#L95"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-consensus/testrun.wdl/#L95"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-consensus/ww-consensus.wdl"
 message = "ww-consensus.wdl:51:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-consensus/ww-consensus.wdl/#L51"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-consensus/ww-consensus.wdl/#L51"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/testrun.wdl"
 message = "testrun.wdl:14:10: note[MetaSections]: workflow `deeptools_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/testrun.wdl/#L14"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/testrun.wdl/#L14"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:151:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L151"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L151"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:154:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L154"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L154"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:155:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L155"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L155"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:157:23: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L157"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L157"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:159:19: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L159"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L159"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:160:24: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L160"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L160"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:161:28: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L161"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L161"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:163:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L163"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L163"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:232:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L232"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L232"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:234:19: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L234"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L234"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:235:23: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L235"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L235"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:236:25: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L236"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L236"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:239:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L239"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L239"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:244:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L244"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L244"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:302:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L302"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L302"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:305:20: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L305"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L305"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:307:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L307"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L307"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:308:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L308"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L308"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:363:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L363"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L363"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:366:20: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L366"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L366"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:368:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L368"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L368"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:432:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L432"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L432"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:434:21: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L434"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L434"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:435:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L435"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L435"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:438:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L438"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L438"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:439:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L439"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L439"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:441:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L441"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L441"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:502:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L502"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L502"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:505:17: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L505"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L505"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:508:19: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L508"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L508"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:509:20: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L509"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L509"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:510:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L510"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L510"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:567:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L567"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L567"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:570:17: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L570"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L570"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:573:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L573"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L573"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:634:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L634"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L634"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:637:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L637"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L637"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:640:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L640"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L640"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:642:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L642"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L642"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:67:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L67"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L67"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:70:13: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L70"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L70"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:72:23: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L72"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L72"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:74:24: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L74"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L74"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:75:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L75"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L75"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:76:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L76"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L76"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:80:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L80"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L80"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/testrun.wdl"
 message = "testrun.wdl:12:10: note[MetaSections]: workflow `deepvariant_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/testrun.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/testrun.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/testrun.wdl"
 message = "testrun.wdl:70:17: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/testrun.wdl/#L70"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/testrun.wdl/#L70"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/testrun.wdl"
 message = "testrun.wdl:71:17: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/testrun.wdl/#L71"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/testrun.wdl/#L71"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/testrun.wdl"
 message = "testrun.wdl:72:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/testrun.wdl/#L72"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/testrun.wdl/#L72"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/testrun.wdl"
 message = "testrun.wdl:73:17: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/testrun.wdl/#L73"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/testrun.wdl/#L73"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:48:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L48"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L48"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:49:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L49"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L49"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:61:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L61"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L61"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:64:20: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L64"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L64"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:65:13: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L65"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L65"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:66:15: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L66"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L66"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:68:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L68"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L68"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:70:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L70"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L70"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:74:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L74"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L74"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:75:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L75"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L75"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:76:17: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L76"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L76"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:77:17: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L77"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L77"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-delly/testrun.wdl"
 message = "testrun.wdl:112:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-delly/testrun.wdl/#L112"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-delly/testrun.wdl/#L112"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-delly/testrun.wdl"
 message = "testrun.wdl:64:16: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-delly/testrun.wdl/#L64"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-delly/testrun.wdl/#L64"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-delly/testrun.wdl"
 message = "testrun.wdl:65:18: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-delly/testrun.wdl/#L65"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-delly/testrun.wdl/#L65"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-delly/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `delly_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-delly/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-delly/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-delly/testrun.wdl"
 message = "testrun.wdl:74:25: note[ShellCheck]: Use find instead of ls to better handle non-alphanumeric filenames."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-delly/testrun.wdl/#L74"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-delly/testrun.wdl/#L74"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-delly/testrun.wdl"
 message = "testrun.wdl:76:25: note[ShellCheck]: Use find instead of ls to better handle non-alphanumeric filenames."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-delly/testrun.wdl/#L76"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-delly/testrun.wdl/#L76"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-delly/ww-delly.wdl"
 message = "ww-delly.wdl:68:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-delly/ww-delly.wdl/#L68"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-delly/ww-delly.wdl/#L68"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-delly/ww-delly.wdl"
 message = "ww-delly.wdl:69:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-delly/ww-delly.wdl/#L69"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-delly/ww-delly.wdl/#L69"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-delly/ww-delly.wdl"
 message = "ww-delly.wdl:76:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-delly/ww-delly.wdl/#L76"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-delly/ww-delly.wdl/#L76"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deseq2/testrun.wdl"
 message = "testrun.wdl:150:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deseq2/testrun.wdl/#L150"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deseq2/testrun.wdl/#L150"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deseq2/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `deseq2_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deseq2/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deseq2/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deseq2/testrun.wdl"
 message = "testrun.wdl:74:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deseq2/testrun.wdl/#L74"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deseq2/testrun.wdl/#L74"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deseq2/ww-deseq2.wdl"
 message = "ww-deseq2.wdl:122:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deseq2/ww-deseq2.wdl/#L122"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deseq2/ww-deseq2.wdl/#L122"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deseq2/ww-deseq2.wdl"
 message = "ww-deseq2.wdl:144:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deseq2/ww-deseq2.wdl/#L144"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deseq2/ww-deseq2.wdl/#L144"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deseq2/ww-deseq2.wdl"
 message = "ww-deseq2.wdl:220:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deseq2/ww-deseq2.wdl/#L220"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deseq2/ww-deseq2.wdl/#L220"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deseq2/ww-deseq2.wdl"
 message = "ww-deseq2.wdl:29:3: note[ParameterMetaMatched]: parameter metadata in task `combine_count_matrices` is out of order"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deseq2/ww-deseq2.wdl/#L29"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deseq2/ww-deseq2.wdl/#L29"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deseq2/ww-deseq2.wdl"
 message = "ww-deseq2.wdl:54:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deseq2/ww-deseq2.wdl/#L54"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deseq2/ww-deseq2.wdl/#L54"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deseq2/ww-deseq2.wdl"
 message = "ww-deseq2.wdl:60:15: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deseq2/ww-deseq2.wdl/#L60"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deseq2/ww-deseq2.wdl/#L60"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deseq2/ww-deseq2.wdl"
 message = "ww-deseq2.wdl:61:15: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deseq2/ww-deseq2.wdl/#L61"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deseq2/ww-deseq2.wdl/#L61"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deseq2/ww-deseq2.wdl"
 message = "ww-deseq2.wdl:62:20: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deseq2/ww-deseq2.wdl/#L62"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deseq2/ww-deseq2.wdl/#L62"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-diamond/testrun.wdl"
 message = "testrun.wdl:104:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-diamond/testrun.wdl/#L104"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-diamond/testrun.wdl/#L104"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-diamond/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `diamond_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-diamond/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-diamond/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-diamond/ww-diamond.wdl"
 message = "ww-diamond.wdl:111:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-diamond/ww-diamond.wdl/#L111"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-diamond/ww-diamond.wdl/#L111"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-diamond/ww-diamond.wdl"
 message = "ww-diamond.wdl:45:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-diamond/ww-diamond.wdl/#L45"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-diamond/ww-diamond.wdl/#L45"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/testrun.wdl"
 message = "testrun.wdl:109:6: note[MetaSections]: task `validate_download` is missing a `parameter_meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/testrun.wdl/#L109"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/testrun.wdl/#L109"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/testrun.wdl"
 message = "testrun.wdl:137:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/testrun.wdl/#L137"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/testrun.wdl/#L137"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/testrun.wdl"
 message = "testrun.wdl:140:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/testrun.wdl/#L140"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/testrun.wdl/#L140"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/testrun.wdl"
 message = "testrun.wdl:162:5: note[ShellCheck]: single_num_acc appears unused. Verify use (or export if used externally)."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/testrun.wdl/#L162"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/testrun.wdl/#L162"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/testrun.wdl"
 message = "testrun.wdl:163:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/testrun.wdl/#L163"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/testrun.wdl/#L163"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/testrun.wdl"
 message = "testrun.wdl:165:48: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/testrun.wdl/#L165"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/testrun.wdl/#L165"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/testrun.wdl"
 message = "testrun.wdl:186:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/testrun.wdl/#L186"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/testrun.wdl/#L186"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/testrun.wdl"
 message = "testrun.wdl:204:5: note[ShellCheck]: multi_num_acc appears unused. Verify use (or export if used externally)."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/testrun.wdl/#L204"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/testrun.wdl/#L204"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/testrun.wdl"
 message = "testrun.wdl:205:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/testrun.wdl/#L205"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/testrun.wdl/#L205"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/testrun.wdl"
 message = "testrun.wdl:268:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/testrun.wdl/#L268"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/testrun.wdl/#L268"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/testrun.wdl"
 message = "testrun.wdl:278:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/testrun.wdl/#L278"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/testrun.wdl/#L278"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/testrun.wdl"
 message = "testrun.wdl:7:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/testrun.wdl/#L7"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/testrun.wdl/#L7"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:103:10: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L103"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L103"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:107:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L107"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L107"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:129:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L129"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L129"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:12:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:176:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L176"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L176"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:181:16: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L181"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L181"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:182:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L182"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L182"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:183:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L183"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L183"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:184:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L184"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L184"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:187:10: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L187"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L187"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:191:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L191"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L191"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:250:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L250"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L250"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:257:64: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L257"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L257"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:260:5: note[ShellCheck]: This redirection doesn't have a command. Move to its command (or use 'true' as no-op)."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L260"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L260"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:261:5: note[ShellCheck]: This redirection doesn't have a command. Move to its command (or use 'true' as no-op)."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L261"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L261"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:262:5: note[ShellCheck]: This redirection doesn't have a command. Move to its command (or use 'true' as no-op)."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L262"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L262"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:263:5: note[ShellCheck]: This redirection doesn't have a command. Move to its command (or use 'true' as no-op)."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L263"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L263"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:267:32: note[ShellCheck]: read without -r will mangle backslashes."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L267"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L267"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:276:82: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L276"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L276"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:304:39: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L304"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L304"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:65:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L65"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L65"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:70:16: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L70"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L70"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:73:26: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L73"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L73"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:74:53: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L74"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L74"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:76:51: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L76"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L76"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:87:19: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L87"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L87"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:87:50: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L87"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L87"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:94:22: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L94"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L94"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:95:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L95"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L95"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:96:20: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L96"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L96"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:97:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L97"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L97"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ena/ww-ena.wdl"
 message = "ww-ena.wdl:98:20: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ena/ww-ena.wdl/#L98"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ena/ww-ena.wdl/#L98"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-esmfold/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:13:10: note[MetaSections]: workflow `esmfold_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-esmfold/testrun_hpc.wdl/#L13"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-esmfold/testrun_hpc.wdl/#L13"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-esmfold/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:51:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-esmfold/testrun_hpc.wdl/#L51"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-esmfold/testrun_hpc.wdl/#L51"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-esmfold/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:56:14: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-esmfold/testrun_hpc.wdl/#L56"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-esmfold/testrun_hpc.wdl/#L56"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-esmfold/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:96:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-esmfold/testrun_hpc.wdl/#L96"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-esmfold/testrun_hpc.wdl/#L96"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-esmfold/ww-esmfold.wdl"
 message = "ww-esmfold.wdl:58:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-esmfold/ww-esmfold.wdl/#L58"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-esmfold/ww-esmfold.wdl/#L58"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-esmfold/ww-esmfold.wdl"
 message = "ww-esmfold.wdl:69:10: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-esmfold/ww-esmfold.wdl/#L69"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-esmfold/ww-esmfold.wdl/#L69"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-esmfold/ww-esmfold.wdl"
 message = "ww-esmfold.wdl:72:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-esmfold/ww-esmfold.wdl/#L72"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-esmfold/ww-esmfold.wdl/#L72"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-esmfold/ww-esmfold.wdl"
 message = "ww-esmfold.wdl:75:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-esmfold/ww-esmfold.wdl/#L75"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-esmfold/ww-esmfold.wdl/#L75"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-fastp/testrun.wdl"
 message = "testrun.wdl:17:10: note[MetaSections]: workflow `fastp_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-fastp/testrun.wdl/#L17"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-fastp/testrun.wdl/#L17"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-fastp/ww-fastp.wdl"
 message = "ww-fastp.wdl:135:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-fastp/ww-fastp.wdl/#L135"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-fastp/ww-fastp.wdl/#L135"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-fastp/ww-fastp.wdl"
 message = "ww-fastp.wdl:156:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-fastp/ww-fastp.wdl/#L156"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-fastp/ww-fastp.wdl/#L156"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-fastp/ww-fastp.wdl"
 message = "ww-fastp.wdl:41:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-fastp/ww-fastp.wdl/#L41"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-fastp/ww-fastp.wdl/#L41"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-fastp/ww-fastp.wdl"
 message = "ww-fastp.wdl:64:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-fastp/ww-fastp.wdl/#L64"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-fastp/ww-fastp.wdl/#L64"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-fastqc/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `fastqc_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-fastqc/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-fastqc/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-fastqc/ww-fastqc.wdl"
 message = "ww-fastqc.wdl:52:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-fastqc/ww-fastqc.wdl/#L52"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-fastqc/ww-fastqc.wdl/#L52"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-fastqc/ww-fastqc.wdl"
 message = "ww-fastqc.wdl:89:19: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-fastqc/ww-fastqc.wdl/#L89"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-fastqc/ww-fastqc.wdl/#L89"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:13:10: note[MetaSections]: workflow `gatk_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L13"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L13"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:367:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L367"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L367"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:370:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L370"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L370"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:385:46: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L385"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L385"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:395:52: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L395"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L395"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:405:44: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L405"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L405"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:415:42: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L415"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L415"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:425:42: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L425"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L425"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:435:50: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L435"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L435"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:444:34: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L444"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L444"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:445:47: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L445"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L445"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:454:34: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L454"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L454"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:455:39: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L455"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L455"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:464:34: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L464"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L464"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:465:56: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L465"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L465"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:474:34: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L474"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L474"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:475:48: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L475"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L475"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:485:48: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L485"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L485"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:494:39: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L494"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L494"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:503:49: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L503"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L503"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:510:56: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L510"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L510"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:510:7: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L510"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L510"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:520:55: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L520"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L520"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:529:38: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L529"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L529"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:530:46: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L530"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L530"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:539:51: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L539"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L539"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:548:46: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L548"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L548"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/testrun.wdl"
 message = "testrun.wdl:562:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/testrun.wdl/#L562"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/testrun.wdl/#L562"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1041:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1041"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1041"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1059:16: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1059"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1059"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:105:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L105"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L105"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1064:13: note[ShellCheck]: Declare and assign separately to avoid masking return values."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1064"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1064"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1168:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1168"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1168"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1192:13: note[ShellCheck]: Declare and assign separately to avoid masking return values."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1192"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1192"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1258:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1258"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1258"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1331:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1331"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1331"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1335:15: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1335"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1335"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1336:16: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1336"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1336"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1388:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1388"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1388"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1399:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1399"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1399"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1404:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1404"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1404"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1405:14: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1405"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1405"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1474:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1474"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1474"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1564:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1564"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1564"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:183:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L183"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L183"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:211:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L211"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L211"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:293:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L293"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L293"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:303:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L303"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L303"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:379:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L379"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L379"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:419:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L419"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L419"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:44:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L44"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L44"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:512:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L512"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L512"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:562:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L562"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L562"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:629:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L629"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L629"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:727:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L727"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L727"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:819:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L819"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L819"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:912:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L912"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L912"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:916:10: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L916"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L916"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:971:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L971"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L971"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:975:15: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L975"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L975"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gdc/ww-gdc.wdl"
 message = "ww-gdc.wdl:179:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gdc/ww-gdc.wdl/#L179"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gdc/ww-gdc.wdl/#L179"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gdc/ww-gdc.wdl"
 message = "ww-gdc.wdl:194:7: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gdc/ww-gdc.wdl/#L194"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gdc/ww-gdc.wdl/#L194"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gdc/ww-gdc.wdl"
 message = "ww-gdc.wdl:208:13: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gdc/ww-gdc.wdl/#L208"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gdc/ww-gdc.wdl/#L208"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gdc/ww-gdc.wdl"
 message = "ww-gdc.wdl:221:10: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gdc/ww-gdc.wdl/#L221"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gdc/ww-gdc.wdl/#L221"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gdc/ww-gdc.wdl"
 message = "ww-gdc.wdl:52:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gdc/ww-gdc.wdl/#L52"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gdc/ww-gdc.wdl/#L52"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gdc/ww-gdc.wdl"
 message = "ww-gdc.wdl:66:11: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gdc/ww-gdc.wdl/#L66"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gdc/ww-gdc.wdl/#L66"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gdc/ww-gdc.wdl"
 message = "ww-gdc.wdl:78:13: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gdc/ww-gdc.wdl/#L78"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gdc/ww-gdc.wdl/#L78"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gdc/ww-gdc.wdl"
 message = "ww-gdc.wdl:90:10: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gdc/ww-gdc.wdl/#L90"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gdc/ww-gdc.wdl/#L90"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gffread/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `gffread_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gffread/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gffread/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gffread/ww-gffread.wdl"
 message = "ww-gffread.wdl:19:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gffread/ww-gffread.wdl/#L19"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gffread/ww-gffread.wdl/#L19"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gffread/ww-gffread.wdl"
 message = "ww-gffread.wdl:35:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gffread/ww-gffread.wdl/#L35"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gffread/ww-gffread.wdl/#L35"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gffread/ww-gffread.wdl"
 message = "ww-gffread.wdl:43:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gffread/ww-gffread.wdl/#L43"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gffread/ww-gffread.wdl/#L43"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gffread/ww-gffread.wdl"
 message = "ww-gffread.wdl:84:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gffread/ww-gffread.wdl/#L84"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gffread/ww-gffread.wdl/#L84"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gffread/ww-gffread.wdl"
 message = "ww-gffread.wdl:92:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gffread/ww-gffread.wdl/#L92"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gffread/ww-gffread.wdl/#L92"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
-message = "testrun.wdl:6:10: note[MetaSections]: workflow `glimpse2_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/testrun.wdl/#L6"
+message = "testrun.wdl:101:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L101"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:106:7: note[ConciseInput]: redundant input assignment"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L106"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:113:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L113"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:120:7: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L120"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:130:7: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L130"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:138:7: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L138"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:149:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L149"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:157:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L157"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:20:5: warning[BashSetSyntax]: bad `set` command"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L20"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:22:16: note[DeprecatedPlaceholder]: use of the deprecated `sep` placeholder option"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L22"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:22:20: note[DoubleQuotes]: string defined with single quotes"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L22"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:25:16: note[DeprecatedPlaceholder]: use of the deprecated `sep` placeholder option"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L25"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:25:20: note[DoubleQuotes]: string defined with single quotes"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L25"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:31:15: note[DeclarationName]: declaration identifier 'cram_directory' contains type name 'Directory'"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L31"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:34:3: note[RequirementsSection]: task `create_cram_directory` contains a deprecated `runtime` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L34"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:35:13: note[ContainerUri]: container URI uses a mutable tag"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L35"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:41:10: note[MetaSections]: workflow `glimpse2_example` is missing a `meta` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L41"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:49:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L49"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:57:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L57"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:64:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L64"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:6:6: note[MetaSections]: task `create_cram_directory` is missing a `parameter_meta` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L6"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:72:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L72"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:78:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L78"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:85:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L85"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/testrun.wdl"
+message = "testrun.wdl:93:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/testrun.wdl/#L93"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
 message = "ww-glimpse2.wdl:123:12: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L123"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L123"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
 message = "ww-glimpse2.wdl:133:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L133"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L133"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
+message = "ww-glimpse2.wdl:155:3: note[RequirementsSection]: task `glimpse2_split_reference` contains a deprecated `runtime` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L155"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
 message = "ww-glimpse2.wdl:198:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L198"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L198"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
 message = "ww-glimpse2.wdl:199:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L199"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L199"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
 message = "ww-glimpse2.wdl:212:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L212"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L212"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:283:17: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L283"
+message = "ww-glimpse2.wdl:237:3: note[RequirementsSection]: task `glimpse2_phase` contains a deprecated `runtime` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L237"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:284:17: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L284"
+message = "ww-glimpse2.wdl:248:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L248"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:300:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L300"
+message = "ww-glimpse2.wdl:266:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L266"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:303:17: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L303"
+message = "ww-glimpse2.wdl:281:15: note[DeclarationName]: declaration identifier 'input_cram_dir' contains type name 'Dir'"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L281"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:303:23: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L303"
+message = "ww-glimpse2.wdl:281:15: note[InputName]: declaration identifier starts with 'input'"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L281"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:304:20: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L304"
+message = "ww-glimpse2.wdl:296:5: warning[BashSetSyntax]: bad `set` command"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L296"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:304:26: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L304"
+message = 'ww-glimpse2.wdl:299:21: note[ShellCheck]: Quote expansions in this for loop glob to prevent wordsplitting, e.g. "$dir"/*.txt .'
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L299"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:305:23: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L305"
+message = 'ww-glimpse2.wdl:299:46: note[ShellCheck]: Quote expansions in this for loop glob to prevent wordsplitting, e.g. "$dir"/*.txt .'
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L299"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:305:29: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L305"
+message = "ww-glimpse2.wdl:361:3: note[RequirementsSection]: task `glimpse2_phase_cram` contains a deprecated `runtime` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L361"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:386:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L386"
+message = "ww-glimpse2.wdl:410:5: warning[BashSetSyntax]: bad `set` command"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L410"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:393:7: note[ShellCheck]: index_type appears unused. Verify use (or export if used externally)."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L393"
+message = "ww-glimpse2.wdl:417:7: note[ShellCheck]: index_type appears unused. Verify use (or export if used externally)."
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L417"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:397:19: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L397"
+message = "ww-glimpse2.wdl:421:19: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L421"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:397:25: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L397"
+message = "ww-glimpse2.wdl:421:21: note[DeprecatedPlaceholder]: use of the deprecated `sep` placeholder option"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L421"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:398:20: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L398"
+message = "ww-glimpse2.wdl:421:25: note[DoubleQuotes]: string defined with single quotes"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L421"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:398:26: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L398"
+message = "ww-glimpse2.wdl:422:20: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L422"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:403:12: note[ShellCheck]: Useless echo? Instead of 'echo $(cmd)', just use 'cmd'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L403"
+message = "ww-glimpse2.wdl:422:22: note[DeprecatedPlaceholder]: use of the deprecated `sep` placeholder option"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L422"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:481:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L481"
+message = "ww-glimpse2.wdl:422:26: note[DoubleQuotes]: string defined with single quotes"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L422"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:492:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L492"
+message = "ww-glimpse2.wdl:427:12: note[ShellCheck]: Useless echo? Instead of 'echo $(cmd)', just use 'cmd'."
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L427"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:493:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L493"
+message = "ww-glimpse2.wdl:447:3: note[RequirementsSection]: task `glimpse2_ligate` contains a deprecated `runtime` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L447"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:544:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L544"
+message = "ww-glimpse2.wdl:505:5: warning[BashSetSyntax]: bad `set` command"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L505"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
-message = "ww-glimpse2.wdl:556:19: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L556"
+message = "ww-glimpse2.wdl:516:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L516"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
+message = "ww-glimpse2.wdl:517:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L517"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
+message = "ww-glimpse2.wdl:528:3: note[RequirementsSection]: task `glimpse2_concordance` contains a deprecated `runtime` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L528"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
+message = "ww-glimpse2.wdl:568:5: warning[BashSetSyntax]: bad `set` command"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L568"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
 message = "ww-glimpse2.wdl:57:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-glimpse2/ww-glimpse2.wdl/#L57"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L57"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
+message = "ww-glimpse2.wdl:580:19: note[OutputName]: declaration identifier starts with 'output'"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L580"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
+message = "ww-glimpse2.wdl:584:3: note[RequirementsSection]: task `parse_chunks_file` contains a deprecated `runtime` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L584"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-glimpse2/ww-glimpse2.wdl"
+message = "ww-glimpse2.wdl:79:3: note[RequirementsSection]: task `glimpse2_chunk` contains a deprecated `runtime` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-glimpse2/ww-glimpse2.wdl/#L79"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/testrun.wdl"
 message = "testrun.wdl:106:3: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/testrun.wdl/#L106"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/testrun.wdl/#L106"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/testrun.wdl"
 message = "testrun.wdl:12:10: note[MetaSections]: workflow `ichorcna_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/testrun.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/testrun.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/testrun.wdl"
 message = "testrun.wdl:230:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/testrun.wdl/#L230"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/testrun.wdl/#L230"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:129:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L129"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L129"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:157:20: note[DeprecatedPlaceholder]: use of the deprecated `${}` placeholder option"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L157"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L157"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:158:17: note[DeprecatedPlaceholder]: use of the deprecated `${}` placeholder option"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L158"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L158"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:159:28: note[DeprecatedPlaceholder]: use of the deprecated `${}` placeholder option"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L159"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L159"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:160:31: note[DeprecatedPlaceholder]: use of the deprecated `${}` placeholder option"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L160"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L160"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:161:25: note[DeprecatedPlaceholder]: use of the deprecated `${}` placeholder option"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L161"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L161"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:162:19: note[DeprecatedPlaceholder]: use of the deprecated `${}` placeholder option"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L162"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L162"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:27:3: note[ParameterMetaMatched]: parameter metadata in task `readcounter_wig` is out of order"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L27"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L27"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:50:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L50"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L50"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:56:20: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L56"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L56"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:61:22: note[DeprecatedPlaceholder]: use of the deprecated `${}` placeholder option"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L61"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L61"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:79:9: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L79"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L79"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-jcast/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `jcast_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-jcast/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-jcast/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-jcast/ww-jcast.wdl"
 message = "ww-jcast.wdl:100:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-jcast/ww-jcast.wdl/#L100"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-jcast/ww-jcast.wdl/#L100"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-jcast/ww-jcast.wdl"
 message = "ww-jcast.wdl:101:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-jcast/ww-jcast.wdl/#L101"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-jcast/ww-jcast.wdl/#L101"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-jcast/ww-jcast.wdl"
 message = "ww-jcast.wdl:117:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-jcast/ww-jcast.wdl/#L117"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-jcast/ww-jcast.wdl/#L117"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-jcast/ww-jcast.wdl"
 message = "ww-jcast.wdl:118:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-jcast/ww-jcast.wdl/#L118"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-jcast/ww-jcast.wdl/#L118"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-jcast/ww-jcast.wdl"
 message = "ww-jcast.wdl:40:19: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-jcast/ww-jcast.wdl/#L40"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-jcast/ww-jcast.wdl/#L40"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-jcast/ww-jcast.wdl"
 message = "ww-jcast.wdl:67:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-jcast/ww-jcast.wdl/#L67"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-jcast/ww-jcast.wdl/#L67"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-jcast/ww-jcast.wdl"
 message = "ww-jcast.wdl:73:32: note[ShellCheck]: The arguments to this comparison can never be equal. Make sure your syntax is correct."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-jcast/ww-jcast.wdl/#L73"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-jcast/ww-jcast.wdl/#L73"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-jcast/ww-jcast.wdl"
 message = "ww-jcast.wdl:73:74: note[ShellCheck]: The arguments to this comparison can never be equal. Make sure your syntax is correct."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-jcast/ww-jcast.wdl/#L73"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-jcast/ww-jcast.wdl/#L73"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-jcast/ww-jcast.wdl"
 message = "ww-jcast.wdl:75:34: note[ShellCheck]: The arguments to this comparison can never be equal. Make sure your syntax is correct."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-jcast/ww-jcast.wdl/#L75"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-jcast/ww-jcast.wdl/#L75"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-jcast/ww-jcast.wdl"
 message = "ww-jcast.wdl:77:34: note[ShellCheck]: The arguments to this comparison can never be equal. Make sure your syntax is correct."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-jcast/ww-jcast.wdl/#L77"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-jcast/ww-jcast.wdl/#L77"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-jcast/ww-jcast.wdl"
 message = "ww-jcast.wdl:99:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-jcast/ww-jcast.wdl/#L99"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-jcast/ww-jcast.wdl/#L99"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-manta/testrun.wdl"
 message = "testrun.wdl:103:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-manta/testrun.wdl/#L103"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-manta/testrun.wdl/#L103"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-manta/testrun.wdl"
 message = "testrun.wdl:54:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-manta/testrun.wdl/#L54"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-manta/testrun.wdl/#L54"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-manta/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `manta_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-manta/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-manta/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-manta/ww-manta.wdl"
 message = "ww-manta.wdl:57:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-manta/ww-manta.wdl/#L57"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-manta/ww-manta.wdl/#L57"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-manta/ww-manta.wdl"
 message = "ww-manta.wdl:66:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-manta/ww-manta.wdl/#L66"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-manta/ww-manta.wdl/#L66"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-megahit/testrun.wdl"
 message = "testrun.wdl:67:7: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-megahit/testrun.wdl/#L67"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-megahit/testrun.wdl/#L67"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-megahit/testrun.wdl"
 message = "testrun.wdl:71:7: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-megahit/testrun.wdl/#L71"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-megahit/testrun.wdl/#L71"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-megahit/testrun.wdl"
 message = "testrun.wdl:7:10: note[MetaSections]: workflow `megahit_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-megahit/testrun.wdl/#L7"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-megahit/testrun.wdl/#L7"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-megahit/testrun.wdl"
 message = "testrun.wdl:85:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-megahit/testrun.wdl/#L85"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-megahit/testrun.wdl/#L85"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-megahit/ww-megahit.wdl"
 message = "ww-megahit.wdl:36:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-megahit/ww-megahit.wdl/#L36"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-megahit/ww-megahit.wdl/#L36"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-megahit/ww-megahit.wdl"
 message = "ww-megahit.wdl:44:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-megahit/ww-megahit.wdl/#L44"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-megahit/ww-megahit.wdl/#L44"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-megahit/ww-megahit.wdl"
 message = "ww-megahit.wdl:46:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-megahit/ww-megahit.wdl/#L46"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-megahit/ww-megahit.wdl/#L46"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-mosdepth/testrun.wdl"
+message = "testrun.wdl:6:10: note[MetaSections]: workflow `mosdepth_example` is missing a `meta` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-mosdepth/testrun.wdl/#L6"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-mosdepth/ww-mosdepth.wdl"
+message = "ww-mosdepth.wdl:44:10: note[InputName]: declaration identifier starts with 'input'"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-mosdepth/ww-mosdepth.wdl/#L44"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-mosdepth/ww-mosdepth.wdl"
+message = "ww-mosdepth.wdl:45:10: note[InputName]: declaration identifier starts with 'input'"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-mosdepth/ww-mosdepth.wdl/#L45"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-mosdepth/ww-mosdepth.wdl"
+message = "ww-mosdepth.wdl:54:5: warning[BashSetSyntax]: bad `set` command"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-mosdepth/ww-mosdepth.wdl/#L54"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-mosdepth/ww-mosdepth.wdl"
+message = "ww-mosdepth.wdl:57:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-mosdepth/ww-mosdepth.wdl/#L57"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-mosdepth/ww-mosdepth.wdl"
+message = "ww-mosdepth.wdl:58:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-mosdepth/ww-mosdepth.wdl/#L58"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-mosdepth/ww-mosdepth.wdl"
+message = "ww-mosdepth.wdl:60:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-mosdepth/ww-mosdepth.wdl/#L60"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-mosdepth/ww-mosdepth.wdl"
+message = "ww-mosdepth.wdl:61:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-mosdepth/ww-mosdepth.wdl/#L61"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-mosdepth/ww-mosdepth.wdl"
+message = "ww-mosdepth.wdl:71:13: note[ContainerUri]: container URI uses a mutable tag"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-mosdepth/ww-mosdepth.wdl/#L71"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-multiqc/testrun.wdl"
 message = "testrun.wdl:10:10: note[MetaSections]: workflow `multiqc_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-multiqc/testrun.wdl/#L10"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-multiqc/testrun.wdl/#L10"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-multiqc/ww-multiqc.wdl"
 message = "ww-multiqc.wdl:42:17: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-multiqc/ww-multiqc.wdl/#L42"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-multiqc/ww-multiqc.wdl/#L42"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-multiqc/ww-multiqc.wdl"
 message = "ww-multiqc.wdl:52:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-multiqc/ww-multiqc.wdl/#L52"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-multiqc/ww-multiqc.wdl/#L52"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-multiqc/ww-multiqc.wdl"
 message = "ww-multiqc.wdl:56:20: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-multiqc/ww-multiqc.wdl/#L56"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-multiqc/ww-multiqc.wdl/#L56"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-multiqc/ww-multiqc.wdl"
 message = "ww-multiqc.wdl:67:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-multiqc/ww-multiqc.wdl/#L67"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-multiqc/ww-multiqc.wdl/#L67"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/testrun.wdl"
 message = "testrun.wdl:12:10: note[MetaSections]: workflow `rmats_turbo_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/testrun.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/testrun.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/testrun.wdl"
 message = "testrun.wdl:3:1: note[UnusedDocComments]: unused doc comment"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/testrun.wdl/#L3"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/testrun.wdl/#L3"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:109:10: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L109"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L109"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:110:17: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L110"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L110"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:117:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L117"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L117"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:118:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L118"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L118"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:119:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L119"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L119"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:120:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L120"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L120"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:121:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L121"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L121"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:122:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L122"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L122"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:138:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L138"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L138"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:205:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L205"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L205"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:212:17: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L212"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L212"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:225:10: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L225"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L225"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:226:17: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L226"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L226"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:231:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L231"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L231"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:232:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L232"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L232"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:233:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L233"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L233"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:314:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L314"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L314"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:322:28: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L322"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L322"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:335:10: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L335"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L335"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:340:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L340"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L340"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:341:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L341"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L341"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:342:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L342"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L342"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:358:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L358"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L358"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:417:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L417"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L417"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:441:10: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L441"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L441"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:446:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L446"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L446"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:462:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L462"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L462"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:84:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L84"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L84"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:91:17: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L91"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L91"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rmats-turbo/ww-rmats-turbo.wdl"
 message = "ww-rmats-turbo.wdl:92:17: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L92"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rmats-turbo/ww-rmats-turbo.wdl/#L92"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rseqc/testrun.wdl"
 message = "testrun.wdl:7:10: note[MetaSections]: workflow `rseqc_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rseqc/testrun.wdl/#L7"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rseqc/testrun.wdl/#L7"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rseqc/ww-rseqc.wdl"
 message = "ww-rseqc.wdl:56:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rseqc/ww-rseqc.wdl/#L56"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rseqc/ww-rseqc.wdl/#L56"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/testrun.wdl"
 message = "testrun.wdl:116:7: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/testrun.wdl/#L116"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/testrun.wdl/#L116"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/testrun.wdl"
 message = "testrun.wdl:132:7: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/testrun.wdl/#L132"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/testrun.wdl/#L132"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/testrun.wdl"
 message = "testrun.wdl:13:10: note[MetaSections]: workflow `salmon_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/testrun.wdl/#L13"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/testrun.wdl/#L13"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/testrun.wdl"
 message = "testrun.wdl:161:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/testrun.wdl/#L161"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/testrun.wdl/#L161"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/testrun.wdl"
 message = "testrun.wdl:91:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/testrun.wdl/#L91"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/testrun.wdl/#L91"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/ww-salmon.wdl"
 message = "ww-salmon.wdl:118:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/ww-salmon.wdl/#L118"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/ww-salmon.wdl/#L118"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/ww-salmon.wdl"
 message = "ww-salmon.wdl:122:14: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/ww-salmon.wdl/#L122"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/ww-salmon.wdl/#L122"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/ww-salmon.wdl"
 message = "ww-salmon.wdl:136:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/ww-salmon.wdl/#L136"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/ww-salmon.wdl/#L136"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/ww-salmon.wdl"
 message = "ww-salmon.wdl:137:12: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/ww-salmon.wdl/#L137"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/ww-salmon.wdl/#L137"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/ww-salmon.wdl"
 message = "ww-salmon.wdl:144:14: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/ww-salmon.wdl/#L144"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/ww-salmon.wdl/#L144"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/ww-salmon.wdl"
 message = "ww-salmon.wdl:144:42: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/ww-salmon.wdl/#L144"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/ww-salmon.wdl/#L144"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/ww-salmon.wdl"
 message = "ww-salmon.wdl:149:12: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/ww-salmon.wdl/#L149"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/ww-salmon.wdl/#L149"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/ww-salmon.wdl"
 message = "ww-salmon.wdl:198:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/ww-salmon.wdl/#L198"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/ww-salmon.wdl/#L198"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/ww-salmon.wdl"
 message = "ww-salmon.wdl:203:30: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/ww-salmon.wdl/#L203"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/ww-salmon.wdl/#L203"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/ww-salmon.wdl"
 message = "ww-salmon.wdl:205:18: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/ww-salmon.wdl/#L205"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/ww-salmon.wdl/#L205"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/ww-salmon.wdl"
 message = "ww-salmon.wdl:43:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/ww-salmon.wdl/#L43"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/ww-salmon.wdl/#L43"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-salmon/ww-salmon.wdl"
 message = "ww-salmon.wdl:48:12: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-salmon/ww-salmon.wdl/#L48"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-salmon/ww-salmon.wdl/#L48"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/testrun.wdl"
 message = "testrun.wdl:110:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/testrun.wdl/#L110"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/testrun.wdl/#L110"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/testrun.wdl"
 message = "testrun.wdl:211:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/testrun.wdl/#L211"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/testrun.wdl/#L211"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `samtools_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/ww-samtools.wdl"
 message = "ww-samtools.wdl:117:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/ww-samtools.wdl/#L117"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/ww-samtools.wdl/#L117"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/ww-samtools.wdl"
 message = "ww-samtools.wdl:121:39: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/ww-samtools.wdl/#L121"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/ww-samtools.wdl/#L121"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/ww-samtools.wdl"
 message = "ww-samtools.wdl:140:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/ww-samtools.wdl/#L140"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/ww-samtools.wdl/#L140"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/ww-samtools.wdl"
 message = "ww-samtools.wdl:159:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/ww-samtools.wdl/#L159"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/ww-samtools.wdl/#L159"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/ww-samtools.wdl"
 message = "ww-samtools.wdl:160:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/ww-samtools.wdl/#L160"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/ww-samtools.wdl/#L160"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/ww-samtools.wdl"
 message = "ww-samtools.wdl:169:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/ww-samtools.wdl/#L169"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/ww-samtools.wdl/#L169"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/ww-samtools.wdl"
 message = "ww-samtools.wdl:192:48: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/ww-samtools.wdl/#L192"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/ww-samtools.wdl/#L192"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/ww-samtools.wdl"
 message = "ww-samtools.wdl:254:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/ww-samtools.wdl/#L254"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/ww-samtools.wdl/#L254"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/ww-samtools.wdl"
 message = "ww-samtools.wdl:28:3: note[ParameterMetaMatched]: parameter metadata in task `crams_to_fastq` is out of order"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/ww-samtools.wdl/#L28"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/ww-samtools.wdl/#L28"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/ww-samtools.wdl"
 message = "ww-samtools.wdl:47:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/ww-samtools.wdl/#L47"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/ww-samtools.wdl/#L47"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/ww-samtools.wdl"
 message = "ww-samtools.wdl:53:17: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/ww-samtools.wdl/#L53"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/ww-samtools.wdl/#L53"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-samtools/ww-samtools.wdl"
 message = "ww-samtools.wdl:61:72: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-samtools/ww-samtools.wdl/#L61"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-samtools/ww-samtools.wdl/#L61"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-seurat/testrun.wdl"
 message = "testrun.wdl:103:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-seurat/testrun.wdl/#L103"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-seurat/testrun.wdl/#L103"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-seurat/testrun.wdl"
 message = "testrun.wdl:58:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-seurat/testrun.wdl/#L58"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-seurat/testrun.wdl/#L58"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-seurat/testrun.wdl"
 message = "testrun.wdl:69:26: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-seurat/testrun.wdl/#L69"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-seurat/testrun.wdl/#L69"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-seurat/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `seurat_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-seurat/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-seurat/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-seurat/testrun.wdl"
 message = "testrun.wdl:71:26: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-seurat/testrun.wdl/#L71"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-seurat/testrun.wdl/#L71"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-seurat/ww-seurat.wdl"
 message = "ww-seurat.wdl:43:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-seurat/ww-seurat.wdl/#L43"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-seurat/ww-seurat.wdl/#L43"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-seurat/ww-seurat.wdl"
 message = "ww-seurat.wdl:55:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-seurat/ww-seurat.wdl/#L55"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-seurat/ww-seurat.wdl/#L55"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-shapemapper/testrun.wdl"
 message = "testrun.wdl:15:10: note[MetaSections]: workflow `shapemapper_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-shapemapper/testrun.wdl/#L15"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-shapemapper/testrun.wdl/#L15"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-shapemapper/testrun.wdl"
 message = "testrun.wdl:33:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-shapemapper/testrun.wdl/#L33"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-shapemapper/testrun.wdl/#L33"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-shapemapper/ww-shapemapper.wdl"
 message = "ww-shapemapper.wdl:60:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-shapemapper/ww-shapemapper.wdl/#L60"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-shapemapper/ww-shapemapper.wdl/#L60"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-shapemapper/ww-shapemapper.wdl"
 message = "ww-shapemapper.wdl:63:11: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-shapemapper/ww-shapemapper.wdl/#L63"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-shapemapper/ww-shapemapper.wdl/#L63"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-shapemapper/ww-shapemapper.wdl"
 message = "ww-shapemapper.wdl:76:53: note[DeprecatedPlaceholder]: use of the deprecated `${}` placeholder option"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-shapemapper/ww-shapemapper.wdl/#L76"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-shapemapper/ww-shapemapper.wdl/#L76"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-shapemapper/ww-shapemapper.wdl"
 message = "ww-shapemapper.wdl:82:14: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-shapemapper/ww-shapemapper.wdl/#L82"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-shapemapper/ww-shapemapper.wdl/#L82"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-shapemapper/ww-shapemapper.wdl"
 message = "ww-shapemapper.wdl:82:43: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-shapemapper/ww-shapemapper.wdl/#L82"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-shapemapper/ww-shapemapper.wdl/#L82"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-shapemapper/ww-shapemapper.wdl"
 message = "ww-shapemapper.wdl:86:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-shapemapper/ww-shapemapper.wdl/#L86"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-shapemapper/ww-shapemapper.wdl/#L86"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sjl/testrun.wdl"
 message = "testrun.wdl:48:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sjl/testrun.wdl/#L48"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sjl/testrun.wdl/#L48"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sjl/testrun.wdl"
 message = "testrun.wdl:51:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sjl/testrun.wdl/#L51"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sjl/testrun.wdl/#L51"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sjl/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `sjl_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sjl/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sjl/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sjl/testrun.wdl"
 message = "testrun.wdl:77:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sjl/testrun.wdl/#L77"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sjl/testrun.wdl/#L77"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sjl/ww-sjl.wdl"
 message = "ww-sjl.wdl:56:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sjl/ww-sjl.wdl/#L56"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sjl/ww-sjl.wdl/#L56"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/testrun.wdl"
 message = "testrun.wdl:109:46: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/testrun.wdl/#L109"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/testrun.wdl/#L109"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/testrun.wdl"
 message = "testrun.wdl:120:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/testrun.wdl/#L120"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/testrun.wdl/#L120"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/testrun.wdl"
 message = "testrun.wdl:12:10: note[MetaSections]: workflow `smoove_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/testrun.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/testrun.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/testrun.wdl"
 message = "testrun.wdl:133:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/testrun.wdl/#L133"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/testrun.wdl/#L133"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/testrun.wdl"
 message = "testrun.wdl:74:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/testrun.wdl/#L74"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/testrun.wdl/#L74"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/testrun.wdl"
 message = "testrun.wdl:82:43: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/testrun.wdl/#L82"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/testrun.wdl/#L82"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/testrun.wdl"
 message = "testrun.wdl:89:39: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/testrun.wdl/#L89"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/testrun.wdl/#L89"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/ww-smoove.wdl"
 message = "ww-smoove.wdl:106:14: note[DeprecatedPlaceholder]: use of the deprecated `${}` placeholder option"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/ww-smoove.wdl/#L106"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/ww-smoove.wdl/#L106"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/ww-smoove.wdl"
 message = "ww-smoove.wdl:56:26: note[DeprecatedPlaceholder]: use of the deprecated `${}` placeholder option"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/ww-smoove.wdl/#L56"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/ww-smoove.wdl/#L56"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/ww-smoove.wdl"
 message = "ww-smoove.wdl:57:32: note[DeprecatedPlaceholder]: use of the deprecated `${}` placeholder option"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/ww-smoove.wdl/#L57"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/ww-smoove.wdl/#L57"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/ww-smoove.wdl"
 message = "ww-smoove.wdl:71:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/ww-smoove.wdl/#L71"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/ww-smoove.wdl/#L71"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/ww-smoove.wdl"
 message = "ww-smoove.wdl:72:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/ww-smoove.wdl/#L72"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/ww-smoove.wdl/#L72"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sourmash/testrun.wdl"
 message = "testrun.wdl:162:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sourmash/testrun.wdl/#L162"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sourmash/testrun.wdl/#L162"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sourmash/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `sourmash_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sourmash/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sourmash/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sourmash/testrun.wdl"
 message = "testrun.wdl:92:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sourmash/testrun.wdl/#L92"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sourmash/testrun.wdl/#L92"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sourmash/ww-sourmash.wdl"
 message = "ww-sourmash.wdl:120:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sourmash/ww-sourmash.wdl/#L120"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sourmash/ww-sourmash.wdl/#L120"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sourmash/ww-sourmash.wdl"
 message = "ww-sourmash.wdl:123:36: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sourmash/ww-sourmash.wdl/#L123"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sourmash/ww-sourmash.wdl/#L123"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sourmash/ww-sourmash.wdl"
 message = "ww-sourmash.wdl:181:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sourmash/ww-sourmash.wdl/#L181"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sourmash/ww-sourmash.wdl/#L181"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sourmash/ww-sourmash.wdl"
 message = "ww-sourmash.wdl:26:3: note[ParameterMetaMatched]: parameter metadata in task `sketch` is out of order"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sourmash/ww-sourmash.wdl/#L26"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sourmash/ww-sourmash.wdl/#L26"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sourmash/ww-sourmash.wdl"
 message = "ww-sourmash.wdl:54:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sourmash/ww-sourmash.wdl/#L54"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sourmash/ww-sourmash.wdl/#L54"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sourmash/ww-sourmash.wdl"
 message = "ww-sourmash.wdl:59:59: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sourmash/ww-sourmash.wdl/#L59"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sourmash/ww-sourmash.wdl/#L59"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sourmash/ww-sourmash.wdl"
 message = "ww-sourmash.wdl:62:59: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sourmash/ww-sourmash.wdl/#L62"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sourmash/ww-sourmash.wdl/#L62"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sourmash/ww-sourmash.wdl"
 message = "ww-sourmash.wdl:97:3: note[ParameterMetaMatched]: parameter metadata in task `gather` is out of order"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sourmash/ww-sourmash.wdl/#L97"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sourmash/ww-sourmash.wdl/#L97"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-spades/testrun.wdl"
 message = "testrun.wdl:107:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-spades/testrun.wdl/#L107"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-spades/testrun.wdl/#L107"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-spades/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `spades_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-spades/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-spades/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-spades/ww-spades.wdl"
 message = "ww-spades.wdl:50:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-spades/ww-spades.wdl/#L50"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-spades/ww-spades.wdl/#L50"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sra/testrun.wdl"
 message = "testrun.wdl:120:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sra/testrun.wdl/#L120"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sra/testrun.wdl/#L120"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sra/testrun.wdl"
 message = "testrun.wdl:53:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sra/testrun.wdl/#L53"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sra/testrun.wdl/#L53"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sra/testrun.wdl"
 message = "testrun.wdl:5:10: note[MetaSections]: workflow `sra_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sra/testrun.wdl/#L5"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sra/testrun.wdl/#L5"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sra/ww-sra.wdl"
 message = "ww-sra.wdl:106:14: note[ShellCheck]: Don't use variables in the printf format string. Use printf '..%s..' \"$foo\"."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sra/ww-sra.wdl/#L106"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sra/ww-sra.wdl/#L106"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sra/ww-sra.wdl"
 message = "ww-sra.wdl:12:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sra/ww-sra.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sra/ww-sra.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sra/ww-sra.wdl"
 message = "ww-sra.wdl:47:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sra/ww-sra.wdl/#L47"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sra/ww-sra.wdl/#L47"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sra/ww-sra.wdl"
 message = "ww-sra.wdl:50:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sra/ww-sra.wdl/#L50"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sra/ww-sra.wdl/#L50"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sra/ww-sra.wdl"
 message = "ww-sra.wdl:58:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sra/ww-sra.wdl/#L58"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sra/ww-sra.wdl/#L58"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sra/ww-sra.wdl"
 message = "ww-sra.wdl:67:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sra/ww-sra.wdl/#L67"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sra/ww-sra.wdl/#L67"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-sra/ww-sra.wdl"
 message = "ww-sra.wdl:74:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-sra/ww-sra.wdl/#L74"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-sra/ww-sra.wdl/#L74"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-star/testrun.wdl"
 message = "testrun.wdl:12:10: note[MetaSections]: workflow `star_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-star/testrun.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-star/testrun.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-star/testrun.wdl"
 message = "testrun.wdl:132:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-star/testrun.wdl/#L132"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-star/testrun.wdl/#L132"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-star/testrun.wdl"
 message = "testrun.wdl:268:5: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-star/testrun.wdl/#L268"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-star/testrun.wdl/#L268"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-star/testrun.wdl"
 message = "testrun.wdl:289:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-star/testrun.wdl/#L289"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-star/testrun.wdl/#L289"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-star/ww-star.wdl"
 message = "ww-star.wdl:121:10: note[InputName]: declaration identifier must be at least 3 characters"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-star/ww-star.wdl/#L121"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-star/ww-star.wdl/#L121"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-star/ww-star.wdl"
 message = "ww-star.wdl:122:11: note[InputName]: declaration identifier must be at least 3 characters"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-star/ww-star.wdl/#L122"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-star/ww-star.wdl/#L122"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-star/ww-star.wdl"
 message = "ww-star.wdl:133:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-star/ww-star.wdl/#L133"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-star/ww-star.wdl/#L133"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-star/ww-star.wdl"
 message = "ww-star.wdl:146:51: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-star/ww-star.wdl/#L146"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-star/ww-star.wdl/#L146"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-star/ww-star.wdl"
 message = "ww-star.wdl:146:62: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-star/ww-star.wdl/#L146"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-star/ww-star.wdl/#L146"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-star/ww-star.wdl"
 message = "ww-star.wdl:48:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-star/ww-star.wdl/#L48"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-star/ww-star.wdl/#L48"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-starling/testrun.wdl"
 message = "testrun.wdl:9:10: note[MetaSections]: workflow `starling_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-starling/testrun.wdl/#L9"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-starling/testrun.wdl/#L9"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-starling/ww-starling.wdl"
 message = "ww-starling.wdl:130:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-starling/ww-starling.wdl/#L130"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-starling/ww-starling.wdl/#L130"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-starling/ww-starling.wdl"
 message = "ww-starling.wdl:139:10: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-starling/ww-starling.wdl/#L139"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-starling/ww-starling.wdl/#L139"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-starling/ww-starling.wdl"
 message = "ww-starling.wdl:200:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-starling/ww-starling.wdl/#L200"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-starling/ww-starling.wdl/#L200"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-starling/ww-starling.wdl"
 message = "ww-starling.wdl:263:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-starling/ww-starling.wdl/#L263"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-starling/ww-starling.wdl/#L263"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-starling/ww-starling.wdl"
 message = "ww-starling.wdl:55:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-starling/ww-starling.wdl/#L55"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-starling/ww-starling.wdl/#L55"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-starling/ww-starling.wdl"
 message = "ww-starling.wdl:65:10: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-starling/ww-starling.wdl/#L65"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-starling/ww-starling.wdl/#L65"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/testrun.wdl"
 message = "testrun.wdl:12:10: note[MetaSections]: workflow `strelka_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/testrun.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/testrun.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/testrun.wdl"
 message = "testrun.wdl:136:43: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/testrun.wdl/#L136"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/testrun.wdl/#L136"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/testrun.wdl"
 message = "testrun.wdl:174:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/testrun.wdl/#L174"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/testrun.wdl/#L174"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/testrun.wdl"
 message = "testrun.wdl:216:43: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/testrun.wdl/#L216"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/testrun.wdl/#L216"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/testrun.wdl"
 message = "testrun.wdl:229:43: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/testrun.wdl/#L229"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/testrun.wdl/#L229"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/testrun.wdl"
 message = "testrun.wdl:278:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/testrun.wdl/#L278"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/testrun.wdl/#L278"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/testrun.wdl"
 message = "testrun.wdl:311:9: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/testrun.wdl/#L311"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/testrun.wdl/#L311"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/testrun.wdl"
 message = "testrun.wdl:319:9: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/testrun.wdl/#L319"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/testrun.wdl/#L319"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/testrun.wdl"
 message = "testrun.wdl:363:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/testrun.wdl/#L363"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/testrun.wdl/#L363"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:179:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L179"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L179"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:180:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L180"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L180"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = 'ww-strelka.wdl:195:17: note[ShellCheck]: Quote expansions in this for loop glob to prevent wordsplitting, e.g. "$dir"/*.txt .'
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L195"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L195"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = 'ww-strelka.wdl:195:41: note[ShellCheck]: Quote expansions in this for loop glob to prevent wordsplitting, e.g. "$dir"/*.txt .'
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L195"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L195"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = 'ww-strelka.wdl:202:17: note[ShellCheck]: Quote expansions in this for loop glob to prevent wordsplitting, e.g. "$dir"/*.txt .'
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L202"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L202"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = 'ww-strelka.wdl:202:41: note[ShellCheck]: Quote expansions in this for loop glob to prevent wordsplitting, e.g. "$dir"/*.txt .'
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L202"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L202"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:210:22: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L210"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L210"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:210:46: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L210"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L210"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:210:98: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L210"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L210"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:211:102: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L211"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L211"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:211:24: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L211"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L211"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:211:48: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L211"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L211"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:68:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L68"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L68"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:69:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L69"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L69"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:93:26: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L93"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L93"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:93:67: note[ShellCheck]: Consider using 'grep -c' instead of 'grep|wc -l'."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L93"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L93"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-template/testrun.wdl"
 message = "testrun.wdl:16:10: note[MetaSections]: workflow `template_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-template/testrun.wdl/#L16"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-template/testrun.wdl/#L16"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-template/testrun.wdl"
 message = "testrun.wdl:43:17: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-template/testrun.wdl/#L43"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-template/testrun.wdl/#L43"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-template/ww-template.wdl"
 message = "ww-template.wdl:45:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-template/ww-template.wdl/#L45"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-template/ww-template.wdl/#L45"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-template/ww-template.wdl"
 message = "ww-template.wdl:53:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-template/ww-template.wdl/#L53"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-template/ww-template.wdl/#L53"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-template/ww-template.wdl"
 message = "ww-template.wdl:67:10: note[OutputName]: declaration identifier starts with 'output'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-template/ww-template.wdl/#L67"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-template/ww-template.wdl/#L67"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/testrun.wdl"
 message = "testrun.wdl:450:29: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/testrun.wdl/#L450"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/testrun.wdl/#L450"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/testrun.wdl"
 message = "testrun.wdl:523:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/testrun.wdl/#L523"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/testrun.wdl/#L523"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/testrun.wdl"
 message = "testrun.wdl:5:10: note[MetaSections]: workflow `testdata_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/testrun.wdl/#L5"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/testrun.wdl/#L5"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1037:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1037"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1037"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1047:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1047"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1047"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1131:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1131"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1131"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1184:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1184"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1184"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:124:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L124"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L124"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1270:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1270"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1270"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1319:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1319"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1319"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1408:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1408"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1408"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1456:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1456"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1456"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1490:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1490"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1490"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1519:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1519"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1519"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:153:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L153"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L153"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1597:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1597"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1597"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1614:46: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1614"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1614"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1656:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1656"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1656"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1728:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1728"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1728"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1746:48: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1746"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1746"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:177:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L177"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L177"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1787:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1787"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1787"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1843:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1843"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1843"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1863:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1863"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1863"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1917:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1917"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1917"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:1982:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L1982"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L1982"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:199:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L199"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L199"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:2003:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L2003"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L2003"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:2025:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L2025"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L2025"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:235:3: note[ParameterMetaMatched]: parameter metadata in task `download_fastq_data` is out of order"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L235"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L235"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:259:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L259"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L259"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:311:3: warning[BashSetSyntax]: missing `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L311"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L311"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:313:23: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L313"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L313"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:313:61: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L313"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L313"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:377:58: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L377"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L377"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:390:57: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L390"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L390"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:395:50: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L395"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L395"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:398:44: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L398"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L398"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:401:51: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L401"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L401"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:401:78: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L401"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L401"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:402:36: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L402"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L402"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:405:108: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L405"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L405"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:405:82: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L405"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L405"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:496:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L496"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L496"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:515:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L515"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L515"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:516:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L516"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L516"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:525:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L525"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L525"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:741:19: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L741"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L741"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:790:3: warning[BashSetSyntax]: missing `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L790"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L790"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:793:19: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L793"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L793"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:841:3: warning[BashSetSyntax]: missing `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L841"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L841"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:843:19: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L843"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L843"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:939:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L939"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L939"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:991:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L991"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L991"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-trimgalore/testrun.wdl"
 message = "testrun.wdl:17:10: note[MetaSections]: workflow `trimgalore_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-trimgalore/testrun.wdl/#L17"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-trimgalore/testrun.wdl/#L17"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-trimgalore/ww-trimgalore.wdl"
 message = "ww-trimgalore.wdl:156:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-trimgalore/ww-trimgalore.wdl/#L156"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-trimgalore/ww-trimgalore.wdl/#L156"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-trimgalore/ww-trimgalore.wdl"
 message = "ww-trimgalore.wdl:64:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-trimgalore/ww-trimgalore.wdl/#L64"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-trimgalore/ww-trimgalore.wdl/#L64"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-tritonnp/testrun.wdl"
 message = "testrun.wdl:13:10: note[MetaSections]: workflow `tritonnp_example` is missing a `parameter_meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-tritonnp/testrun.wdl/#L13"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-tritonnp/testrun.wdl/#L13"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-tritonnp/ww-tritonnp.wdl"
 message = "ww-tritonnp.wdl:129:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-tritonnp/ww-tritonnp.wdl/#L129"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-tritonnp/ww-tritonnp.wdl/#L129"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-tritonnp/ww-tritonnp.wdl"
 message = "ww-tritonnp.wdl:61:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-tritonnp/ww-tritonnp.wdl/#L61"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-tritonnp/ww-tritonnp.wdl/#L61"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-umi-tools/testrun.wdl"
 message = "testrun.wdl:17:10: note[MetaSections]: workflow `umi_tools_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-umi-tools/testrun.wdl/#L17"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-umi-tools/testrun.wdl/#L17"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-umi-tools/ww-umi-tools.wdl"
 message = "ww-umi-tools.wdl:15:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-umi-tools/ww-umi-tools.wdl/#L15"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-umi-tools/ww-umi-tools.wdl/#L15"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-umi-tools/ww-umi-tools.wdl"
 message = "ww-umi-tools.wdl:38:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-umi-tools/ww-umi-tools.wdl/#L38"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-umi-tools/ww-umi-tools.wdl/#L38"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-umi-tools/ww-umi-tools.wdl"
 message = "ww-umi-tools.wdl:39:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-umi-tools/ww-umi-tools.wdl/#L39"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-umi-tools/ww-umi-tools.wdl/#L39"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-umi-tools/ww-umi-tools.wdl"
 message = "ww-umi-tools.wdl:51:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-umi-tools/ww-umi-tools.wdl/#L51"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-umi-tools/ww-umi-tools.wdl/#L51"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-umi-tools/ww-umi-tools.wdl"
 message = "ww-umi-tools.wdl:64:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-umi-tools/ww-umi-tools.wdl/#L64"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-umi-tools/ww-umi-tools.wdl/#L64"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-varscan/testrun.wdl"
 message = "testrun.wdl:105:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-varscan/testrun.wdl/#L105"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-varscan/testrun.wdl/#L105"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-varscan/testrun.wdl"
 message = "testrun.wdl:177:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-varscan/testrun.wdl/#L177"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-varscan/testrun.wdl/#L177"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-varscan/testrun.wdl"
 message = "testrun.wdl:7:10: note[MetaSections]: workflow `varscan_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-varscan/testrun.wdl/#L7"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-varscan/testrun.wdl/#L7"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/testrun.wdl"
 message = "testrun.wdl:8:10: note[MetaSections]: workflow `viennarna_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/testrun.wdl/#L8"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/testrun.wdl/#L8"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:109:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L109"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L109"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:120:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L120"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L120"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:123:16: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L123"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L123"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:127:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L127"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L127"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:186:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L186"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L186"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:192:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L192"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L192"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:242:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L242"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L242"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:254:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L254"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L254"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:261:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L261"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L261"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:262:9: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L262"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L262"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:43:10: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L43"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L43"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:54:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L54"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L54"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:57:16: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L57"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L57"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-viennarna/ww-viennarna.wdl"
 message = "ww-viennarna.wdl:61:7: note[ShellCheck]: Double quote to prevent globbing and word splitting."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-viennarna/ww-viennarna.wdl/#L61"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-viennarna/ww-viennarna.wdl/#L61"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-bwa-gatk/testrun.wdl"
 message = "testrun.wdl:12:10: note[MetaSections]: workflow `bwa_gatk_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-bwa-gatk/testrun.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-bwa-gatk/testrun.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-ena-star/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `ena_star_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-ena-star/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-ena-star/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-fastq-to-cram/testrun.wdl"
 message = "testrun.wdl:20:10: note[MetaSections]: workflow `fastq_to_cram_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-fastq-to-cram/testrun.wdl/#L20"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-fastq-to-cram/testrun.wdl/#L20"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
-message = "testrun.wdl:11:10: note[MetaSections]: workflow `imputation_testrun` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-imputation/testrun.wdl/#L11"
+message = "testrun.wdl:20:5: warning[BashSetSyntax]: bad `set` command"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L20"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:22:16: note[DeprecatedPlaceholder]: use of the deprecated `sep` placeholder option"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L22"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:22:20: note[DoubleQuotes]: string defined with single quotes"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L22"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:25:16: note[DeprecatedPlaceholder]: use of the deprecated `sep` placeholder option"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L25"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:25:20: note[DoubleQuotes]: string defined with single quotes"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L25"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:31:15: note[DeclarationName]: declaration identifier 'cram_directory' contains type name 'Directory'"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L31"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:34:3: note[RequirementsSection]: task `create_cram_directory` contains a deprecated `runtime` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L34"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:35:13: note[ContainerUri]: container URI uses a mutable tag"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L35"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:46:10: note[MetaSections]: workflow `imputation_testrun` is missing a `meta` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L46"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:53:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L53"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:61:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L61"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:68:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L68"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:6:6: note[MetaSections]: task `create_cram_directory` is missing a `parameter_meta` section"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L6"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:76:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L76"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:82:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L82"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:89:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L89"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/testrun.wdl"
+message = "testrun.wdl:97:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/testrun.wdl/#L97"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:118:7: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L118"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:124:9: note[ConciseInput]: redundant input assignment"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L124"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:125:9: note[ConciseInput]: redundant input assignment"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L125"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:132:7: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L132"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:139:9: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L139"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:13:8: note[MetaSections]: struct `ChromosomeData` is missing both `meta` and `parameter_meta` sections"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L13"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:160:9: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L160"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:161:11: note[ConciseInput]: redundant input assignment"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L161"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:162:11: note[ConciseInput]: redundant input assignment"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L162"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:163:11: note[ConciseInput]: redundant input assignment"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L163"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:166:11: note[ConciseInput]: redundant input assignment"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L166"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:167:11: note[ConciseInput]: redundant input assignment"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L167"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:168:11: note[ConciseInput]: redundant input assignment"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L168"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:169:11: note[ConciseInput]: redundant input assignment"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L169"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:177:7: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L177"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:181:9: note[ConciseInput]: redundant input assignment"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L181"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:189:5: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L189"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:193:7: note[ConciseInput]: redundant input assignment"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L193"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:201:7: note[CallInputKeyword]: the `input:` keyword is unnecessary for WDL version 1.2 and later"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L201"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
 message = "ww-imputation.wdl:36:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-imputation/ww-imputation.wdl/#L36"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L36"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
-message = "ww-imputation.wdl:79:17: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-imputation/ww-imputation.wdl/#L79"
+message = "ww-imputation.wdl:46:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L46"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
-message = "ww-imputation.wdl:80:17: note[InputName]: declaration identifier starts with 'input'"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-imputation/ww-imputation.wdl/#L80"
+message = "ww-imputation.wdl:77:15: note[DeclarationName]: declaration identifier 'input_cram_dir' contains type name 'Dir'"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L77"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/pipelines/ww-imputation/ww-imputation.wdl"
+message = "ww-imputation.wdl:77:15: note[InputName]: declaration identifier starts with 'input'"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-imputation/ww-imputation.wdl/#L77"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-jetlag/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `jetlag_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-jetlag/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-jetlag/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-jetlag/ww-jetlag.wdl"
 message = "ww-jetlag.wdl:25:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-jetlag/ww-jetlag.wdl/#L25"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-jetlag/ww-jetlag.wdl/#L25"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-leukemia/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `leukemia_test` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-leukemia/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-leukemia/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-leukemia/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:12:10: note[MetaSections]: workflow `leukemia_test` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-leukemia/testrun_hpc.wdl/#L12"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-leukemia/testrun_hpc.wdl/#L12"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-leukemia/ww-leukemia.wdl"
 message = "ww-leukemia.wdl:102:9: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-leukemia/ww-leukemia.wdl/#L102"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-leukemia/ww-leukemia.wdl/#L102"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-leukemia/ww-leukemia.wdl"
 message = "ww-leukemia.wdl:129:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-leukemia/ww-leukemia.wdl/#L129"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-leukemia/ww-leukemia.wdl/#L129"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-leukemia/ww-leukemia.wdl"
 message = "ww-leukemia.wdl:131:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-leukemia/ww-leukemia.wdl/#L131"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-leukemia/ww-leukemia.wdl/#L131"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-leukemia/ww-leukemia.wdl"
 message = "ww-leukemia.wdl:133:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-leukemia/ww-leukemia.wdl/#L133"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-leukemia/ww-leukemia.wdl/#L133"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-leukemia/ww-leukemia.wdl"
 message = "ww-leukemia.wdl:76:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-leukemia/ww-leukemia.wdl/#L76"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-leukemia/ww-leukemia.wdl/#L76"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-proseq/testrun.wdl"
 message = "testrun.wdl:20:10: note[MetaSections]: workflow `proseq_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-proseq/testrun.wdl/#L20"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-proseq/testrun.wdl/#L20"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-proseq/ww-proseq.wdl"
 message = "ww-proseq.wdl:27:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-proseq/ww-proseq.wdl/#L27"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-proseq/ww-proseq.wdl/#L27"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-proseq/ww-proseq.wdl"
 message = "ww-proseq.wdl:53:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-proseq/ww-proseq.wdl/#L53"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-proseq/ww-proseq.wdl/#L53"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/testrun.wdl"
 message = "testrun.wdl:13:10: note[MetaSections]: workflow `rnaseq_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/testrun.wdl/#L13"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/testrun.wdl/#L13"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:34:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L34"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L34"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:381:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L381"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L381"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:384:12: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L384"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L384"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:387:19: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L387"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L387"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:388:18: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L388"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L388"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:389:14: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L389"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L389"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:390:14: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L390"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L390"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:391:18: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L391"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L391"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:392:18: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L392"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L392"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:393:20: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L393"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L393"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:394:19: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L394"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L394"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:395:15: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L395"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L395"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:396:15: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L396"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L396"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:397:18: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L397"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L397"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:398:15: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L398"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L398"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:399:12: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L399"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L399"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-rnaseq/ww-rnaseq.wdl"
 message = "ww-rnaseq.wdl:455:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L455"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-rnaseq/ww-rnaseq.wdl/#L455"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-splicing-proteomics/testrun.wdl"
 message = "testrun.wdl:20:10: note[MetaSections]: workflow `splicing_proteomics_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-splicing-proteomics/testrun.wdl/#L20"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-splicing-proteomics/testrun.wdl/#L20"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl"
 message = "ww-splicing-proteomics.wdl:30:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl/#L30"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-splicing-proteomics/ww-splicing-proteomics.wdl/#L30"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/testrun.wdl"
 message = "testrun.wdl:137:7: note[ShellCheck]: Consider using { cmd1; cmd2; } >> file instead of individual redirects."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/testrun.wdl/#L137"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/testrun.wdl/#L137"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/testrun.wdl"
 message = "testrun.wdl:168:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/testrun.wdl/#L168"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/testrun.wdl/#L168"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/testrun.wdl"
 message = "testrun.wdl:57:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/testrun.wdl/#L57"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/testrun.wdl/#L57"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `sra_cellranger_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/testrun.wdl"
 message = "testrun.wdl:86:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/testrun.wdl/#L86"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/testrun.wdl/#L86"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:144:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/testrun_hpc.wdl/#L144"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/testrun_hpc.wdl/#L144"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:14:10: note[MetaSections]: workflow `sra_cellranger_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/testrun_hpc.wdl/#L14"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/testrun_hpc.wdl/#L14"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:54:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/testrun_hpc.wdl/#L54"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/testrun_hpc.wdl/#L54"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/testrun_hpc.wdl"
 message = "testrun_hpc.wdl:81:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/testrun_hpc.wdl/#L81"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/testrun_hpc.wdl/#L81"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:266:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L266"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L266"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:268:10: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L268"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L268"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:268:16: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L268"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L268"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:269:12: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L269"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L269"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:269:18: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L269"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L269"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:302:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L302"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L302"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:347:5: warning[BashSetSyntax]: bad `set` command"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L347"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L347"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:350:17: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L350"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L350"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:350:23: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L350"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L350"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:351:11: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L351"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L351"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:351:17: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L351"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L351"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:352:10: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L352"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L352"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:352:16: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L352"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L352"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:353:14: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L353"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L353"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:353:20: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L353"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L353"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:354:15: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L354"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L354"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:354:21: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L354"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L354"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:355:10: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L355"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L355"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:355:16: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L355"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L355"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:356:16: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L356"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L356"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:356:22: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L356"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L356"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:357:18: note[ShellCheck]: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a."
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L357"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L357"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:357:24: note[DoubleQuotes]: string defined with single quotes"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L357"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L357"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:36:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L36"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L36"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:379:13: note[ContainerUri]: container URI uses a mutable tag"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L379"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L379"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:37:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L37"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L37"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl"
 message = "ww-sra-cellranger.wdl:46:5: note[DescriptionLength]: this description will be clipped in Sprocket documentation"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L46"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-cellranger/ww-sra-cellranger.wdl/#L46"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-salmon/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `sra_salmon_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-salmon/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-salmon/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-sra-star/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `sra_star_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-sra-star/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-sra-star/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-star-deseq2/testrun.wdl"
 message = "testrun.wdl:20:10: note[MetaSections]: workflow `star_deseq2_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-star-deseq2/testrun.wdl/#L20"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-star-deseq2/testrun.wdl/#L20"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/pipelines/ww-starling-batch/testrun.wdl"
 message = "testrun.wdl:6:10: note[MetaSections]: workflow `starling_batch_example` is missing a `meta` section"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/pipelines/ww-starling-batch/testrun.wdl/#L6"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/pipelines/ww-starling-batch/testrun.wdl/#L6"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/data_structures/flag_filter.wdl"

--- a/crates/gauntlet/Gauntlet.toml
+++ b/crates/gauntlet/Gauntlet.toml
@@ -32,7 +32,7 @@ commit_hash = "30f0226d2c404b5c39f9a11704196da955c804d5"
 
 [repositories."getwilds/wilds-wdl-library"]
 identifier = "getwilds/wilds-wdl-library"
-commit_hash = "404b3b6b4138b43ba33d08edbde6510a39be5a27"
+commit_hash = "659d5802cc65695b211ae9b72d9095524b33734b"
 
 [repositories."stjudecloud/workflows"]
 identifier = "stjudecloud/workflows"
@@ -7665,232 +7665,237 @@ permalink = "https://github.com/chanzuckerberg/czid-workflows/blob/30f0226d2c404
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bcftools/ww-bcftools.wdl"
 message = "ww-bcftools.wdl:144:17: warning[UnusedInput]: unused input `vcf_indices`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bcftools/ww-bcftools.wdl/#L144"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bcftools/ww-bcftools.wdl/#L144"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bcftools/ww-bcftools.wdl"
 message = "ww-bcftools.wdl:46:10: warning[UnusedInput]: unused input `reference_fasta_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bcftools/ww-bcftools.wdl/#L46"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bcftools/ww-bcftools.wdl/#L46"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bcftools/ww-bcftools.wdl"
 message = "ww-bcftools.wdl:48:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bcftools/ww-bcftools.wdl/#L48"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bcftools/ww-bcftools.wdl/#L48"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedtools/ww-bedtools.wdl"
 message = "ww-bedtools.wdl:165:10: warning[UnusedInput]: unused input `reference_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedtools/ww-bedtools.wdl/#L165"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedtools/ww-bedtools.wdl/#L165"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-bedtools/ww-bedtools.wdl"
 message = "ww-bedtools.wdl:167:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-bedtools/ww-bedtools.wdl/#L167"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-bedtools/ww-bedtools.wdl/#L167"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:55:10: warning[UnusedInput]: unused input `input_bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L55"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L55"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-clair3/ww-clair3.wdl"
 message = "ww-clair3.wdl:57:10: warning[UnusedInput]: unused input `ref_fasta_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-clair3/ww-clair3.wdl/#L57"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-clair3/ww-clair3.wdl/#L57"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:154:10: warning[UnusedInput]: unused input `tumor_bai`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L154"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L154"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-cnvkit/ww-cnvkit.wdl"
 message = "ww-cnvkit.wdl:156:11: warning[UnusedInput]: unused input `normal_bai`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-cnvkit/ww-cnvkit.wdl/#L156"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-cnvkit/ww-cnvkit.wdl/#L156"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:133:10: warning[UnusedInput]: unused input `treatment_bai`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L133"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L133"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:135:10: warning[UnusedInput]: unused input `control_bai`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L135"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L135"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:418:17: warning[UnusedInput]: unused input `bai_files`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L418"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L418"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:49:10: warning[UnusedInput]: unused input `bai`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L49"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L49"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deeptools/ww-deeptools.wdl"
 message = "ww-deeptools.wdl:623:17: warning[UnusedInput]: unused input `bai_files`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deeptools/ww-deeptools.wdl/#L623"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deeptools/ww-deeptools.wdl/#L623"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:49:10: warning[UnusedInput]: unused input `input_bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L49"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L49"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-deepvariant/ww-deepvariant.wdl"
 message = "ww-deepvariant.wdl:51:10: warning[UnusedInput]: unused input `ref_fasta_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-deepvariant/ww-deepvariant.wdl/#L51"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-deepvariant/ww-deepvariant.wdl/#L51"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-delly/ww-delly.wdl"
 message = "ww-delly.wdl:44:10: warning[UnusedInput]: unused input `aligned_bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-delly/ww-delly.wdl/#L44"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-delly/ww-delly.wdl/#L44"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-delly/ww-delly.wdl"
 message = "ww-delly.wdl:46:10: warning[UnusedInput]: unused input `reference_fasta_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-delly/ww-delly.wdl/#L46"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-delly/ww-delly.wdl/#L46"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1028:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1028"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1028"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1154:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1154"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1154"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1462:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1462"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1462"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:1550:17: warning[UnusedInput]: unused input `normal_vcf_indices`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L1550"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L1550"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:169:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L169"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L169"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:279:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L279"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L279"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:281:10: warning[UnusedInput]: unused input `reference_fasta_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L281"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L281"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:362:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L362"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L362"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:617:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L617"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L617"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:714:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L714"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L714"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:805:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L805"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L805"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:903:17: warning[UnusedInput]: unused input `vcf_indices`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L903"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L903"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-gatk/ww-gatk.wdl"
 message = "ww-gatk.wdl:97:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-gatk/ww-gatk.wdl/#L97"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-gatk/ww-gatk.wdl/#L97"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-ichorcna/ww-ichorcna.wdl"
 message = "ww-ichorcna.wdl:40:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-ichorcna/ww-ichorcna.wdl/#L40"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-ichorcna/ww-ichorcna.wdl/#L40"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-manta/ww-manta.wdl"
 message = "ww-manta.wdl:44:10: warning[UnusedInput]: unused input `reference_fasta_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-manta/ww-manta.wdl/#L44"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-manta/ww-manta.wdl/#L44"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-manta/ww-manta.wdl"
 message = "ww-manta.wdl:46:10: warning[UnusedInput]: unused input `aligned_bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-manta/ww-manta.wdl/#L46"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-manta/ww-manta.wdl/#L46"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-manta/ww-manta.wdl"
 message = "ww-manta.wdl:49:11: warning[UnusedInput]: unused input `call_regions_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-manta/ww-manta.wdl/#L49"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-manta/ww-manta.wdl/#L49"
+
+[[diagnostics]]
+document = "getwilds/wilds-wdl-library:/modules/ww-mosdepth/ww-mosdepth.wdl"
+message = "ww-mosdepth.wdl:45:10: warning[UnusedInput]: unused input `input_bam_index`"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-mosdepth/ww-mosdepth.wdl/#L45"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-rseqc/ww-rseqc.wdl"
 message = "ww-rseqc.wdl:46:10: warning[UnusedInput]: unused input `bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-rseqc/ww-rseqc.wdl/#L46"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-rseqc/ww-rseqc.wdl/#L46"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/ww-smoove.wdl"
 message = "ww-smoove.wdl:44:10: warning[UnusedInput]: unused input `aligned_bam_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/ww-smoove.wdl/#L44"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/ww-smoove.wdl/#L44"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-smoove/ww-smoove.wdl"
 message = "ww-smoove.wdl:46:10: warning[UnusedInput]: unused input `reference_fasta_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-smoove/ww-smoove.wdl/#L46"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-smoove/ww-smoove.wdl/#L46"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:151:10: warning[UnusedInput]: unused input `tumor_bai`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L151"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L151"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:154:10: warning[UnusedInput]: unused input `normal_bai`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L154"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L154"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:156:10: warning[UnusedInput]: unused input `ref_fasta_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L156"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L156"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:44:10: warning[UnusedInput]: unused input `bai`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L44"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L44"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-strelka/ww-strelka.wdl"
 message = "ww-strelka.wdl:46:10: warning[UnusedInput]: unused input `ref_fasta_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-strelka/ww-strelka.wdl/#L46"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-strelka/ww-strelka.wdl/#L46"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-testdata/ww-testdata.wdl"
 message = "ww-testdata.wdl:516:10: warning[UnusedInput]: unused input `input_bai`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-testdata/ww-testdata.wdl/#L516"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-testdata/ww-testdata.wdl/#L516"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-tritonnp/ww-tritonnp.wdl"
 message = "ww-tritonnp.wdl:46:10: warning[UnusedInput]: unused input `bam_index_path`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-tritonnp/ww-tritonnp.wdl/#L46"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-tritonnp/ww-tritonnp.wdl/#L46"
 
 [[diagnostics]]
 document = "getwilds/wilds-wdl-library:/modules/ww-tritonnp/ww-tritonnp.wdl"
 message = "ww-tritonnp.wdl:50:10: warning[UnusedInput]: unused input `reference_genome_index`"
-permalink = "https://github.com/getwilds/wilds-wdl-library/blob/404b3b6b4138b43ba33d08edbde6510a39be5a27/modules/ww-tritonnp/ww-tritonnp.wdl/#L50"
+permalink = "https://github.com/getwilds/wilds-wdl-library/blob/659d5802cc65695b211ae9b72d9095524b33734b/modules/ww-tritonnp/ww-tritonnp.wdl/#L50"
 
 [[diagnostics]]
 document = "stjudecloud/workflows:/tools/arriba.wdl"


### PR DESCRIPTION
CI broke again from upstream changes

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
