### PR TITLE
fix: respect --limit for status page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* For `sprocket dev server status`, the `--limit` parameter is now respected: passing `--limit N` displays at most N runs by fetching a single page. When `--limit` is omitted, all runs are displayed by paginating through the server's results. The footer distinguishes between "total run(s) in the system" (no filter) and "total matching run(s)" (with a `--status` filter) so a filtered count is not misreported as global ([#1050](https://github.com/stjude-rust-labs/sprocket/pull/1050)).
+* For `sprocket dev server status`, the `--limit` parameter is now respected: passing `--limit N` displays at most N runs by fetching a single page. When `--limit` is omitted, all runs are displayed by paginating through the server's results. The footer distinguishes between "total run(s) in the system" (no filter) and "total matching run(s)" (with a `--status` filter) so a filtered count is not misreported as global. The `--json` output now includes a `total` field alongside `runs` ([#1050](https://github.com/stjude-rust-labs/sprocket/pull/1050)).
 * For `sprocket run`, the execution backend is now considered for the call
   cache key derivation, which prevents unexpected behavior when switching
   executing backends. NOTE: this will cause existing call cache entries to be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* For `sprocket dev server status`, the `--limit` parameter is now respected ([#1050](https://github.com/stjude-rust-labs/sprocket/pull/1050)).
+* For `sprocket dev server status`, the `--limit` parameter is now respected: passing `--limit N` displays at most N runs by fetching a single page. When `--limit` is omitted, all runs are displayed by paginating through the server's results. The footer distinguishes between "total run(s) in the system" (no filter) and "total matching run(s)" (with a `--status` filter) so a filtered count is not misreported as global ([#1050](https://github.com/stjude-rust-labs/sprocket/pull/1050)).
 * For `sprocket run`, the execution backend is now considered for the call
   cache key derivation, which prevents unexpected behavior when switching
   executing backends. NOTE: this will cause existing call cache entries to be

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* For `sprocket dev server status`, the `--limit` parameter is now respected ([#1050](https://github.com/stjude-rust-labs/sprocket/pull/1050)).
 * For `sprocket run`, the execution backend is now considered for the call
   cache key derivation, which prevents unexpected behavior when switching
   executing backends. NOTE: this will cause existing call cache entries to be

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -15,6 +15,7 @@ use crate::commands::inspect::status_color;
 use crate::commands::inspect::task_counts_summary;
 use crate::config::Config;
 use crate::server::ListRunsResponse;
+use crate::server::Run;
 use crate::server::RunResponse;
 use crate::server::RunStatus;
 use crate::server::paths;
@@ -40,11 +41,13 @@ pub struct Args {
     #[clap(long, value_name = "STATUS")]
     status: Option<String>,
 
-    /// Maximum number of runs to return per page.
+    /// Maximum number of runs to display.
     ///
-    /// Only used when no `RUN` is provided.
-    #[clap(long, value_name = "N", default_value = "100", value_parser = clap::value_parser!(i64).range(1..))]
-    limit: i64,
+    /// When set, fetches a single page of at most `N` runs. When omitted, all
+    /// runs are displayed by paginating through the server's results. Only
+    /// used when no `RUN` is provided.
+    #[clap(long, value_name = "N", value_parser = clap::value_parser!(i64).range(1..))]
+    limit: Option<i64>,
 
     /// Output the raw JSON response instead of the formatted summary.
     #[clap(long)]
@@ -152,31 +155,25 @@ async fn status_single(
     Ok(())
 }
 
-/// Lists all runs one per line, paginating through all pages.
+/// Lists runs.
+///
+/// When `limit` is `Some(n)`, fetches a single page of at most `n` runs. When
+/// `limit` is `None`, paginates through all runs from the server. Prints one
+/// run per line followed by a footer summarizing the count actually displayed
+/// alongside the server-reported total (which reflects any active
+/// `status_filter`).
 async fn status_list(
     base_url: &str,
     status_filter: Option<RunStatus>,
-    limit: i64,
+    limit: Option<i64>,
     json: bool,
     colorize: bool,
 ) -> CommandResult<()> {
     let client = reqwest::Client::new();
-
-    // `--limit` is a client-visible cap on how many runs to show, so fetch a
-    // single page of at most `limit` runs. The server's `total` field is
-    // captured separately so the footer can report how many runs exist in the
-    // system independent of what was displayed.
-    let mut url = format!("{base_url}{path}?limit={limit}", path = paths::LIST_RUNS);
-    if let Some(s) = &status_filter {
-        url.push_str(&format!("&status={s}"));
-    }
-
-    let page: ListRunsResponse = send_json(client.get(&url), "run list").await?;
-    let total_runs = page.total;
-    let all_runs = page.runs;
+    let (runs, total_runs) = fetch_run_list(&client, base_url, status_filter, limit).await?;
 
     if json {
-        let value = serde_json::json!({ "runs": all_runs });
+        let value = serde_json::json!({ "runs": runs, "total": total_runs });
         println!(
             "{}",
             serde_json::to_string_pretty(&value).context("failed to pretty-print response")?
@@ -184,9 +181,9 @@ async fn status_list(
         return Ok(());
     }
 
-    let total = all_runs.len();
+    let total = runs.len();
 
-    for run in &all_runs {
+    for run in &runs {
         let status_str = run.status.to_string();
         let status_display = if colorize {
             status_str
@@ -230,7 +227,305 @@ async fn status_list(
         );
     }
 
-    println!("{total} run(s) shown. {total_runs} total run(s) in the system.");
+    // The footer distinguishes between "total in the system" (no filter) and
+    // "total matching" (a `--status` filter is in effect). This matters
+    // because the server's `total` reflects the applied filter, so reporting
+    // it as a global count would be misleading when the filter is set.
+    if status_filter.is_some() {
+        println!("{total} run(s) shown. {total_runs} total matching run(s).");
+    } else {
+        println!("{total} run(s) shown. {total_runs} total run(s) in the system.");
+    }
 
     Ok(())
+}
+
+/// Builds the URL for a `list_runs` request.
+///
+/// Extracted for testability. `limit` is passed as a `?limit=N` query
+/// parameter when `Some`; `status_filter` is added as `?status=X` when `Some`;
+/// `next_token` is added as `?next_token=T` when `Some`.
+fn build_list_runs_url(
+    base_url: &str,
+    status_filter: Option<RunStatus>,
+    limit: Option<i64>,
+    next_token: Option<&str>,
+) -> String {
+    let mut url = format!("{base_url}{path}", path = paths::LIST_RUNS);
+    let mut params = Vec::new();
+    if let Some(n) = limit {
+        params.push(format!("limit={n}"));
+    }
+    if let Some(s) = status_filter {
+        params.push(format!("status={s}"));
+    }
+    if let Some(t) = next_token {
+        params.push(format!("next_token={t}"));
+    }
+    if !params.is_empty() {
+        url.push('?');
+        url.push_str(&params.join("&"));
+    }
+    url
+}
+
+/// Fetches the run list from the server.
+///
+/// When `limit` is `Some(n)`, issues a single request with `?limit=n` and
+/// returns only that page. When `limit` is `None`, follows the server's
+/// `next_token` chain and returns every matching run. Returns
+/// `(runs, server_total)` where `server_total` reflects any active
+/// `status_filter`.
+async fn fetch_run_list(
+    client: &reqwest::Client,
+    base_url: &str,
+    status_filter: Option<RunStatus>,
+    limit: Option<i64>,
+) -> CommandResult<(Vec<Run>, i64)> {
+    let mut runs = Vec::new();
+    let mut next_token: Option<String> = None;
+    let total;
+
+    loop {
+        let url = build_list_runs_url(base_url, status_filter, limit, next_token.as_deref());
+        let page: ListRunsResponse = send_json(client.get(&url), "run list").await?;
+        runs.extend(page.runs);
+        next_token = page.next_token;
+
+        // Explicit `--limit N` caps the client at one page. Otherwise follow
+        // the server's pagination chain until it stops.
+        if limit.is_some() || next_token.is_none() {
+            total = page.total;
+            break;
+        }
+    }
+
+    Ok((runs, total))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use axum::Json;
+    use axum::Router;
+    use axum::extract::Query;
+    use axum::extract::State;
+    use axum::routing::get;
+    use chrono::Utc;
+    use serde::Deserialize;
+    use tokio::net::TcpListener;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::server::ListRunsResponse;
+    use crate::server::Run;
+
+    /// State captured by the mock server for later assertions.
+    #[derive(Default)]
+    struct MockState {
+        /// Every request URL/query received, in order.
+        request_queries: Mutex<Vec<String>>,
+    }
+
+    /// Query params the mock cares about.
+    #[derive(Deserialize)]
+    struct MockQuery {
+        #[serde(default)]
+        status: Option<String>,
+        #[serde(default)]
+        limit: Option<i64>,
+        #[serde(default)]
+        next_token: Option<String>,
+    }
+
+    /// Builds a fake `Run` for use in mock responses.
+    fn fake_run(name: &str) -> Run {
+        Run {
+            uuid: Uuid::new_v4(),
+            session_uuid: Uuid::new_v4(),
+            name: name.to_string(),
+            source: "test.wdl".to_string(),
+            target: Some("test".to_string()),
+            status: RunStatus::Running,
+            inputs: "{}".to_string(),
+            outputs: None,
+            error: None,
+            directory: None,
+            index_directory: None,
+            started_at: None,
+            completed_at: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    /// Handler that returns a fixed set of pages depending on `next_token`.
+    ///
+    /// If no `next_token` is provided, returns the first page of 3 runs with
+    /// `next_token=Some("page-2")`. If `next_token=page-2` is provided,
+    /// returns 2 runs with `next_token=None` (last page). Total across all
+    /// pages: 5.
+    async fn paginated_handler(
+        State(state): State<Arc<MockState>>,
+        Query(q): Query<MockQuery>,
+    ) -> Json<ListRunsResponse> {
+        let query_str = format!(
+            "status={s:?}&limit={l:?}&next_token={t:?}",
+            s = q.status,
+            l = q.limit,
+            t = q.next_token,
+        );
+        state.request_queries.lock().unwrap().push(query_str);
+
+        match q.next_token.as_deref() {
+            None => Json(ListRunsResponse {
+                runs: vec![fake_run("a"), fake_run("b"), fake_run("c")],
+                total: 5,
+                next_token: Some("page-2".to_string()),
+            }),
+            Some("page-2") => Json(ListRunsResponse {
+                runs: vec![fake_run("d"), fake_run("e")],
+                total: 5,
+                next_token: None,
+            }),
+            other => panic!("unexpected next_token: {other:?}"),
+        }
+    }
+
+    /// Spins up an axum server on a random port that serves the paginated
+    /// mock at `/api/v1/runs`. Returns the base URL and shared state.
+    async fn start_mock_server() -> (String, Arc<MockState>, tokio::task::JoinHandle<()>) {
+        let state = Arc::new(MockState::default());
+        let router = Router::new()
+            .route(paths::LIST_RUNS, get(paginated_handler))
+            .with_state(state.clone());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        let base_url = format!("http://{addr}");
+        (base_url, state, server)
+    }
+
+    #[tokio::test]
+    async fn fetch_run_list_without_limit_paginates_through_all_pages() {
+        let (base_url, state, server) = start_mock_server().await;
+        let client = reqwest::Client::new();
+
+        let (runs, total) = fetch_run_list(&client, &base_url, None, None)
+            .await
+            .expect("fetch should succeed");
+
+        server.abort();
+
+        assert_eq!(
+            runs.len(),
+            5,
+            "should receive 5 runs across two pages when no --limit is set"
+        );
+        assert_eq!(total, 5, "server-reported total should be 5");
+
+        // Verify the client made two requests: first without `next_token`,
+        // second with `next_token=page-2`.
+        let queries = state.request_queries.lock().unwrap();
+        assert_eq!(queries.len(), 2, "should have made two requests");
+        assert!(
+            queries[0].contains("next_token=None"),
+            "first request should have no next_token: got `{}`",
+            queries[0]
+        );
+        assert!(
+            queries[1].contains("next_token=Some(\"page-2\")"),
+            "second request should have next_token=page-2: got `{}`",
+            queries[1]
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_run_list_with_limit_fetches_single_page_only() {
+        let (base_url, state, server) = start_mock_server().await;
+        let client = reqwest::Client::new();
+
+        let (runs, total) = fetch_run_list(&client, &base_url, None, Some(3))
+            .await
+            .expect("fetch should succeed");
+
+        server.abort();
+
+        assert_eq!(
+            runs.len(),
+            3,
+            "should receive only the first page's 3 runs when --limit is set"
+        );
+        assert_eq!(total, 5, "server-reported total should still be 5");
+
+        // Verify the client made exactly ONE request and did NOT follow the
+        // pagination chain.
+        let queries = state.request_queries.lock().unwrap();
+        assert_eq!(
+            queries.len(),
+            1,
+            "should have made exactly one request when --limit is set"
+        );
+        assert!(
+            queries[0].contains("limit=Some(3)"),
+            "request should include limit=3: got `{}`",
+            queries[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_run_list_forwards_status_filter_in_request() {
+        let (base_url, state, server) = start_mock_server().await;
+        let client = reqwest::Client::new();
+
+        let (..) = fetch_run_list(&client, &base_url, Some(RunStatus::Running), Some(1))
+            .await
+            .expect("fetch should succeed");
+
+        server.abort();
+
+        // Verify the request URL included `status=running`.
+        let queries = state.request_queries.lock().unwrap();
+        assert_eq!(queries.len(), 1);
+        assert!(
+            queries[0].contains("status=Some(\"running\")"),
+            "request should include the status filter: got `{}`",
+            queries[0]
+        );
+    }
+
+    #[test]
+    fn build_list_runs_url_matrix() {
+        // No params: no query string.
+        let url = build_list_runs_url("http://example.com", None, None, None);
+        assert_eq!(url, format!("http://example.com{}", paths::LIST_RUNS));
+
+        // Limit only.
+        let url = build_list_runs_url("http://example.com", None, Some(5), None);
+        assert!(url.ends_with("?limit=5"), "got `{url}`");
+
+        // Status only.
+        let url = build_list_runs_url("http://example.com", Some(RunStatus::Failed), None, None);
+        assert!(url.ends_with("?status=failed"), "got `{url}`");
+
+        // Next token only.
+        let url = build_list_runs_url("http://example.com", None, None, Some("abc"));
+        assert!(url.ends_with("?next_token=abc"), "got `{url}`");
+
+        // All three, in the fixed order limit → status → next_token.
+        let url = build_list_runs_url(
+            "http://example.com",
+            Some(RunStatus::Running),
+            Some(10),
+            Some("t"),
+        );
+        assert!(
+            url.ends_with("?limit=10&status=running&next_token=t"),
+            "got `{url}`"
+        );
+    }
 }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -161,27 +161,19 @@ async fn status_list(
     colorize: bool,
 ) -> CommandResult<()> {
     let client = reqwest::Client::new();
-    let mut next_token: Option<String> = None;
-    let mut all_runs = Vec::new();
 
-    loop {
-        let mut url = format!("{base_url}{path}?limit={limit}", path = paths::LIST_RUNS,);
-        if let Some(s) = &status_filter {
-            url.push_str(&format!("&status={s}"));
-        }
-        if let Some(token) = &next_token {
-            url.push_str(&format!("&next_token={token}"));
-        }
-
-        let page: ListRunsResponse = send_json(client.get(&url), "run list").await?;
-
-        all_runs.extend(page.runs);
-        next_token = page.next_token;
-
-        if next_token.is_none() {
-            break;
-        }
+    // `--limit` is a client-visible cap on how many runs to show, so fetch a
+    // single page of at most `limit` runs. The server's `total` field is
+    // captured separately so the footer can report how many runs exist in the
+    // system independent of what was displayed.
+    let mut url = format!("{base_url}{path}?limit={limit}", path = paths::LIST_RUNS);
+    if let Some(s) = &status_filter {
+        url.push_str(&format!("&status={s}"));
     }
+
+    let page: ListRunsResponse = send_json(client.get(&url), "run list").await?;
+    let total_runs = page.total;
+    let all_runs = page.runs;
 
     if json {
         let value = serde_json::json!({ "runs": all_runs });
@@ -238,7 +230,7 @@ async fn status_list(
         );
     }
 
-    println!("{total} run(s) shown.");
+    println!("{total} run(s) shown. {total_runs} total run(s) in the system.");
 
     Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -30,6 +30,7 @@ pub(crate) use api::v1::info::ServerInfoResponse;
 pub use api::v1::paths;
 pub(crate) use api::v1::runs::CancelRunResponse;
 pub(crate) use api::v1::runs::ListRunsResponse;
+pub(crate) use api::v1::runs::Run;
 pub(crate) use api::v1::runs::RunResponse;
 pub(crate) use api::v1::runs::SubmitRunRequest;
 pub(crate) use api::v1::tasks::ListTasksResponse;

--- a/tests/cli/dev/server/status/help/stdout
+++ b/tests/cli/dev/server/status/help/stdout
@@ -15,11 +15,9 @@ Options:
           Valid values: `queued`, `running`, `completed`, `failed`, `canceling`, `canceled`. Only used when no `RUN` is provided.
 
       --limit <N>
-          Maximum number of runs to return per page.
+          Maximum number of runs to display.
           
-          Only used when no `RUN` is provided.
-          
-          [default: 100]
+          When set, fetches a single page of at most `N` runs. When omitted, all runs are displayed by paginating through the server's results. Only used when no `RUN` is provided.
 
       --json
           Output the raw JSON response instead of the formatted summary


### PR DESCRIPTION
Updates `sprocket dev server status` to respect the `--limit` argument. Fixes #1022 . 

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
