### PR TITLE
feat: write additional information for Slurm and LSF backends.

### DIFF
--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -7,7 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Fixed
+#### Added
+
+* The LSF and Slurm backends now write files to the attempt directory recording
+  the command used to queue the task and the resulting job identifiers ([#1057](https://github.com/stjude-rust-labs/sprocket/pull/1057)).
+
+#### Fixed
 
 * The execution backend is now considered for the call cache key derivation,
   which prevents unexpected behavior when switching executing backends. NOTE:

--- a/crates/wdl-engine/src/backend/lsf_apptainer.rs
+++ b/crates/wdl-engine/src/backend/lsf_apptainer.rs
@@ -12,6 +12,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt as _;
 #[cfg(windows)]
@@ -73,6 +74,13 @@ use crate::v1::requirements;
 /// The name of the file where the Apptainer command invocation will be written.
 const APPTAINER_COMMAND_FILE_NAME: &str = "apptainer_command";
 
+/// The name of the file which stores the id of the job that was submitted to
+/// LSF.
+const JOB_ID_FILE_NAME: &str = "job_id";
+
+/// The name of the file which stores the full command used to enqueue the task.
+const BSUB_COMMAND_FILE_NAME: &str = "bsub_command";
+
 /// The maximum length of an LSF job name, in *bytes*.
 ///
 /// See <https://www.ibm.com/docs/en/spectrum-lsf/10.1.0?topic=o-j>.
@@ -108,6 +116,28 @@ fn truncate_job_name(name: &str) -> &str {
         .expect("should have index");
 
     &name[0..index]
+}
+
+/// Writes a `bsub_command` file with the given bsub command.
+fn write_bsub_command_file(dir: &Path, command: &Command) -> Result<()> {
+    let path = dir.join(BSUB_COMMAND_FILE_NAME);
+    let mut file = std::fs::File::create(&path)
+        .with_context(|| format!("failed to create file `{path}`", path = path.display()))?;
+    writeln!(&mut file, "{command:?}", command = command.as_std())
+        .with_context(|| format!("failed to write file `{path}`", path = path.display()))?;
+
+    Ok(())
+}
+
+/// Writes a `job_id` file with the given job identifier.
+fn write_job_id_file(dir: &Path, job_id: u64) -> Result<()> {
+    let path = dir.join(JOB_ID_FILE_NAME);
+    let mut file = std::fs::File::create(&path)
+        .with_context(|| format!("failed to create file `{path}`", path = path.display()))?;
+    writeln!(&mut file, "{job_id}")
+        .with_context(|| format!("failed to write file `{path}`", path = path.display()))?;
+
+    Ok(())
 }
 
 /// Represents an LSF job state.
@@ -507,7 +537,13 @@ impl Monitor {
             ))
             .arg(command_path);
 
-        trace!(?command, "spawning `bsub` to queue task");
+        trace!(
+            "spawning `bsub` to queue task: `{command:?}`",
+            command = command.as_std()
+        );
+
+        // Write the full `bsub` command to the attempt directory
+        write_bsub_command_file(request.attempt_dir, &command)?;
 
         let child = command.spawn().context("failed to spawn `bsub`")?;
         let output = child
@@ -539,7 +575,9 @@ impl Monitor {
             })
             .context("`bsub` output did not contain the job identifier")?;
 
+        // Write out the job id to the attempt directory
         debug!("task `{task_name}` was queued as LSF job `{job_id}`");
+        write_job_id_file(request.attempt_dir, job_id)?;
 
         let (tx, rx) = oneshot::channel();
         let mut state = self.state.lock().expect("failed to lock state");
@@ -635,7 +673,10 @@ impl Monitor {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        trace!(?command, "spawning `bjobs` to monitor tasks");
+        trace!(
+            "spawning `bjobs` to monitor tasks: `{command:?}`",
+            command = command.as_std()
+        );
 
         let child = command.spawn().context("failed to spawn `bjobs` command")?;
 
@@ -743,7 +784,10 @@ impl LsfApptainerBackend {
             .await
             .context("failed to acquire permit for canceling job")?;
 
-        trace!(?command, "spawning `bkill` to cancel task");
+        trace!(
+            "spawning `bkill` to cancel task: `{command:?}`",
+            command = command.as_std()
+        );
 
         let mut child = command.spawn().context("failed to spawn `bkill` command")?;
         let status = child.wait().await.context("failed to wait for `bkill`")?;

--- a/crates/wdl-engine/src/backend/lsf_apptainer.rs
+++ b/crates/wdl-engine/src/backend/lsf_apptainer.rs
@@ -12,7 +12,6 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::io::Write;
 #[cfg(unix)]
 use std::os::unix::process::ExitStatusExt as _;
 #[cfg(windows)]
@@ -119,25 +118,23 @@ fn truncate_job_name(name: &str) -> &str {
 }
 
 /// Writes a `bsub_command` file with the given `bsub` command.
-fn write_bsub_command_file(dir: &Path, command: &Command) -> Result<()> {
+async fn write_bsub_command_file(dir: &Path, command: &Command) -> Result<()> {
     let path = dir.join(BSUB_COMMAND_FILE_NAME);
-    let mut file = std::fs::File::create(&path)
-        .with_context(|| format!("failed to create file `{path}`", path = path.display()))?;
-    writeln!(&mut file, "{command:?}", command = command.as_std())
+    fs::write(&path, format!("{command:?}\n"))
+        .await
         .with_context(|| format!("failed to write file `{path}`", path = path.display()))?;
-
     Ok(())
 }
 
 /// Writes a `job_id` file with the given job identifier.
-fn write_job_id_file(dir: &Path, job_id: u64) -> Result<()> {
+///
+/// If a failure to write the file occurs, an error is logged instead of
+/// returned so that the engine can continue to monitor the task.
+async fn write_job_id_file(dir: &Path, job_id: u64) {
     let path = dir.join(JOB_ID_FILE_NAME);
-    let mut file = std::fs::File::create(&path)
-        .with_context(|| format!("failed to create file `{path}`", path = path.display()))?;
-    writeln!(&mut file, "{job_id}")
-        .with_context(|| format!("failed to write file `{path}`", path = path.display()))?;
-
-    Ok(())
+    if let Err(e) = fs::write(&path, format!("{job_id}\n")).await {
+        error!("failed to write file `{path}`: {e}", path = path.display());
+    }
 }
 
 /// Represents an LSF job state.
@@ -543,7 +540,7 @@ impl Monitor {
         );
 
         // Write the full `bsub` command to the attempt directory
-        write_bsub_command_file(request.attempt_dir, &command)?;
+        write_bsub_command_file(request.attempt_dir, &command).await?;
 
         let child = command.spawn().context("failed to spawn `bsub`")?;
         let output = child
@@ -577,7 +574,7 @@ impl Monitor {
 
         // Write out the job id to the attempt directory
         debug!("task `{task_name}` was queued as LSF job `{job_id}`");
-        write_job_id_file(request.attempt_dir, job_id)?;
+        write_job_id_file(request.attempt_dir, job_id).await;
 
         let (tx, rx) = oneshot::channel();
         let mut state = self.state.lock().expect("failed to lock state");

--- a/crates/wdl-engine/src/backend/lsf_apptainer.rs
+++ b/crates/wdl-engine/src/backend/lsf_apptainer.rs
@@ -120,7 +120,7 @@ fn truncate_job_name(name: &str) -> &str {
 /// Writes a `bsub_command` file with the given `bsub` command.
 async fn write_bsub_command_file(dir: &Path, command: &Command) -> Result<()> {
     let path = dir.join(BSUB_COMMAND_FILE_NAME);
-    fs::write(&path, format!("{command:?}\n"))
+    fs::write(&path, format!("{command:?}\n", command = command.as_std()))
         .await
         .with_context(|| format!("failed to write file `{path}`", path = path.display()))?;
     Ok(())

--- a/crates/wdl-engine/src/backend/lsf_apptainer.rs
+++ b/crates/wdl-engine/src/backend/lsf_apptainer.rs
@@ -118,7 +118,7 @@ fn truncate_job_name(name: &str) -> &str {
     &name[0..index]
 }
 
-/// Writes a `bsub_command` file with the given bsub command.
+/// Writes a `bsub_command` file with the given `bsub` command.
 fn write_bsub_command_file(dir: &Path, command: &Command) -> Result<()> {
     let path = dir.join(BSUB_COMMAND_FILE_NAME);
     let mut file = std::fs::File::create(&path)

--- a/crates/wdl-engine/src/backend/slurm_apptainer.rs
+++ b/crates/wdl-engine/src/backend/slurm_apptainer.rs
@@ -12,7 +12,6 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::io::Write;
 use std::path::Path;
 use std::process::ExitStatus;
 use std::process::Stdio;
@@ -83,25 +82,23 @@ const DEFAULT_MONITOR_INTERVAL: u64 = 30;
 const DEFAULT_MAX_CONCURRENCY: u32 = 10;
 
 /// Writes a `sbatch_command` file with the given `sbatch` command.
-fn write_sbatch_command_file(dir: &Path, command: &Command) -> Result<()> {
+async fn write_sbatch_command_file(dir: &Path, command: &Command) -> Result<()> {
     let path = dir.join(SBATCH_COMMAND_FILE_NAME);
-    let mut file = std::fs::File::create(&path)
-        .with_context(|| format!("failed to create file `{path}`", path = path.display()))?;
-    writeln!(&mut file, "{command:?}", command = command.as_std())
+    fs::write(&path, format!("{command:?}\n"))
+        .await
         .with_context(|| format!("failed to write file `{path}`", path = path.display()))?;
-
     Ok(())
 }
 
 /// Writes a `job_id` file with the given job identifier.
-fn write_job_id_file(dir: &Path, job_id: u64) -> Result<()> {
+///
+/// If a failure to write the file occurs, an error is logged instead of
+/// returned so that the engine can continue to monitor the task.
+async fn write_job_id_file(dir: &Path, job_id: u64) {
     let path = dir.join(JOB_ID_FILE_NAME);
-    let mut file = std::fs::File::create(&path)
-        .with_context(|| format!("failed to create file `{path}`", path = path.display()))?;
-    writeln!(&mut file, "{job_id}")
-        .with_context(|| format!("failed to write file `{path}`", path = path.display()))?;
-
-    Ok(())
+    if let Err(e) = fs::write(&path, format!("{job_id}\n")).await {
+        error!("failed to write file `{path}`: {e}", path = path.display());
+    }
 }
 
 /// Represents a Slurm job state.
@@ -666,7 +663,7 @@ impl Monitor {
             .stderr(Stdio::piped());
 
         // Write the full `sbatch` command to the attempt directory
-        write_sbatch_command_file(request.attempt_dir, &command)?;
+        write_sbatch_command_file(request.attempt_dir, &command).await?;
 
         trace!(
             "spawning `sbatch` to queue task: `{command:?}`",
@@ -705,7 +702,7 @@ impl Monitor {
 
         // Write out the job id to the attempt directory
         debug!("task `{task_name}` was queued as Slurm job `{job_id}`");
-        write_job_id_file(request.attempt_dir, job_id)?;
+        write_job_id_file(request.attempt_dir, job_id).await;
 
         let (tx, rx) = oneshot::channel();
         let mut state = self.state.lock().expect("failed to lock state");

--- a/crates/wdl-engine/src/backend/slurm_apptainer.rs
+++ b/crates/wdl-engine/src/backend/slurm_apptainer.rs
@@ -82,7 +82,7 @@ const DEFAULT_MONITOR_INTERVAL: u64 = 30;
 /// The default maximum concurrency for `sbatch` and `scancel` operations.
 const DEFAULT_MAX_CONCURRENCY: u32 = 10;
 
-/// Writes a `sbatch_command` file with the given sbatch command.
+/// Writes a `sbatch_command` file with the given `sbatch` command.
 fn write_sbatch_command_file(dir: &Path, command: &Command) -> Result<()> {
     let path = dir.join(SBATCH_COMMAND_FILE_NAME);
     let mut file = std::fs::File::create(&path)

--- a/crates/wdl-engine/src/backend/slurm_apptainer.rs
+++ b/crates/wdl-engine/src/backend/slurm_apptainer.rs
@@ -12,6 +12,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::io::Write;
 use std::path::Path;
 use std::process::ExitStatus;
 use std::process::Stdio;
@@ -68,11 +69,40 @@ use crate::v1::requirements;
 /// The name of the file where the Apptainer command invocation will be written.
 const APPTAINER_COMMAND_FILE_NAME: &str = "apptainer_command";
 
+/// The name of the file which stores the id of the job that was submitted to
+/// Slurm.
+const JOB_ID_FILE_NAME: &str = "job_id";
+
+/// The name of the file which stores the full command used to enqueue the task.
+const SBATCH_COMMAND_FILE_NAME: &str = "sbatch_command";
+
 /// The default monitor interval, in seconds.
 const DEFAULT_MONITOR_INTERVAL: u64 = 30;
 
 /// The default maximum concurrency for `sbatch` and `scancel` operations.
 const DEFAULT_MAX_CONCURRENCY: u32 = 10;
+
+/// Writes a `sbatch_command` file with the given sbatch command.
+fn write_sbatch_command_file(dir: &Path, command: &Command) -> Result<()> {
+    let path = dir.join(SBATCH_COMMAND_FILE_NAME);
+    let mut file = std::fs::File::create(&path)
+        .with_context(|| format!("failed to create file `{path}`", path = path.display()))?;
+    writeln!(&mut file, "{command:?}", command = command.as_std())
+        .with_context(|| format!("failed to write file `{path}`", path = path.display()))?;
+
+    Ok(())
+}
+
+/// Writes a `job_id` file with the given job identifier.
+fn write_job_id_file(dir: &Path, job_id: u64) -> Result<()> {
+    let path = dir.join(JOB_ID_FILE_NAME);
+    let mut file = std::fs::File::create(&path)
+        .with_context(|| format!("failed to create file `{path}`", path = path.display()))?;
+    writeln!(&mut file, "{job_id}")
+        .with_context(|| format!("failed to write file `{path}`", path = path.display()))?;
+
+    Ok(())
+}
 
 /// Represents a Slurm job state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -635,7 +665,13 @@ impl Monitor {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        trace!(?command, "spawning `sbatch` to queue task");
+        // Write the full `sbatch` command to the attempt directory
+        write_sbatch_command_file(request.attempt_dir, &command)?;
+
+        trace!(
+            "spawning `sbatch` to queue task: `{command:?}`",
+            command = command.as_std()
+        );
 
         let child = command.spawn().context("failed to spawn `sbatch`")?;
         let output = child
@@ -667,7 +703,9 @@ impl Monitor {
 
         let job_id = job_id.context("`sbatch` did not output a job identifier")?;
 
+        // Write out the job id to the attempt directory
         debug!("task `{task_name}` was queued as Slurm job `{job_id}`");
+        write_job_id_file(request.attempt_dir, job_id)?;
 
         let (tx, rx) = oneshot::channel();
         let mut state = self.state.lock().expect("failed to lock state");
@@ -743,7 +781,10 @@ impl Monitor {
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
 
-        trace!(?command, "spawning `sacct` to monitor tasks");
+        trace!(
+            "spawning `sacct` to monitor tasks: `{command:?}`",
+            command = command.as_std()
+        );
 
         let child = command.spawn().context("failed to spawn `sacct` command")?;
 
@@ -839,7 +880,10 @@ impl SlurmApptainerBackend {
             .await
             .context("failed to acquire permit for canceling job")?;
 
-        trace!(?command, "spawning `scancel` to cancel task");
+        trace!(
+            "spawning `scancel` to cancel task: `{command:?}`",
+            command = command.as_std()
+        );
 
         let mut child = command
             .spawn()

--- a/crates/wdl-engine/src/backend/slurm_apptainer.rs
+++ b/crates/wdl-engine/src/backend/slurm_apptainer.rs
@@ -84,7 +84,7 @@ const DEFAULT_MAX_CONCURRENCY: u32 = 10;
 /// Writes a `sbatch_command` file with the given `sbatch` command.
 async fn write_sbatch_command_file(dir: &Path, command: &Command) -> Result<()> {
     let path = dir.join(SBATCH_COMMAND_FILE_NAME);
-    fs::write(&path, format!("{command:?}\n"))
+    fs::write(&path, format!("{command:?}\n", command = command.as_std()))
         .await
         .with_context(|| format!("failed to write file `{path}`", path = path.display()))?;
     Ok(())


### PR DESCRIPTION
This PR creates two new files in the attempt directory for the Slurm and LSF backends:

* A file that stores the identifier of the job submitted to Slurm or LSF (`job_id`)
* A file that stores the command used to enqueue the task with Slurm or LSF (`sbatch_command` or `bsub_command`, respectively).

Closes #1010.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
