### PR TITLE
fix: don't dangle commas after if/then/elses

### DIFF
--- a/crates/wdl-format/CHANGELOG.md
+++ b/crates/wdl-format/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+* Commas are no longer "dangled" after if/then/else clauses ([#1056](https://github.com/stjude-rust-labs/sprocket/pull/1056)).
 * Duplicate sections in a task, workflow, or struct are no longer dropped; every section is retained in the order it was written. A task that has both a `requirements` and a `runtime` section now retains both ([#1112](https://github.com/stjude-rust-labs/sprocket/pull/1112)).
 * Formatting no longer panics on `input` hints keys that use dotted struct member paths, such as `foo.bar` ([#854](https://github.com/stjude-rust-labs/sprocket/issues/854)).
 * Comments within import statements are preserved ([#1034](https://github.com/stjude-rust-labs/sprocket/pull/1034)).

--- a/crates/wdl-format/CHANGELOG.md
+++ b/crates/wdl-format/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-* Commas are no longer "dangled" after if/then/else clauses ([#1056](https://github.com/stjude-rust-labs/sprocket/pull/1056)).
+* Commas and closing delimiters are no longer dangled after multiline if/then/else expressions ([#1056](https://github.com/stjude-rust-labs/sprocket/pull/1056)).
 * Duplicate sections in a task, workflow, or struct are no longer dropped; every section is retained in the order it was written. A task that has both a `requirements` and a `runtime` section now retains both ([#1112](https://github.com/stjude-rust-labs/sprocket/pull/1112)).
 * Formatting no longer panics on `input` hints keys that use dotted struct member paths, such as `foo.bar` ([#854](https://github.com/stjude-rust-labs/sprocket/issues/854)).
 * Comments within import statements are preserved ([#1034](https://github.com/stjude-rust-labs/sprocket/pull/1034)).

--- a/crates/wdl-format/src/token/post.rs
+++ b/crates/wdl-format/src/token/post.rs
@@ -415,11 +415,9 @@ impl Postprocessor {
             }
             PreToken::IndentStart => {
                 self.indent_level += 1;
-                self.end_line(stream);
             }
             PreToken::IndentEnd => {
                 self.indent_level = self.indent_level.saturating_sub(1);
-                self.end_line(stream);
             }
             PreToken::LineSpacingPolicy(policy) => {
                 self.line_spacing_policy = policy;

--- a/crates/wdl-format/src/token/pre.rs
+++ b/crates/wdl-format/src/token/pre.rs
@@ -135,17 +135,15 @@ impl TokenStream<PreToken> {
         self.0.push(PreToken::WordEnd);
     }
 
-    /// Inserts an indent start token to the stream. This will also end the
+    /// Inserts an indent start token to the stream. This will **not** end the
     /// current line.
     pub fn increment_indent(&mut self) {
-        self.end_line();
         self.0.push(PreToken::IndentStart);
     }
 
-    /// Inserts an indent end token to the stream. This will also end the
+    /// Inserts an indent end token to the stream. This will **not** end the
     /// current line.
     pub fn decrement_indent(&mut self) {
-        self.end_line();
         self.0.push(PreToken::IndentEnd);
     }
 

--- a/crates/wdl-format/src/token/pre.rs
+++ b/crates/wdl-format/src/token/pre.rs
@@ -137,12 +137,18 @@ impl TokenStream<PreToken> {
 
     /// Inserts an indent start token to the stream. This will **not** end the
     /// current line.
+    ///
+    /// Callers that want the indent change to take effect on the next line must
+    /// call `end_line()` after this.
     pub fn increment_indent(&mut self) {
         self.0.push(PreToken::IndentStart);
     }
 
     /// Inserts an indent end token to the stream. This will **not** end the
     /// current line.
+    ///
+    /// Callers that want the indent change to take effect on the next line must
+    /// call `end_line()` after this.
     pub fn decrement_indent(&mut self) {
         self.0.push(PreToken::IndentEnd);
     }

--- a/crates/wdl-format/src/v1.rs
+++ b/crates/wdl-format/src/v1.rs
@@ -233,6 +233,7 @@ pub fn format_input_section(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut inputs = Vec::new();
     let mut close_brace = None;
@@ -259,6 +260,7 @@ pub fn format_input_section(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("input section close brace")).write(stream, config);
     stream.end_line();
 }
@@ -285,10 +287,12 @@ pub fn format_output_section(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     for child in children {
         if child.element().kind() == SyntaxKind::CloseBrace {
             stream.decrement_indent();
+            stream.end_line();
         } else {
             assert_eq!(child.element().kind(), SyntaxKind::BoundDeclNode);
         }
@@ -348,6 +352,7 @@ pub fn format_literal_input(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut items = Vec::new();
     let mut commas = Vec::new();
@@ -379,6 +384,7 @@ pub fn format_literal_input(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("literal input close brace")).write(stream, config);
 }
 
@@ -430,6 +436,7 @@ pub fn format_literal_hints(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut items = Vec::new();
     let mut commas = Vec::new();
@@ -461,6 +468,7 @@ pub fn format_literal_hints(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("literal hints close brace")).write(stream, config);
 }
 
@@ -514,6 +522,7 @@ pub fn format_literal_output(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut items = Vec::new();
     let mut commas = Vec::new();
@@ -545,5 +554,6 @@ pub fn format_literal_output(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("literal output close brace")).write(stream, config);
 }

--- a/crates/wdl-format/src/v1/enum.rs
+++ b/crates/wdl-format/src/v1/enum.rs
@@ -43,6 +43,7 @@ pub fn format_enum_definition(
                 (&child).write(stream, config);
                 stream.end_line();
                 stream.increment_indent();
+                stream.end_line();
             }
             SyntaxKind::EnumChoiceNode => {
                 choices.push(child.clone());
@@ -79,6 +80,7 @@ pub fn format_enum_definition(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("enum definition close brace")).write(stream, config);
     stream.end_line();
 }

--- a/crates/wdl-format/src/v1/expr.rs
+++ b/crates/wdl-format/src/v1/expr.rs
@@ -395,6 +395,7 @@ pub fn format_literal_array(
     let empty = items.is_empty();
     if !empty {
         stream.increment_indent();
+        stream.end_line();
     }
 
     let mut items = items.iter().peekable();
@@ -415,6 +416,7 @@ pub fn format_literal_array(
 
     if !empty {
         stream.decrement_indent();
+        stream.end_line();
     }
     (&close_bracket.expect("literal array close bracket")).write(stream, config);
 }
@@ -459,6 +461,7 @@ pub fn format_literal_map(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut items = Vec::new();
     let mut commas = Vec::new();
@@ -496,6 +499,7 @@ pub fn format_literal_map(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("literal map close brace")).write(stream, config);
 }
 
@@ -545,6 +549,7 @@ pub fn format_literal_object(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut members = Vec::new();
     let mut commas = Vec::new();
@@ -582,6 +587,7 @@ pub fn format_literal_object(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("literal object close brace")).write(stream, config);
 }
 
@@ -1007,6 +1013,7 @@ pub fn format_if_expr(
             SyntaxKind::ThenKeyword => {
                 if !in_chain {
                     stream.increment_indent();
+                    stream.end_line();
                 } else {
                     stream.end_line();
                 }

--- a/crates/wdl-format/src/v1/import.rs
+++ b/crates/wdl-format/src/v1/import.rs
@@ -57,6 +57,7 @@ pub fn format_import_members(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut items = Vec::new();
     let mut commas = Vec::new();
@@ -93,6 +94,7 @@ pub fn format_import_members(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("import members close brace")).write(stream, config);
 }
 

--- a/crates/wdl-format/src/v1/meta.rs
+++ b/crates/wdl-format/src/v1/meta.rs
@@ -60,6 +60,7 @@ pub fn format_metadata_array(
     let empty = items.is_empty();
     if !empty {
         stream.increment_indent();
+        stream.end_line();
     }
 
     let mut items = items.iter().peekable();
@@ -80,6 +81,7 @@ pub fn format_metadata_array(
 
     if !empty {
         stream.decrement_indent();
+        stream.end_line();
     }
     (&close_bracket.expect("metadata array close bracket")).write(stream, config);
 }
@@ -125,6 +127,7 @@ pub fn format_metadata_object(
     let empty = items.is_empty();
     if !empty {
         stream.increment_indent();
+        stream.end_line();
     }
 
     let mut items = items.iter().peekable();
@@ -145,6 +148,7 @@ pub fn format_metadata_object(
 
     if !empty {
         stream.decrement_indent();
+        stream.end_line();
     }
     (&close_brace.expect("metadata object close brace")).write(stream, config);
 }
@@ -195,6 +199,7 @@ pub fn format_metadata_section(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut items = Vec::new();
     let mut close_brace = None;
@@ -220,6 +225,7 @@ pub fn format_metadata_section(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("metadata section close brace")).write(stream, config);
     stream.end_line();
 }
@@ -250,6 +256,7 @@ pub fn format_parameter_metadata_section(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut items = Vec::new();
     let mut close_brace = None;
@@ -275,6 +282,7 @@ pub fn format_parameter_metadata_section(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("parameter metadata section close brace")).write(stream, config);
     stream.end_line();
 }

--- a/crates/wdl-format/src/v1/struct.rs
+++ b/crates/wdl-format/src/v1/struct.rs
@@ -36,6 +36,7 @@ pub fn format_struct_definition(
     (&open_brace).write(stream, config);
     stream.end_line();
     stream.increment_indent();
+    stream.end_line();
 
     let mut meta_sections = Vec::new();
     let mut parameter_meta_sections = Vec::new();
@@ -73,6 +74,7 @@ pub fn format_struct_definition(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     close_brace
         .expect("struct definition close brace")
         .write(stream, config);
@@ -126,6 +128,7 @@ pub fn format_literal_struct(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut members = Vec::new();
     let mut commas = Vec::new();
@@ -168,5 +171,6 @@ pub fn format_literal_struct(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("literal struct close brace")).write(stream, config);
 }

--- a/crates/wdl-format/src/v1/task.rs
+++ b/crates/wdl-format/src/v1/task.rs
@@ -42,6 +42,7 @@ pub fn format_task_definition(
     (&open_brace).write(stream, config);
     stream.end_line();
     stream.increment_indent();
+    stream.end_line();
 
     let mut meta_sections = Vec::new();
     let mut parameter_meta_sections = Vec::new();
@@ -116,6 +117,7 @@ pub fn format_task_definition(
     stream.trim_while(|t| matches!(t, PreToken::BlankLine | PreToken::Trivia(Trivia::BlankLine)));
 
     stream.decrement_indent();
+    stream.end_line();
     close_brace.expect("task close brace").write(stream, config);
     stream.end_line();
 }
@@ -201,6 +203,7 @@ pub fn format_command_section(
             // Now we parse the stripped command section and format it.
             // End the line after the open delimiter and increment indent.
             stream.increment_indent();
+            stream.end_line();
 
             let mut bash_indent: Option<Rc<String>> = None;
             for (part, child) in parts.iter().zip(children.by_ref()) {
@@ -245,6 +248,7 @@ pub fn format_command_section(
             }
 
             stream.decrement_indent();
+            stream.end_line();
 
             for child in children {
                 match child.element().kind() {
@@ -322,6 +326,7 @@ pub fn format_requirements_section(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut items = Vec::new();
     let mut close_brace = None;
@@ -349,6 +354,7 @@ pub fn format_requirements_section(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("requirements close brace")).write(stream, config);
     stream.end_line();
 }
@@ -426,6 +432,7 @@ pub fn format_runtime_section(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut items = Vec::new();
     let mut close_brace = None;
@@ -453,6 +460,7 @@ pub fn format_runtime_section(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("runtime close brace")).write(stream, config);
     stream.end_line();
 }
@@ -478,6 +486,7 @@ pub fn format_task_hints_section(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut items = Vec::new();
     let mut close_brace = None;
@@ -505,6 +514,7 @@ pub fn format_task_hints_section(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_brace.expect("task hints close brace")).write(stream, config);
     stream.end_line();
 }

--- a/crates/wdl-format/src/v1/workflow.rs
+++ b/crates/wdl-format/src/v1/workflow.rs
@@ -85,10 +85,12 @@ pub fn format_conditional_statement_clause(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     for child in children {
         if child.element().kind() == SyntaxKind::CloseBrace {
             stream.decrement_indent();
+            stream.end_line();
         }
         (&child).write(stream, config);
     }
@@ -139,10 +141,12 @@ pub fn format_scatter_statement(
     (&open_brace).write(stream, config);
     stream.end_line();
     stream.increment_indent();
+    stream.end_line();
 
     for child in children {
         if child.element().kind() == SyntaxKind::CloseBrace {
             stream.decrement_indent();
+            stream.end_line();
         }
         (&child).write(stream, config);
     }
@@ -180,6 +184,7 @@ pub fn format_workflow_definition(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut meta_sections = Vec::new();
     let mut parameter_meta_sections = Vec::new();
@@ -250,6 +255,7 @@ pub fn format_workflow_definition(
     stream.trim_while(|t| matches!(t, PreToken::BlankLine | PreToken::Trivia(Trivia::BlankLine)));
 
     stream.decrement_indent();
+    stream.end_line();
     close_brace
         .expect("workflow close brace")
         .write(stream, config);
@@ -272,6 +278,7 @@ pub fn format_workflow_hints_array(
     assert_eq!(open_bracket.element().kind(), SyntaxKind::OpenBracket);
     (&open_bracket).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     let mut items = Vec::new();
     let mut commas = Vec::new();
@@ -308,6 +315,7 @@ pub fn format_workflow_hints_array(
     }
 
     stream.decrement_indent();
+    stream.end_line();
     (&close_bracket.expect("workflow hints array close bracket")).write(stream, config);
 }
 
@@ -383,10 +391,12 @@ pub fn format_workflow_hints_object(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     for child in children {
         if child.element().kind() == SyntaxKind::CloseBrace {
             stream.decrement_indent();
+            stream.end_line();
         }
         (&child).write(stream, config);
         stream.end_line();
@@ -414,10 +424,12 @@ pub fn format_workflow_hints_section(
     assert_eq!(open_brace.element().kind(), SyntaxKind::OpenBrace);
     (&open_brace).write(stream, config);
     stream.increment_indent();
+    stream.end_line();
 
     for child in children {
         if child.element().kind() == SyntaxKind::CloseBrace {
             stream.decrement_indent();
+            stream.end_line();
         }
         (&child).write(stream, config);
         stream.end_line();

--- a/crates/wdl-format/src/v1/workflow/call.rs
+++ b/crates/wdl-format/src/v1/workflow/call.rs
@@ -178,6 +178,7 @@ pub fn format_call_statement(
             (&colon.expect("colon")).write(stream, config);
         }
         stream.increment_indent();
+        stream.end_line();
 
         let mut inputs = inputs.iter().peekable();
         let mut commas = commas.iter();
@@ -196,6 +197,7 @@ pub fn format_call_statement(
         }
 
         stream.decrement_indent();
+        stream.end_line();
         (&close_brace.expect("close brace")).write(stream, config);
     }
     stream.end_line();

--- a/crates/wdl-format/tests/format/ENCODE-DCC_chip-seq-pipeline/source.formatted.wdl
+++ b/crates/wdl-format/tests/format/ENCODE-DCC_chip-seq-pipeline/source.formatted.wdl
@@ -1479,8 +1479,7 @@ workflow chip {
                 fastqs_R1 = fastqs_R1[i],
                 fastqs_R2 = if paired_end_
                     then fastqs_R2[i]
-                    else []
-                ,
+                    else [],
                 crop_length = crop_length,
                 crop_length_tol = crop_length_tol,
                 trimmomatic_phred_score_format = trimmomatic_phred_score_format,
@@ -1492,8 +1491,7 @@ workflow chip {
                     then bwa_idx_tar_
                     else if aligner == "bowtie2"
                     then bowtie2_idx_tar_
-                    else custom_aligner_idx_tar
-                ,
+                    else custom_aligner_idx_tar,
                 paired_end = paired_end_,
                 use_bwa_mem_for_pe = use_bwa_mem_for_pe,
                 bwa_mem_read_len_limit = bwa_mem_read_len_limit,
@@ -1609,8 +1607,7 @@ workflow chip {
                     then bwa_idx_tar_
                     else if aligner == "bowtie2"
                     then bowtie2_idx_tar_
-                    else custom_aligner_idx_tar
-                ,
+                    else custom_aligner_idx_tar,
                 paired_end = false,
                 use_bwa_mem_for_pe = false,
                 bwa_mem_read_len_limit = 0,
@@ -1752,8 +1749,7 @@ workflow chip {
                 fastqs_R1 = ctl_fastqs_R1[i],
                 fastqs_R2 = if ctl_paired_end_
                     then ctl_fastqs_R2[i]
-                    else []
-                ,
+                    else [],
                 crop_length = crop_length,
                 crop_length_tol = crop_length_tol,
                 trimmomatic_phred_score_format = trimmomatic_phred_score_format,
@@ -1765,8 +1761,7 @@ workflow chip {
                     then bwa_idx_tar_
                     else if aligner == "bowtie2"
                     then bowtie2_idx_tar_
-                    else custom_aligner_idx_tar
-                ,
+                    else custom_aligner_idx_tar,
                 paired_end = ctl_paired_end_,
                 use_bwa_mem_for_pe = use_bwa_mem_for_pe,
                 bwa_mem_read_len_limit = bwa_mem_read_len_limit,
@@ -1954,8 +1949,7 @@ workflow chip {
             call subsample_ctl { input:
                 ta = if chosen_ctl_ta_id == -1
                     then pool_ta_ctl.ta_pooled
-                    else ctl_ta_[chosen_ctl_ta_id]
-                ,
+                    else ctl_ta_[chosen_ctl_ta_id],
                 subsample = chosen_ctl_ta_subsample,
                 paired_end = chosen_ctl_paired_end,
                 mem_factor = subsample_ctl_mem_factor,
@@ -2023,8 +2017,7 @@ workflow chip {
                     then runtime_environment_spp
                     else if peak_caller_ == "macs2"
                     then runtime_environment_macs2
-                    else runtime_environment
-                ,
+                    else runtime_environment,
             }
         }
         File? peak_ = if has_output_of_call_peak
@@ -2082,8 +2075,7 @@ workflow chip {
                     then runtime_environment_spp
                     else if peak_caller_ == "macs2"
                     then runtime_environment_macs2
-                    else runtime_environment
-                ,
+                    else runtime_environment,
             }
         }
         File? peak_pr1_ = if has_output_of_call_peak_pr1
@@ -2120,8 +2112,7 @@ workflow chip {
                     then runtime_environment_spp
                     else if peak_caller_ == "macs2"
                     then runtime_environment_macs2
-                    else runtime_environment
-                ,
+                    else runtime_environment,
             }
         }
         File? peak_pr2_ = if has_output_of_call_peak_pr2
@@ -2143,8 +2134,7 @@ workflow chip {
         call subsample_ctl as subsample_ctl_pooled { input:
             ta = if num_ctl < 2
                 then ctl_ta_[0]
-                else pool_ta_ctl.ta_pooled
-            ,
+                else pool_ta_ctl.ta_pooled,
             subsample = chosen_ctl_ta_pooled_subsample,
             paired_end = ctl_paired_end_[0],
             mem_factor = subsample_ctl_mem_factor,
@@ -2199,8 +2189,7 @@ workflow chip {
                 then runtime_environment_spp
                 else if peak_caller_ == "macs2"
                 then runtime_environment_macs2
-                else runtime_environment
-            ,
+                else runtime_environment,
         }
     }
     File? peak_pooled_ = if has_output_of_call_peak_pooled
@@ -2259,8 +2248,7 @@ workflow chip {
                 then runtime_environment_spp
                 else if peak_caller_ == "macs2"
                 then runtime_environment_macs2
-                else runtime_environment
-            ,
+                else runtime_environment,
         }
     }
     File? peak_ppr1_ = if has_output_of_call_peak_ppr1
@@ -2298,8 +2286,7 @@ workflow chip {
                 then runtime_environment_spp
                 else if peak_caller_ == "macs2"
                 then runtime_environment_macs2
-                else runtime_environment
-            ,
+                else runtime_environment,
         }
     }
     File? peak_ppr2_ = if has_output_of_call_peak_ppr2
@@ -2435,8 +2422,7 @@ workflow chip {
                 then select_first([
                     overlap_pr.bfilt_overlap_peak,
                 ])
-                else []
-            ,
+                else [],
             peak_ppr = overlap_ppr.bfilt_overlap_peak,
             peak_type = peak_type_,
             chrsz = chrsz_,
@@ -2453,8 +2439,7 @@ workflow chip {
                 then select_first([
                     idr_pr.bfilt_idr_peak,
                 ])
-                else []
-            ,
+                else [],
             peak_ppr = idr_ppr.bfilt_idr_peak,
             peak_type = peak_type_,
             chrsz = chrsz_,
@@ -2497,8 +2482,7 @@ workflow chip {
             then select_first([
                 jsd.jsd_qcs,
             ])
-            else []
-        ,
+            else [],
 
         frip_qcs = select_all(call_peak.frip_qc),
         frip_qcs_pr1 = select_all(call_peak_pr1.frip_qc),
@@ -2512,24 +2496,21 @@ workflow chip {
             then select_first([
                 idr_pr.idr_plot,
             ])
-            else []
-        ,
+            else [],
         idr_plot_ppr = idr_ppr.idr_plot,
         frip_idr_qcs = select_all(idr.frip_qc),
         frip_idr_qcs_pr = if defined(idr_pr.frip_qc)
             then select_first([
                 idr_pr.frip_qc,
             ])
-            else []
-        ,
+            else [],
         frip_idr_qc_ppr = idr_ppr.frip_qc,
         frip_overlap_qcs = select_all(overlap.frip_qc),
         frip_overlap_qcs_pr = if defined(overlap_pr.frip_qc)
             then select_first([
                 overlap_pr.frip_qc,
             ])
-            else []
-        ,
+            else [],
         frip_overlap_qc_ppr = overlap_ppr.frip_qc,
         idr_reproducibility_qc = reproducibility_idr.reproducibility_qc,
         overlap_reproducibility_qc = reproducibility_overlap.reproducibility_qc,
@@ -2612,8 +2593,7 @@ task align {
             ~{write_tsv(tmp_fastqs)} \
             ~{if paired_end
                 then "--paired-end"
-                else ""
-            } \
+                else ""} \
             ~{"--nth " + cpu}
 
         if [ -z '~{trim_bp}' ]; then
@@ -2639,24 +2619,20 @@ task align {
                 --fastq1 R1$SUFFIX/*.fastq.gz \
                 ~{if paired_end
                     then "--fastq2 R2$SUFFIX/*.fastq.gz"
-                    else ""
-                } \
+                    else ""} \
                 ~{if paired_end
                     then "--paired-end"
-                    else ""
-                } \
+                    else ""} \
                 --crop-length ~{crop_length} \
                 --crop-length-tol "~{crop_length_tol}" \
                 ~{"--phred-score-format " + trimmomatic_phred_score_format} \
                 --out-dir-R1 R1$NEW_SUFFIX \
                 ~{if paired_end
                     then "--out-dir-R2 R2$NEW_SUFFIX"
-                    else ""
-                } \
+                    else ""} \
                 ~{"--trimmomatic-java-heap " + if defined(trimmomatic_java_heap)
                     then trimmomatic_java_heap
-                    else (round(mem_gb * trimmomatic_java_heap_factor) + "G")
-                } \
+                    else (round(mem_gb * trimmomatic_java_heap_factor) + "G")} \
                 ~{"--nth " + cpu}
             SUFFIX=$NEW_SUFFIX
         fi
@@ -2667,16 +2643,13 @@ task align {
                 R1$SUFFIX/*.fastq.gz \
                 ~{if paired_end
                     then "R2$SUFFIX/*.fastq.gz"
-                    else ""
-                } \
+                    else ""} \
                 ~{if paired_end
                     then "--paired-end"
-                    else ""
-                } \
+                    else ""} \
                 ~{if use_bwa_mem_for_pe
                     then "--use-bwa-mem-for-pe"
-                    else ""
-                } \
+                    else ""} \
                 ~{"--bwa-mem-read-len-limit " + bwa_mem_read_len_limit} \
                 ~{"--mem-gb " + samtools_mem_gb} \
                 ~{"--nth " + cpu}
@@ -2687,17 +2660,14 @@ task align {
                 R1$SUFFIX/*.fastq.gz \
                 ~{if paired_end
                     then "R2$SUFFIX/*.fastq.gz"
-                    else ""
-                } \
+                    else ""} \
                 ~{"--multimapping " + multimapping} \
                 ~{if paired_end
                     then "--paired-end"
-                    else ""
-                } \
+                    else ""} \
                 ~{if use_bowtie2_local_mode
                     then "--local"
-                    else ""
-                } \
+                    else ""} \
                 ~{"--mem-gb " + samtools_mem_gb} \
                 ~{"--nth " + cpu}
         else
@@ -2706,12 +2676,10 @@ task align {
                 R1$SUFFIX/*.fastq.gz \
                 ~{if paired_end
                     then "R2$SUFFIX/*.fastq.gz"
-                    else ""
-                } \
+                    else ""} \
                 ~{if paired_end
                     then "--paired-end"
-                    else ""
-                } \
+                    else ""} \
                 ~{"--mem-gb " + samtools_mem_gb} \
                 ~{"--nth " + cpu}
         fi 
@@ -2776,8 +2744,7 @@ task filter {
             ~{bam} \
             ~{if paired_end
                 then "--paired-end"
-                else ""
-            } \
+                else ""} \
             --multimapping 0 \
             ~{"--dup-marker " + dup_marker} \
             ~{"--mapq-thresh " + mapq_thresh} \
@@ -2785,15 +2752,13 @@ task filter {
             ~{"--chrsz " + chrsz} \
             ~{if no_dup_removal
                 then "--no-dup-removal"
-                else ""
-            } \
+                else ""} \
             ~{"--mito-chr-name " + mito_chr_name} \
             ~{"--mem-gb " + samtools_mem_gb} \
             ~{"--nth " + cpu} \
             ~{"--picard-java-heap " + if defined(picard_java_heap)
                 then picard_java_heap
-                else (round(mem_gb * picard_java_heap_factor) + "G")
-            }
+                else (round(mem_gb * picard_java_heap_factor) + "G")}
 
         if [ '~{redact_nodup_bam}' == 'true' ]; then
             python3 $(which encode_task_bam_to_pbam.py) \
@@ -2848,8 +2813,7 @@ task bam2ta {
             --disable-tn5-shift \
             ~{if paired_end
                 then "--paired-end"
-                else ""
-            } \
+                else ""} \
             ~{"--mito-chr-name " + mito_chr_name} \
             ~{"--subsample " + subsample} \
             ~{"--mem-gb " + samtools_mem_gb} \
@@ -2892,8 +2856,7 @@ task spr {
             ~{"--pseudoreplication-random-seed " + pseudoreplication_random_seed} \
             ~{if paired_end
                 then "--paired-end"
-                else ""
-            }
+                else ""}
     >>>
 
     output {
@@ -2971,8 +2934,7 @@ task xcor {
             ~{ta} \
             ~{if paired_end
                 then "--paired-end"
-                else ""
-            } \
+                else ""} \
             ~{"--mito-chr-name " + mito_chr_name} \
             ~{"--subsample " + subsample} \
             ~{"--chip-seq-type " + chip_seq_type} \
@@ -3024,8 +2986,7 @@ task jsd {
             ~{sep=" " select_all(nodup_bams)} \
             ~{if length(ctl_bams) > 0
                 then "--ctl-bam " + select_first(ctl_bams)
-                else ""
-            } \
+                else ""} \
             ~{"--mapq-thresh " + mapq_thresh} \
             ~{"--blacklist " + blacklist} \
             ~{"--nth " + cpu}
@@ -3070,8 +3031,7 @@ task choose_ctl {
             ~{"--ctl-ta-pooled " + ctl_ta_pooled} \
             ~{if always_use_pooled_ctl
                 then "--always-use-pooled-ctl"
-                else ""
-            } \
+                else ""} \
             ~{"--ctl-depth-ratio " + ctl_depth_ratio} \
             ~{"--ctl-depth-limit " + ctl_depth_limit} \
             ~{"--exp-ctl-depth-ratio-limit " + exp_ctl_depth_ratio_limit}
@@ -3150,8 +3110,7 @@ task subsample_ctl {
             ~{"--subsample " + subsample} \
             ~{if paired_end
                 then "--paired-end"
-                else ""
-            } \
+                else ""} \
     >>>
 
     output {
@@ -3323,8 +3282,7 @@ task idr {
         set -e
         ~{if defined(ta)
             then ""
-            else "touch null.frip.qc"
-        }
+            else "touch null.frip.qc"}
         touch null 
         python3 $(which encode_task_idr.py) \
             ~{peak1} ~{peak2} ~{peak_pooled} \
@@ -3385,8 +3343,7 @@ task overlap {
         set -e
         ~{if defined(ta)
             then ""
-            else "touch null.frip.qc"
-        }
+            else "touch null.frip.qc"}
         touch null 
         python3 $(which encode_task_overlap.py) \
             ~{peak1} ~{peak2} ~{peak_pooled} \
@@ -3498,8 +3455,7 @@ task gc_bias {
             ~{"--ref-fa " + ref_fa} \
             ~{"--picard-java-heap " + if defined(picard_java_heap)
                 then picard_java_heap
-                else (round(mem_gb * picard_java_heap_factor) + "G")
-            }
+                else (round(mem_gb * picard_java_heap_factor) + "G")}
     >>>
 
     output {
@@ -3597,8 +3553,7 @@ task qc_report {
             --aligner ~{aligner} \
             ~{if (no_dup_removal)
                 then "--no-dup-removal "
-                else ""
-            } \
+                else ""} \
             --peak-caller ~{peak_caller} \
             ~{"--cap-num-peak " + cap_num_peak} \
             --idr-thresh ~{idr_thresh} \

--- a/crates/wdl-format/tests/format/funky_command_leading_whitespace/source.formatted.wdl
+++ b/crates/wdl-format/tests/format/funky_command_leading_whitespace/source.formatted.wdl
@@ -31,26 +31,21 @@ task multiple_placeholders_per_line {
     command <<<
         --clip3pAdapterMMp ~{clip_3p_adapter_mmp.left} ~{(if (length(read_twos) != 0)
             then clip_3p_adapter_mmp.right
-            else None
-        )} \
+            else None)} \
         --alignEndsProtrude ~{align_ends_protrude.left} "~{(if (length(read_twos) != 0)
             then align_ends_protrude.right
-            else None
-        )}" \
+            else None)}" \
         --clip3pNbases ~{clip_3p_n_bases.left} ~{(if (length(read_twos) != 0)
             then clip_3p_n_bases.right
-            else None
-        )} \
+            else None)} \
         --clip3pAfterAdapterNbases ~{clip_3p_after_adapter_n_bases.left} ~{(if (length(
             read_twos
         ) != 0)
             then clip_3p_after_adapter_n_bases.right
-            else None
-        )} \
+            else None)} \
         --clip5pNbases ~{clip_5p_n_bases.left} ~{(if (length(read_twos) != 0)
             then clip_5p_n_bases.right
-            else None
-        )} \
+            else None)} \
         --readNameSeparator "~{read_name_separator}"
     >>>
 }
@@ -79,31 +74,25 @@ task idempotent {
             --clip3pAdapterSeq "~{clip_3p_adapter_seq.left}" ~{(if (length(read_twos) != 0
             )
                 then "'" + clip_3p_adapter_seq.right + "'"
-                else ""
-            )} \
+                else "")} \
             --clip3pAdapterMMp ~{clip_3p_adapter_mmp.left} ~{(if (length(read_twos) != 0)
                 then clip_3p_adapter_mmp.right
-                else None
-            )} \
+                else None)} \
             --alignEndsProtrude ~{align_ends_protrude.left} "~{(if (length(read_twos) != 0
             )
                 then align_ends_protrude.right
-                else None
-            )}" \
+                else None)}" \
             --clip3pNbases ~{clip_3p_n_bases.left} ~{(if (length(read_twos) != 0)
                 then clip_3p_n_bases.right
-                else None
-            )} \
+                else None)} \
             --clip3pAfterAdapterNbases ~{clip_3p_after_adapter_n_bases.left} ~{(if (length(
                 read_twos
             ) != 0)
                 then clip_3p_after_adapter_n_bases.right
-                else None
-            )} \
+                else None)} \
             --clip5pNbases ~{clip_5p_n_bases.left} ~{(if (length(read_twos) != 0)
                 then clip_5p_n_bases.right
-                else None
-            )} \
+                else None)} \
             --readNameSeparator "~{read_name_separator}" \
             --clipAdapterType "~{clip_adapter_type}" \
             foo.bam

--- a/crates/wdl-format/tests/format/if_then_else_exprs/source.formatted.wdl
+++ b/crates/wdl-format/tests/format/if_then_else_exprs/source.formatted.wdl
@@ -5,8 +5,8 @@ workflow if_then_else_exprs {
     input {
         Int a
         Int b
-        Bool foo
-        Bool bar
+        Boolean foo
+        Boolean bar
     }
 
     Int c = (if (a < b)
@@ -25,8 +25,27 @@ workflow if_then_else_exprs {
             else b
         else c + d
 
+    call empty { input:
+        arg = if foo
+            then if bar
+                then c
+                else if c == d
+                then c - d
+                else b
+            else c + d,
+    }
+
     output {
         Int result = c
         Int other_result = qaz
     }
+}
+
+task empty {
+    input {
+        Int arg
+    }
+
+    command <<<
+    >>>
 }

--- a/crates/wdl-format/tests/format/if_then_else_exprs/source.formatted.wdl
+++ b/crates/wdl-format/tests/format/if_then_else_exprs/source.formatted.wdl
@@ -11,8 +11,7 @@ workflow if_then_else_exprs {
 
     Int c = (if (a < b)
         then a
-        else b
-    )
+        else b)
 
     Int d = if (a < b)
         then a

--- a/crates/wdl-format/tests/format/if_then_else_exprs/source.wdl
+++ b/crates/wdl-format/tests/format/if_then_else_exprs/source.wdl
@@ -4,8 +4,8 @@ workflow if_then_else_exprs {
     input {
         Int a
         Int b
-        Bool foo
-        Bool bar
+        Boolean foo
+        Boolean bar
     }
 
     Int c = (
@@ -21,8 +21,18 @@ workflow if_then_else_exprs {
 
     Int qaz = if foo then if bar then c else if c==d then c-d else b else c+d
 
+    call empty { input: arg = if foo then if bar then c else if c==d then c-d else b else c+d,}
+
     output {
         Int result = c
         Int other_result = qaz
     }
+}
+
+task empty {
+    input {
+        Int arg
+    }
+
+    command <<<>>>
 }

--- a/crates/wdl-format/tests/format/multiple_long_placeholders/source.default.formatted.wdl
+++ b/crates/wdl-format/tests/format/multiple_long_placeholders/source.default.formatted.wdl
@@ -5,26 +5,21 @@ task cast_spell {
         --summonSpectralFamiliar ~{arcane_focus_gem.left} ~{(if (length(spell_components)
             != 0)
             then arcane_focus_gem.right
-            else None
-        )} \
+            else None)} \
         --wardOuterPerimeter ~{binding_sigil_ink.left} "~{(if (length(spell_components) != 0
         )
             then binding_sigil_ink.right
-            else None
-        )}" \
+            else None)}" \
         --brewElixir ~{mandrake_root.left} ~{(if (length(spell_components) != 0)
             then mandrake_root.right
-            else None
-        )} \
+            else None)} \
         --inscribeGreaterWardingCircle ~{consecrated_chalk_powder.left} ~{(if (length(
             spell_components
         ) != 0)
             then consecrated_chalk_powder.right
-            else None
-        )} \
+            else None)} \
         --dispelLingering ~{warding_dust.left} ~{(if (length(spell_components) != 0)
             then warding_dust.right
-            else None
-        )} \
+            else None)} \
     >>>
 }

--- a/crates/wdl-format/tests/format/multiple_long_placeholders/source.formatted.wdl
+++ b/crates/wdl-format/tests/format/multiple_long_placeholders/source.formatted.wdl
@@ -6,30 +6,25 @@ task cast_spell {
             length(spell_components) != 0
         )
             then arcane_focus_gem.right
-            else None
-        )} \
+            else None)} \
         --wardOuterPerimeter ~{binding_sigil_ink.left} "~{(if (length(
             spell_components
         ) != 0)
             then binding_sigil_ink.right
-            else None
-        )}" \
+            else None)}" \
         --brewElixir ~{mandrake_root.left} ~{(if (length(
             spell_components
         ) != 0)
             then mandrake_root.right
-            else None
-        )} \
+            else None)} \
         --inscribeGreaterWardingCircle ~{consecrated_chalk_powder.left} ~{
             (if (length(spell_components) != 0)
             then consecrated_chalk_powder.right
-            else None
-        )} \
+            else None)} \
         --dispelLingering ~{warding_dust.left} ~{(if (length(
             spell_components
         ) != 0)
             then warding_dust.right
-            else None
-        )} \
+            else None)} \
     >>>
 }

--- a/crates/wdl-format/tests/format/seaseq-case/source.formatted.wdl
+++ b/crates/wdl-format/tests/format/seaseq-case/source.formatted.wdl
@@ -305,15 +305,13 @@ workflow seaseq {
                 inputfile = eachfastq,
                 default_location = if (one_fastq)
                     then sub(basename(eachfastq), ".fastq.gz|.fq.gz", "") + "/SpikeIn/FastQC"
-                    else "SAMPLE/" + sub(basename(eachfastq), ".fastq.gz|.fq.gz", "") + "/SpikeIn/FastQC"
-                ,
+                    else "SAMPLE/" + sub(basename(eachfastq), ".fastq.gz|.fq.gz", "") + "/SpikeIn/FastQC",
             }
             call util.basicfastqstats as spikein_indv_bfs { input:
                 fastqfile = eachfastq,
                 default_location = if (one_fastq)
                     then sub(basename(eachfastq), ".fastq.gz|.fq.gz", "") + "/SpikeIn/SummaryStats"
-                    else "SAMPLE/" + sub(basename(eachfastq), ".fastq.gz|.fq.gz", "") + "/SpikeIn/SummaryStats"
-                ,
+                    else "SAMPLE/" + sub(basename(eachfastq), ".fastq.gz|.fq.gz", "") + "/SpikeIn/SummaryStats",
             }
             call bowtie.spikein_SE as spikein_indv_map { input:
                 fastqfile = eachfastq,
@@ -321,8 +319,7 @@ workflow seaseq {
                 metricsfile = spikein_indv_bfs.metrics_out,
                 default_location = if (one_fastq)
                     then sub(basename(eachfastq), ".fastq.gz|.fq.gz", "") + "/SpikeIn/SummaryStats"
-                    else "SAMPLE/" + sub(basename(eachfastq), ".fastq.gz|.fq.gz", "") + "/SpikeIn/SummaryStats"
-                ,
+                    else "SAMPLE/" + sub(basename(eachfastq), ".fastq.gz|.fq.gz", "") + "/SpikeIn/SummaryStats",
             }
         }
 
@@ -426,12 +423,10 @@ workflow seaseq {
             metricsfiles = indv_bfs.metrics_out,
             default_location = if defined(results_name)
                 then results_name + "/BAM_files"
-                else "AllMerge_" + length(indv_mapping.sorted_bam) + "_mapped" + "/BAM_files"
-            ,
+                else "AllMerge_" + length(indv_mapping.sorted_bam) + "_mapped" + "/BAM_files",
             outputfile = if defined(results_name)
                 then results_name + ".sorted.bam"
-                else "AllMerge_" + length(fastqfiles) + "_mapped.sorted.bam"
-            ,
+                else "AllMerge_" + length(fastqfiles) + "_mapped.sorted.bam",
         }
 
         call fastqc.fastqc as mergebamfqc { input:


### PR DESCRIPTION
_Describe the problem or feature in addition to a link to the issues._

On `main`, incrementing and decrementing the indentation level is _always_ accompanied by ending the line. This is the correct behavior in all cases, except for if/then/elses where a decrement should not always be followed by a newline. The extra newline was leaving "dangling" commas on lines by themselves. This fixes that by requiring an explicit `end_line()` call after each `increment/decrement_indent()`.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
