### PR TITLE
chore: warn on `clippy::manual_assert_eq`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,6 +161,7 @@ missing_docs_in_private_items = "warn"
 #
 # Ref: https://rust-lang.github.io/rust-clippy/master/index.html#new_without_default
 new_without_default = "allow"
+manual_assert_eq = "warn"
 
 [package]
 name = "sprocket"

--- a/crates/wdl-analysis/src/analyzer.rs
+++ b/crates/wdl-analysis/src/analyzer.rs
@@ -1377,14 +1377,14 @@ workflow something_else {
         let id = results[0].document.id().clone();
         let results = analyzer.analyze(()).await.unwrap();
         assert_eq!(results.len(), 1);
-        assert!(results[0].document.id().as_ref() != id.as_ref());
+        assert_ne!(results[0].document.id().as_ref(), id.as_ref());
         assert_eq!(results[0].document.diagnostics().count(), 0);
 
         // Analyze again and ensure the analysis result id is unchanged
         let id = results[0].document.id().clone();
         let results = analyzer.analyze_document((), uri).await.unwrap();
         assert_eq!(results.len(), 1);
-        assert!(results[0].document.id().as_ref() == id.as_ref());
+        assert_eq!(results[0].document.id().as_ref(), id.as_ref());
         assert_eq!(results[0].document.diagnostics().count(), 0);
     }
 
@@ -1451,7 +1451,7 @@ workflow test {
         let id = results[0].document.id().clone();
         let results = analyzer.analyze_document((), uri).await.unwrap();
         assert_eq!(results.len(), 1);
-        assert!(results[0].document.id().as_ref() != id.as_ref());
+        assert_ne!(results[0].document.id().as_ref(), id.as_ref());
         assert_eq!(results[0].document.diagnostics().count(), 0);
     }
 

--- a/crates/wdl-ast/src/v1/task/requirements/item/container.rs
+++ b/crates/wdl-ast/src/v1/task/requirements/item/container.rs
@@ -79,7 +79,7 @@ task hello {
 
         let container = section.items().filter_map(|p| p.into_container());
 
-        assert!(container.count() == 1);
+        assert_eq!(container.count(), 1);
     }
 
     #[test]

--- a/crates/wdl-ast/src/v1/task/runtime/item/container.rs
+++ b/crates/wdl-ast/src/v1/task/runtime/item/container.rs
@@ -83,7 +83,7 @@ task hello {
 
         let container = section.items().filter_map(|p| p.into_container());
 
-        assert!(container.count() == 1);
+        assert_eq!(container.count(), 1);
     }
 
     #[test]
@@ -113,7 +113,7 @@ task hello {
 
         let container = section.items().filter_map(|p| p.into_container());
 
-        assert!(container.count() == 0);
+        assert_eq!(container.count(), 0);
     }
 
     #[test]
@@ -143,6 +143,6 @@ task hello {
 
         let container = section.items().filter_map(|p| p.into_container());
 
-        assert!(container.count() == 1);
+        assert_eq!(container.count(), 1);
     }
 }

--- a/crates/wdl-engine/src/digest.rs
+++ b/crates/wdl-engine/src/digest.rs
@@ -972,7 +972,7 @@ pub(crate) mod test {
         let modified = calculate_directory_digest(dir.path(), ContentDigestMode::Strong)
             .await
             .expect("failed to calculate digest");
-        assert!(digest != modified);
+        assert_ne!(digest, modified);
 
         // Restore the file
         fs::write(&target, b"hello world!").expect("failed to create temporary file");

--- a/crates/wdl-engine/src/outputs.rs
+++ b/crates/wdl-engine/src/outputs.rs
@@ -46,7 +46,7 @@ impl Outputs {
         // resulting sort is still considered to be stable
         self.values.sort_unstable_by(move |a, _, b, _| {
             let ordering = cmp(a, b);
-            assert!(ordering != Ordering::Equal);
+            assert_ne!(ordering, Ordering::Equal);
             ordering
         });
     }

--- a/crates/wdl-engine/src/stdlib/glob.rs
+++ b/crates/wdl-engine/src/stdlib/glob.rs
@@ -33,7 +33,7 @@ const FUNCTION_NAME: &str = "glob";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#glob
 fn glob(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_file_type().clone()));
 
         // Construct a glob from the given argument

--- a/crates/wdl-engine/src/stdlib/join_paths.rs
+++ b/crates/wdl-engine/src/stdlib/join_paths.rs
@@ -28,7 +28,7 @@ const FUNCTION_NAME: &str = "join_paths";
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#-join_paths
 fn join_paths_simple(context: CallContext<'_>) -> Result<Value, Diagnostic> {
-    debug_assert!(context.arguments.len() == 2);
+    debug_assert_eq!(context.arguments.len(), 2);
     debug_assert!(context.return_type_eq(PrimitiveType::String));
 
     let first = context

--- a/crates/wdl-engine/src/stdlib/read_boolean.rs
+++ b/crates/wdl-engine/src/stdlib/read_boolean.rs
@@ -29,7 +29,7 @@ const FUNCTION_NAME: &str = "read_boolean";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_boolean
 fn read_boolean(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(PrimitiveType::Boolean));
 
         let path = context

--- a/crates/wdl-engine/src/stdlib/read_float.rs
+++ b/crates/wdl-engine/src/stdlib/read_float.rs
@@ -28,7 +28,7 @@ const FUNCTION_NAME: &str = "read_float";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_float
 fn read_float(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(PrimitiveType::Float));
 
         let path = context

--- a/crates/wdl-engine/src/stdlib/read_int.rs
+++ b/crates/wdl-engine/src/stdlib/read_int.rs
@@ -28,7 +28,7 @@ const FUNCTION_NAME: &str = "read_int";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_int
 fn read_int(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(PrimitiveType::Integer));
 
         let path = context

--- a/crates/wdl-engine/src/stdlib/read_json.rs
+++ b/crates/wdl-engine/src/stdlib/read_json.rs
@@ -28,7 +28,7 @@ const FUNCTION_NAME: &str = "read_json";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_json
 fn read_json(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(Type::Union));
 
         let path = context

--- a/crates/wdl-engine/src/stdlib/read_lines.rs
+++ b/crates/wdl-engine/src/stdlib/read_lines.rs
@@ -35,7 +35,7 @@ const FUNCTION_NAME: &str = "read_lines";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_lines
 fn read_lines(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_string_type().clone()));
 
         let path = context

--- a/crates/wdl-engine/src/stdlib/read_map.rs
+++ b/crates/wdl-engine/src/stdlib/read_map.rs
@@ -39,7 +39,7 @@ const FUNCTION_NAME: &str = "read_map";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_map
 fn read_map(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.map_string_string_type().clone()));
 
         let path = context

--- a/crates/wdl-engine/src/stdlib/read_object.rs
+++ b/crates/wdl-engine/src/stdlib/read_object.rs
@@ -43,7 +43,7 @@ const FUNCTION_NAME: &str = "read_object";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_object
 fn read_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(Type::Object));
 
         let path = context

--- a/crates/wdl-engine/src/stdlib/read_objects.rs
+++ b/crates/wdl-engine/src/stdlib/read_objects.rs
@@ -47,7 +47,7 @@ const FUNCTION_NAME: &str = "read_objects";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_objects
 fn read_objects(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_object_type().clone()));
 
         let path = context

--- a/crates/wdl-engine/src/stdlib/read_string.rs
+++ b/crates/wdl-engine/src/stdlib/read_string.rs
@@ -26,7 +26,7 @@ const FUNCTION_NAME: &str = "read_string";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_string
 fn read_string(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(PrimitiveType::String));
 
         let path = context

--- a/crates/wdl-engine/src/stdlib/read_tsv.rs
+++ b/crates/wdl-engine/src/stdlib/read_tsv.rs
@@ -67,7 +67,7 @@ impl TsvHeader {
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_tsv
 fn read_tsv_simple(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(ANALYSIS_STDLIB.array_array_string_type().clone()));
 
         let path = context

--- a/crates/wdl-engine/src/stdlib/write_json.rs
+++ b/crates/wdl-engine/src/stdlib/write_json.rs
@@ -22,7 +22,7 @@ const FUNCTION_NAME: &str = "write_json";
 ///
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_json
 fn write_json(context: CallContext<'_>) -> Result<Value, Diagnostic> {
-    debug_assert!(context.arguments.len() == 1);
+    debug_assert_eq!(context.arguments.len(), 1);
     debug_assert!(context.return_type_eq(PrimitiveType::File));
 
     // Helper for handling errors while writing to the file.

--- a/crates/wdl-engine/src/stdlib/write_lines.rs
+++ b/crates/wdl-engine/src/stdlib/write_lines.rs
@@ -31,7 +31,7 @@ const FUNCTION_NAME: &str = "write_lines";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_lines
 fn write_lines(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(PrimitiveType::File));
 
         // Helper for handling errors while writing to the file.

--- a/crates/wdl-engine/src/stdlib/write_map.rs
+++ b/crates/wdl-engine/src/stdlib/write_map.rs
@@ -34,7 +34,7 @@ const FUNCTION_NAME: &str = "write_map";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_map
 fn write_map(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(PrimitiveType::File));
 
         // Helper for handling errors while writing to the file.

--- a/crates/wdl-engine/src/stdlib/write_object.rs
+++ b/crates/wdl-engine/src/stdlib/write_object.rs
@@ -36,7 +36,7 @@ const FUNCTION_NAME: &str = "write_object";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_object
 fn write_object(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(PrimitiveType::File));
 
         // Helper for handling errors while writing to the file.

--- a/crates/wdl-engine/src/stdlib/write_objects.rs
+++ b/crates/wdl-engine/src/stdlib/write_objects.rs
@@ -46,7 +46,7 @@ const FUNCTION_NAME: &str = "write_objects";
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_objects
 fn write_objects(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(PrimitiveType::File));
 
         // Helper for handling errors while writing to the file.

--- a/crates/wdl-engine/src/stdlib/write_tsv.rs
+++ b/crates/wdl-engine/src/stdlib/write_tsv.rs
@@ -168,7 +168,7 @@ async fn write_array_tsv_file(
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_tsv
 fn write_tsv(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 1);
+        debug_assert_eq!(context.arguments.len(), 1);
         debug_assert!(context.return_type_eq(PrimitiveType::File));
 
         let rows = context
@@ -192,7 +192,7 @@ fn write_tsv(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic
 /// https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_tsv
 fn write_tsv_with_header(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
     async move {
-        debug_assert!(context.arguments.len() == 3);
+        debug_assert_eq!(context.arguments.len(), 3);
         debug_assert!(context.return_type_eq(PrimitiveType::File));
 
         let rows = context

--- a/crates/wdl-format/src/v1.rs
+++ b/crates/wdl-format/src/v1.rs
@@ -58,7 +58,10 @@ pub fn format_ast(element: &FormatElement, stream: &mut TokenStream<PreToken>, c
     let mut children = element.children().expect("AST children");
 
     let version_statement = children.next().expect("version statement");
-    assert!(version_statement.element().kind() == SyntaxKind::VersionStatementNode);
+    assert_eq!(
+        version_statement.element().kind(),
+        SyntaxKind::VersionStatementNode
+    );
     (&version_statement).write(stream, config);
 
     stream.blank_line();
@@ -169,7 +172,7 @@ pub fn format_version_statement(
     // but the preceding trivia may include one that will
     // be added if we don't exclude it.
     let version_keyword = children.next().expect("version keyword");
-    assert!(version_keyword.element().kind() == SyntaxKind::VersionKeyword);
+    assert_eq!(version_keyword.element().kind(), SyntaxKind::VersionKeyword);
     let mut buffer = TokenStream::<PreToken>::default();
     (&version_keyword).write(&mut buffer, config);
     let mut buff_iter = buffer.into_iter();
@@ -203,12 +206,12 @@ pub fn format_input_section(
     let mut children = element.children().expect("input section children");
 
     let input_keyword = children.next().expect("input section input keyword");
-    assert!(input_keyword.element().kind() == SyntaxKind::InputKeyword);
+    assert_eq!(input_keyword.element().kind(), SyntaxKind::InputKeyword);
     (&input_keyword).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("input section open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 
@@ -255,12 +258,12 @@ pub fn format_output_section(
     let mut children = element.children().expect("output section children");
 
     let output_keyword = children.next().expect("output keyword");
-    assert!(output_keyword.element().kind() == SyntaxKind::OutputKeyword);
+    assert_eq!(output_keyword.element().kind(), SyntaxKind::OutputKeyword);
     (&output_keyword).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("output section open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 
@@ -268,7 +271,7 @@ pub fn format_output_section(
         if child.element().kind() == SyntaxKind::CloseBrace {
             stream.decrement_indent();
         } else {
-            assert!(child.element().kind() == SyntaxKind::BoundDeclNode);
+            assert_eq!(child.element().kind(), SyntaxKind::BoundDeclNode);
         }
         (&child).write(stream, config);
         stream.end_line();
@@ -289,16 +292,16 @@ pub fn format_literal_input_item(
     let mut children = element.children().expect("literal input item children");
 
     let key = children.next().expect("literal input item key");
-    assert!(key.element().kind() == SyntaxKind::Ident);
+    assert_eq!(key.element().kind(), SyntaxKind::Ident);
     (&key).write(stream, config);
 
     let colon = children.next().expect("literal input item colon");
-    assert!(colon.element().kind() == SyntaxKind::Colon);
+    assert_eq!(colon.element().kind(), SyntaxKind::Colon);
     (&colon).write(stream, config);
     stream.end_word();
 
     let hints_node = children.next().expect("literal input item hints node");
-    assert!(hints_node.element().kind() == SyntaxKind::LiteralHintsNode);
+    assert_eq!(hints_node.element().kind(), SyntaxKind::LiteralHintsNode);
     (&hints_node).write(stream, config);
 }
 
@@ -316,12 +319,12 @@ pub fn format_literal_input(
     let mut children = element.children().expect("literal input children");
 
     let input_keyword = children.next().expect("literal input keyword");
-    assert!(input_keyword.element().kind() == SyntaxKind::InputKeyword);
+    assert_eq!(input_keyword.element().kind(), SyntaxKind::InputKeyword);
     (&input_keyword).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("literal input open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 
@@ -367,11 +370,11 @@ pub fn format_literal_hints_item(
     let mut children = element.children().expect("literal hints item children");
 
     let key = children.next().expect("literal hints item key");
-    assert!(key.element().kind() == SyntaxKind::Ident);
+    assert_eq!(key.element().kind(), SyntaxKind::Ident);
     (&key).write(stream, config);
 
     let colon = children.next().expect("literal hints item colon");
-    assert!(colon.element().kind() == SyntaxKind::Colon);
+    assert_eq!(colon.element().kind(), SyntaxKind::Colon);
     (&colon).write(stream, config);
     stream.end_word();
 
@@ -393,12 +396,12 @@ pub fn format_literal_hints(
     let mut children = element.children().expect("literal hints children");
 
     let hints_keyword = children.next().expect("literal hints keyword");
-    assert!(hints_keyword.element().kind() == SyntaxKind::HintsKeyword);
+    assert_eq!(hints_keyword.element().kind(), SyntaxKind::HintsKeyword);
     (&hints_keyword).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("literal hints open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 
@@ -447,7 +450,7 @@ pub fn format_literal_output_item(
         if matches!(child.element().kind(), SyntaxKind::Ident | SyntaxKind::Dot) {
             (&child).write(stream, config);
         } else {
-            assert!(child.element().kind() == SyntaxKind::Colon);
+            assert_eq!(child.element().kind(), SyntaxKind::Colon);
             (&child).write(stream, config);
             stream.end_word();
             break;
@@ -472,12 +475,12 @@ pub fn format_literal_output(
     let mut children = element.children().expect("literal output children");
 
     let output_keyword = children.next().expect("literal output keyword");
-    assert!(output_keyword.element().kind() == SyntaxKind::OutputKeyword);
+    assert_eq!(output_keyword.element().kind(), SyntaxKind::OutputKeyword);
     (&output_keyword).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("literal output open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 

--- a/crates/wdl-format/src/v1/enum.rs
+++ b/crates/wdl-format/src/v1/enum.rs
@@ -21,12 +21,12 @@ pub fn format_enum_definition(
     let mut children = element.children().expect("enum definition children");
 
     let enum_keyword = children.next().expect("enum keyword");
-    assert!(enum_keyword.element().kind() == SyntaxKind::EnumKeyword);
+    assert_eq!(enum_keyword.element().kind(), SyntaxKind::EnumKeyword);
     (&enum_keyword).write(stream, config);
     stream.end_word();
 
     let name = children.next().expect("enum name");
-    assert!(name.element().kind() == SyntaxKind::Ident);
+    assert_eq!(name.element().kind(), SyntaxKind::Ident);
     (&name).write(stream, config);
 
     let mut choices = Vec::new();
@@ -91,7 +91,7 @@ pub fn format_enum_choice(
     let mut children = element.children().expect("enum choice children");
 
     let name = children.next().expect("enum choice name");
-    assert!(name.element().kind() == SyntaxKind::Ident);
+    assert_eq!(name.element().kind(), SyntaxKind::Ident);
     (&name).write(stream, config);
 
     for child in children {

--- a/crates/wdl-format/src/v1/expr.rs
+++ b/crates/wdl-format/src/v1/expr.rs
@@ -21,15 +21,15 @@ pub fn format_sep_option(
     let mut children = element.children().expect("sep option children");
 
     let sep_keyword = children.next().expect("sep keyword");
-    assert!(sep_keyword.element().kind() == SyntaxKind::Ident);
+    assert_eq!(sep_keyword.element().kind(), SyntaxKind::Ident);
     (&sep_keyword).write(stream, config);
 
     let equals = children.next().expect("sep equals");
-    assert!(equals.element().kind() == SyntaxKind::Assignment);
+    assert_eq!(equals.element().kind(), SyntaxKind::Assignment);
     (&equals).write(stream, config);
 
     let sep_value = children.next().expect("sep value");
-    assert!(sep_value.element().kind() == SyntaxKind::LiteralStringNode);
+    assert_eq!(sep_value.element().kind(), SyntaxKind::LiteralStringNode);
     (&sep_value).write(stream, config);
     stream.end_word();
 }
@@ -47,11 +47,11 @@ pub fn format_default_option(
     let mut children = element.children().expect("default option children");
 
     let default_keyword = children.next().expect("default keyword");
-    assert!(default_keyword.element().kind() == SyntaxKind::Ident);
+    assert_eq!(default_keyword.element().kind(), SyntaxKind::Ident);
     (&default_keyword).write(stream, config);
 
     let equals = children.next().expect("default equals");
-    assert!(equals.element().kind() == SyntaxKind::Assignment);
+    assert_eq!(equals.element().kind(), SyntaxKind::Assignment);
     (&equals).write(stream, config);
 
     let default_value = children.next().expect("default value");
@@ -79,7 +79,7 @@ pub fn format_true_false_option(
     );
 
     let first_equals = children.next().expect("true false option first equals");
-    assert!(first_equals.element().kind() == SyntaxKind::Assignment);
+    assert_eq!(first_equals.element().kind(), SyntaxKind::Assignment);
 
     let first_value = children.next().expect("true false option first value");
 
@@ -91,12 +91,12 @@ pub fn format_true_false_option(
     );
 
     let second_equals = children.next().expect("true false option second equals");
-    assert!(second_equals.element().kind() == SyntaxKind::Assignment);
+    assert_eq!(second_equals.element().kind(), SyntaxKind::Assignment);
 
     let second_value = children.next().expect("true false option second value");
 
     if first_keyword_kind == SyntaxKind::TrueKeyword {
-        assert!(second_keyword_kind == SyntaxKind::FalseKeyword);
+        assert_eq!(second_keyword_kind, SyntaxKind::FalseKeyword);
         (&first_keyword).write(stream, config);
         (&first_equals).write(stream, config);
         (&first_value).write(stream, config);
@@ -105,7 +105,7 @@ pub fn format_true_false_option(
         (&second_equals).write(stream, config);
         (&second_value).write(stream, config);
     } else {
-        assert!(second_keyword_kind == SyntaxKind::TrueKeyword);
+        assert_eq!(second_keyword_kind, SyntaxKind::TrueKeyword);
         (&second_keyword).write(stream, config);
         (&second_equals).write(stream, config);
         (&second_value).write(stream, config);
@@ -130,7 +130,7 @@ pub fn format_placeholder(
     let mut children = element.children().expect("placeholder children");
 
     let open = children.next().expect("placeholder open");
-    assert!(open.element().kind() == SyntaxKind::PlaceholderOpen);
+    assert_eq!(open.element().kind(), SyntaxKind::PlaceholderOpen);
     let syntax = open.element().inner();
     let text = syntax.as_token().expect("token").text();
     match text {
@@ -239,7 +239,7 @@ pub fn format_literal_none(
 ) {
     let mut children = element.children().expect("literal none children");
     let none = children.next().expect("literal none token");
-    assert!(none.element().kind() == SyntaxKind::NoneKeyword);
+    assert_eq!(none.element().kind(), SyntaxKind::NoneKeyword);
     (&none).write(stream, config);
 }
 
@@ -256,14 +256,14 @@ pub fn format_literal_pair(
     let mut children = element.children().expect("literal pair children");
 
     let open_paren = children.next().expect("literal pair open paren");
-    assert!(open_paren.element().kind() == SyntaxKind::OpenParen);
+    assert_eq!(open_paren.element().kind(), SyntaxKind::OpenParen);
     (&open_paren).write(stream, config);
 
     let left = children.next().expect("literal pair left");
     (&left).write(stream, config);
 
     let comma = children.next().expect("literal pair comma");
-    assert!(comma.element().kind() == SyntaxKind::Comma);
+    assert_eq!(comma.element().kind(), SyntaxKind::Comma);
     (&comma).write(stream, config);
     stream.end_word();
 
@@ -271,7 +271,7 @@ pub fn format_literal_pair(
     (&right).write(stream, config);
 
     let close_paren = children.next().expect("literal pair close paren");
-    assert!(close_paren.element().kind() == SyntaxKind::CloseParen);
+    assert_eq!(close_paren.element().kind(), SyntaxKind::CloseParen);
     (&close_paren).write(stream, config);
 }
 
@@ -302,7 +302,7 @@ pub fn format_negation_expr(
 ) {
     let mut children = element.children().expect("negation expr children");
     let minus = children.next().expect("negation expr minus");
-    assert!(minus.element().kind() == SyntaxKind::Minus);
+    assert_eq!(minus.element().kind(), SyntaxKind::Minus);
     (&minus).write(stream, config);
 
     let expr = children.next().expect("negation expr expr");
@@ -367,7 +367,7 @@ pub fn format_literal_array(
     let mut children = element.children().expect("literal array children");
 
     let open_bracket = children.next().expect("literal array open bracket");
-    assert!(open_bracket.element().kind() == SyntaxKind::OpenBracket);
+    assert_eq!(open_bracket.element().kind(), SyntaxKind::OpenBracket);
     (&open_bracket).write(stream, config);
 
     let mut items = Vec::new();
@@ -425,7 +425,7 @@ pub fn format_literal_map_item(
     (&key).write(stream, config);
 
     let colon = children.next().expect("literal map item colon");
-    assert!(colon.element().kind() == SyntaxKind::Colon);
+    assert_eq!(colon.element().kind(), SyntaxKind::Colon);
     (&colon).write(stream, config);
     stream.end_word();
 
@@ -446,7 +446,7 @@ pub fn format_literal_map(
     let mut children = element.children().expect("literal map children");
 
     let open_brace = children.next().expect("literal map open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 
@@ -496,11 +496,11 @@ pub fn format_literal_object_item(
     let mut children = element.children().expect("literal object item children");
 
     let key = children.next().expect("literal object item key");
-    assert!(key.element().kind() == SyntaxKind::Ident);
+    assert_eq!(key.element().kind(), SyntaxKind::Ident);
     (&key).write(stream, config);
 
     let colon = children.next().expect("literal object item colon");
-    assert!(colon.element().kind() == SyntaxKind::Colon);
+    assert_eq!(colon.element().kind(), SyntaxKind::Colon);
     (&colon).write(stream, config);
     stream.end_word();
 
@@ -522,12 +522,12 @@ pub fn format_literal_object(
     let mut children = element.children().expect("literal object children");
 
     let object_keyword = children.next().expect("literal object keyword");
-    assert!(object_keyword.element().kind() == SyntaxKind::ObjectKeyword);
+    assert_eq!(object_keyword.element().kind(), SyntaxKind::ObjectKeyword);
     (&object_keyword).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("literal object open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 
@@ -778,7 +778,7 @@ pub fn format_logical_not_expr(
 ) {
     let mut children = element.children().expect("logical not expr children");
     let not = children.next().expect("logical not expr not");
-    assert!(not.element().kind() == SyntaxKind::Exclamation);
+    assert_eq!(not.element().kind(), SyntaxKind::Exclamation);
     (&not).write(stream, config);
 
     let expr = children.next().expect("logical not expr expr");

--- a/crates/wdl-format/src/v1/meta.rs
+++ b/crates/wdl-format/src/v1/meta.rs
@@ -36,7 +36,7 @@ pub fn format_metadata_array(
     let mut children = element.children().expect("metadata array children");
 
     let open_bracket = children.next().expect("metadata array open bracket");
-    assert!(open_bracket.element().kind() == SyntaxKind::OpenBracket);
+    assert_eq!(open_bracket.element().kind(), SyntaxKind::OpenBracket);
     (&open_bracket).write(stream, config);
 
     let mut items = Vec::new();
@@ -92,7 +92,7 @@ pub fn format_metadata_object(
     let mut children = element.children().expect("metadata object children");
 
     let open_brace = children.next().expect("metadata object open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
 
     let mut items = Vec::new();
@@ -152,11 +152,11 @@ pub fn format_metadata_object_item(
     let mut children = element.children().expect("metadata object item children");
 
     let key = children.next().expect("metadata object item key");
-    assert!(key.element().kind() == SyntaxKind::Ident);
+    assert_eq!(key.element().kind(), SyntaxKind::Ident);
     (&key).write(stream, config);
 
     let colon = children.next().expect("metadata object item colon");
-    assert!(colon.element().kind() == SyntaxKind::Colon);
+    assert_eq!(colon.element().kind(), SyntaxKind::Colon);
     (&colon).write(stream, config);
     stream.end_word();
 
@@ -177,12 +177,12 @@ pub fn format_metadata_section(
     let mut children = element.children().expect("meta section children");
 
     let meta_keyword = children.next().expect("meta keyword");
-    assert!(meta_keyword.element().kind() == SyntaxKind::MetaKeyword);
+    assert_eq!(meta_keyword.element().kind(), SyntaxKind::MetaKeyword);
     (&meta_keyword).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("metadata section open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 
@@ -227,14 +227,17 @@ pub fn format_parameter_metadata_section(
     let mut children = element.children().expect("parameter meta section children");
 
     let parameter_meta_keyword = children.next().expect("parameter meta keyword");
-    assert!(parameter_meta_keyword.element().kind() == SyntaxKind::ParameterMetaKeyword);
+    assert_eq!(
+        parameter_meta_keyword.element().kind(),
+        SyntaxKind::ParameterMetaKeyword
+    );
     (&parameter_meta_keyword).write(stream, config);
     stream.end_word();
 
     let open_brace = children
         .next()
         .expect("parameter metadata section open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 

--- a/crates/wdl-format/src/v1/struct.rs
+++ b/crates/wdl-format/src/v1/struct.rs
@@ -21,17 +21,17 @@ pub fn format_struct_definition(
     let mut children = element.children().expect("struct definition children");
 
     let struct_keyword = children.next().expect("struct keyword");
-    assert!(struct_keyword.element().kind() == SyntaxKind::StructKeyword);
+    assert_eq!(struct_keyword.element().kind(), SyntaxKind::StructKeyword);
     (&struct_keyword).write(stream, config);
     stream.end_word();
 
     let name = children.next().expect("struct name");
-    assert!(name.element().kind() == SyntaxKind::Ident);
+    assert_eq!(name.element().kind(), SyntaxKind::Ident);
     (&name).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.end_line();
     stream.increment_indent();
@@ -96,11 +96,11 @@ pub fn format_literal_struct_item(
     let mut children = element.children().expect("literal struct item children");
 
     let key = children.next().expect("literal struct item key");
-    assert!(key.element().kind() == SyntaxKind::Ident);
+    assert_eq!(key.element().kind(), SyntaxKind::Ident);
     (&key).write(stream, config);
 
     let colon = children.next().expect("literal struct item colon");
-    assert!(colon.element().kind() == SyntaxKind::Colon);
+    assert_eq!(colon.element().kind(), SyntaxKind::Colon);
     (&colon).write(stream, config);
     stream.end_word();
 
@@ -122,12 +122,12 @@ pub fn format_literal_struct(
     let mut children = element.children().expect("literal struct children");
 
     let name = children.next().expect("literal struct name");
-    assert!(name.element().kind() == SyntaxKind::Ident);
+    assert_eq!(name.element().kind(), SyntaxKind::Ident);
     (&name).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("literal struct open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 

--- a/crates/wdl-format/src/v1/task.rs
+++ b/crates/wdl-format/src/v1/task.rs
@@ -27,17 +27,17 @@ pub fn format_task_definition(
     stream.ignore_trailing_blank_lines();
 
     let task_keyword = children.next().expect("task keyword");
-    assert!(task_keyword.element().kind() == SyntaxKind::TaskKeyword);
+    assert_eq!(task_keyword.element().kind(), SyntaxKind::TaskKeyword);
     (&task_keyword).write(stream, config);
     stream.end_word();
 
     let name = children.next().expect("task name");
-    assert!(name.element().kind() == SyntaxKind::Ident);
+    assert_eq!(name.element().kind(), SyntaxKind::Ident);
     (&name).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.end_line();
     stream.increment_indent();
@@ -167,7 +167,7 @@ pub fn format_command_section(
     let mut children = element.children().expect("command section children");
 
     let command_keyword = children.next().expect("command keyword");
-    assert!(command_keyword.element().kind() == SyntaxKind::CommandKeyword);
+    assert_eq!(command_keyword.element().kind(), SyntaxKind::CommandKeyword);
     (&command_keyword).write(stream, config);
     stream.end_word();
 
@@ -320,11 +320,11 @@ pub fn format_requirements_item(
     let mut children = element.children().expect("requirements item children");
 
     let name = children.next().expect("requirements item name");
-    assert!(name.element().kind() == SyntaxKind::Ident);
+    assert_eq!(name.element().kind(), SyntaxKind::Ident);
     (&name).write(stream, config);
 
     let colon = children.next().expect("requirements item colon");
-    assert!(colon.element().kind() == SyntaxKind::Colon);
+    assert_eq!(colon.element().kind(), SyntaxKind::Colon);
     (&colon).write(stream, config);
     stream.end_word();
 
@@ -345,12 +345,15 @@ pub fn format_requirements_section(
     let mut children = element.children().expect("requirements section children");
 
     let requirements_keyword = children.next().expect("requirements keyword");
-    assert!(requirements_keyword.element().kind() == SyntaxKind::RequirementsKeyword);
+    assert_eq!(
+        requirements_keyword.element().kind(),
+        SyntaxKind::RequirementsKeyword
+    );
     (&requirements_keyword).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 
@@ -397,11 +400,11 @@ pub fn format_task_hints_item(
     let mut children = element.children().expect("task hints item children");
 
     let name = children.next().expect("task hints item name");
-    assert!(name.element().kind() == SyntaxKind::Ident);
+    assert_eq!(name.element().kind(), SyntaxKind::Ident);
     (&name).write(stream, config);
 
     let colon = children.next().expect("task hints item colon");
-    assert!(colon.element().kind() == SyntaxKind::Colon);
+    assert_eq!(colon.element().kind(), SyntaxKind::Colon);
     (&colon).write(stream, config);
     stream.end_word();
 
@@ -424,11 +427,11 @@ pub fn format_runtime_item(
     let mut children = element.children().expect("runtime item children");
 
     let name = children.next().expect("runtime item name");
-    assert!(name.element().kind() == SyntaxKind::Ident);
+    assert_eq!(name.element().kind(), SyntaxKind::Ident);
     (&name).write(stream, config);
 
     let colon = children.next().expect("runtime item colon");
-    assert!(colon.element().kind() == SyntaxKind::Colon);
+    assert_eq!(colon.element().kind(), SyntaxKind::Colon);
     (&colon).write(stream, config);
     stream.end_word();
 
@@ -449,12 +452,12 @@ pub fn format_runtime_section(
     let mut children = element.children().expect("runtime section children");
 
     let runtime_keyword = children.next().expect("runtime keyword");
-    assert!(runtime_keyword.element().kind() == SyntaxKind::RuntimeKeyword);
+    assert_eq!(runtime_keyword.element().kind(), SyntaxKind::RuntimeKeyword);
     (&runtime_keyword).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 
@@ -501,12 +504,12 @@ pub fn format_task_hints_section(
     let mut children = element.children().expect("task hints section children");
 
     let hints_keyword = children.next().expect("hints keyword");
-    assert!(hints_keyword.element().kind() == SyntaxKind::HintsKeyword);
+    assert_eq!(hints_keyword.element().kind(), SyntaxKind::HintsKeyword);
     (&hints_keyword).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 

--- a/crates/wdl-format/src/v1/workflow.rs
+++ b/crates/wdl-format/src/v1/workflow.rs
@@ -68,7 +68,7 @@ pub fn format_conditional_statement_clause(
     // the parens and all elements inside!
     if has_condition {
         let open_paren = children.next().expect("open paren");
-        assert!(open_paren.element().kind() == SyntaxKind::OpenParen);
+        assert_eq!(open_paren.element().kind(), SyntaxKind::OpenParen);
         (&open_paren).write(stream, config);
 
         for child in children.by_ref() {
@@ -81,7 +81,7 @@ pub fn format_conditional_statement_clause(
     }
 
     let open_brace = children.next().expect("open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 
@@ -107,21 +107,21 @@ pub fn format_scatter_statement(
     let mut children = element.children().expect("scatter statement children");
 
     let scatter_keyword = children.next().expect("scatter keyword");
-    assert!(scatter_keyword.element().kind() == SyntaxKind::ScatterKeyword);
+    assert_eq!(scatter_keyword.element().kind(), SyntaxKind::ScatterKeyword);
     (&scatter_keyword).write(stream, config);
     stream.end_word();
 
     let open_paren = children.next().expect("open paren");
-    assert!(open_paren.element().kind() == SyntaxKind::OpenParen);
+    assert_eq!(open_paren.element().kind(), SyntaxKind::OpenParen);
     (&open_paren).write(stream, config);
 
     let variable = children.next().expect("scatter variable");
-    assert!(variable.element().kind() == SyntaxKind::Ident);
+    assert_eq!(variable.element().kind(), SyntaxKind::Ident);
     (&variable).write(stream, config);
     stream.end_word();
 
     let in_keyword = children.next().expect("in keyword");
-    assert!(in_keyword.element().kind() == SyntaxKind::InKeyword);
+    assert_eq!(in_keyword.element().kind(), SyntaxKind::InKeyword);
     (&in_keyword).write(stream, config);
     stream.end_word();
 
@@ -134,7 +134,7 @@ pub fn format_scatter_statement(
     }
 
     let open_brace = children.next().expect("open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.end_line();
     stream.increment_indent();
@@ -163,17 +163,20 @@ pub fn format_workflow_definition(
     stream.ignore_trailing_blank_lines();
 
     let workflow_keyword = children.next().expect("workflow keyword");
-    assert!(workflow_keyword.element().kind() == SyntaxKind::WorkflowKeyword);
+    assert_eq!(
+        workflow_keyword.element().kind(),
+        SyntaxKind::WorkflowKeyword
+    );
     (&workflow_keyword).write(stream, config);
     stream.end_word();
 
     let name = children.next().expect("workflow name");
-    assert!(name.element().kind() == SyntaxKind::Ident);
+    assert_eq!(name.element().kind(), SyntaxKind::Ident);
     (&name).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 
@@ -281,7 +284,7 @@ pub fn format_workflow_hints_array(
     let mut children = element.children().expect("workflow hints array children");
 
     let open_bracket = children.next().expect("open bracket");
-    assert!(open_bracket.element().kind() == SyntaxKind::OpenBracket);
+    assert_eq!(open_bracket.element().kind(), SyntaxKind::OpenBracket);
     (&open_bracket).write(stream, config);
     stream.increment_indent();
 
@@ -335,11 +338,11 @@ pub fn format_workflow_hints_item(
     let mut children = element.children().expect("workflow hints item children");
 
     let key = children.next().expect("workflow hints item key");
-    assert!(key.element().kind() == SyntaxKind::Ident);
+    assert_eq!(key.element().kind(), SyntaxKind::Ident);
     (&key).write(stream, config);
 
     let colon = children.next().expect("workflow hints item colon");
-    assert!(colon.element().kind() == SyntaxKind::Colon);
+    assert_eq!(colon.element().kind(), SyntaxKind::Colon);
     (&colon).write(stream, config);
     stream.end_word();
 
@@ -364,11 +367,11 @@ pub fn format_workflow_hints_object_item(
         .expect("workflow hints object item children");
 
     let key = children.next().expect("workflow hints object item key");
-    assert!(key.element().kind() == SyntaxKind::Ident);
+    assert_eq!(key.element().kind(), SyntaxKind::Ident);
     (&key).write(stream, config);
 
     let colon = children.next().expect("workflow hints object item colon");
-    assert!(colon.element().kind() == SyntaxKind::Colon);
+    assert_eq!(colon.element().kind(), SyntaxKind::Colon);
     (&colon).write(stream, config);
     stream.end_word();
 
@@ -391,7 +394,7 @@ pub fn format_workflow_hints_object(
     let mut children = element.children().expect("workflow hints object children");
 
     let open_brace = children.next().expect("open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 
@@ -417,12 +420,12 @@ pub fn format_workflow_hints_section(
     let mut children = element.children().expect("workflow hints section children");
 
     let hints_keyword = children.next().expect("hints keyword");
-    assert!(hints_keyword.element().kind() == SyntaxKind::HintsKeyword);
+    assert_eq!(hints_keyword.element().kind(), SyntaxKind::HintsKeyword);
     (&hints_keyword).write(stream, config);
     stream.end_word();
 
     let open_brace = children.next().expect("open brace");
-    assert!(open_brace.element().kind() == SyntaxKind::OpenBrace);
+    assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
 

--- a/crates/wdl-format/src/v1/workflow/call.rs
+++ b/crates/wdl-format/src/v1/workflow/call.rs
@@ -95,7 +95,7 @@ pub fn format_call_statement(
     let mut children = element.children().expect("call statement children");
 
     let call_keyword = children.next().expect("call keyword");
-    assert!(call_keyword.element().kind() == SyntaxKind::CallKeyword);
+    assert_eq!(call_keyword.element().kind(), SyntaxKind::CallKeyword);
     (&call_keyword).write(stream, config);
     stream.end_word();
 


### PR DESCRIPTION
Needed the extra debug info in a few tests, might as well convert them everywhere

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
