### PR TITLE
chore(wdl-analysis): switch to `test-log`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1546,6 +1546,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5576,6 +5598,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-log"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9c218384242b5c89b68303ab6f6fc53a312d923f0c14dc6bb860c6aeee40f1"
+dependencies = [
+ "env_logger",
+ "test-log-macros",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "test-log-core"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "test-log-macros"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
+dependencies = [
+ "syn 2.0.118",
+ "test-log-core",
+]
+
+[[package]]
 name = "text-size"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6500,6 +6554,7 @@ dependencies = [
  "smallvec",
  "strsim",
  "tempfile",
+ "test-log",
  "tokio",
  "toml-spanner",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,6 +113,7 @@ struct-patch = "0.12.0"
 strum = { version = "0.28", features = ["derive"] }
 sysinfo = "0.39.0"
 tempfile = "3.24.0"
+test-log = { version = "0.2.21", default-features = false, features = ["color", "trace"] }
 thirtyfour = "0.37.1"
 thiserror = "2.0.18"
 tokio = { version = "1.49.0", features = ["full"] }

--- a/crates/wdl-analysis/Cargo.toml
+++ b/crates/wdl-analysis/Cargo.toml
@@ -48,6 +48,7 @@ libtest-mimic = { workspace = true }
 pretty_assertions = { workspace = true }
 semver = { workspace = true }
 tempfile = { workspace = true }
+test-log = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [lints]

--- a/crates/wdl-analysis/src/analyzer.rs
+++ b/crates/wdl-analysis/src/analyzer.rs
@@ -1302,6 +1302,7 @@ mod test {
     use super::*;
 
     #[tokio::test]
+    #[test_log::test]
     async fn it_returns_empty_results() {
         let analyzer = Analyzer::default();
         let results = analyzer.analyze(()).await.unwrap();
@@ -1309,6 +1310,7 @@ mod test {
     }
 
     #[tokio::test]
+    #[test_log::test]
     async fn it_analyzes_a_document() {
         let dir = TempDir::new().expect("failed to create temporary directory");
         let path = dir.path().join("foo.wdl");
@@ -1370,6 +1372,7 @@ workflow test {
     }
 
     #[tokio::test]
+    #[test_log::test]
     async fn it_reanalyzes_a_document_on_change() {
         let dir = TempDir::new().expect("failed to create temporary directory");
         let path = dir.path().join("foo.wdl");
@@ -1445,6 +1448,7 @@ workflow something_else {
     }
 
     #[tokio::test]
+    #[test_log::test]
     async fn it_reanalyzes_a_document_on_incremental_change() {
         let dir = TempDir::new().expect("failed to create temporary directory");
         let path = dir.path().join("foo.wdl");
@@ -1512,6 +1516,7 @@ workflow test {
     }
 
     #[tokio::test]
+    #[test_log::test]
     async fn it_removes_documents() {
         let dir = TempDir::new().expect("failed to create temporary directory");
         let foo = dir.path().join("foo.wdl");
@@ -1574,6 +1579,7 @@ workflow test {
     }
 
     #[tokio::test]
+    #[test_log::test]
     async fn selected_imported_task_conflicts_with_local_workflow() {
         let dir = TempDir::new().expect("failed to create temporary directory");
         fs::write(
@@ -1621,6 +1627,7 @@ workflow run {
     }
 
     #[tokio::test]
+    #[test_log::test]
     async fn symbolic_import_resolves_through_mock_resolver() {
         use wdl_modules::Manifest;
         use wdl_modules::lockfile::ResolvedSource;
@@ -1761,6 +1768,7 @@ workflow run {
     }
 
     #[tokio::test]
+    #[test_log::test]
     async fn concurrent_symbolic_imports_faster_than_serial() {
         use std::sync::atomic::AtomicUsize;
         use std::sync::atomic::Ordering;
@@ -1901,6 +1909,7 @@ workflow run {
     }
 
     #[tokio::test]
+    #[test_log::test]
     async fn it_deletes_documents() {
         let dir = TempDir::new().expect("failed to create temporary directory");
         let foo = dir.path().join("foo.wdl");

--- a/crates/wdl-analysis/src/config.rs
+++ b/crates/wdl-analysis/src/config.rs
@@ -441,14 +441,14 @@ impl DiagnosticsConfig {
 mod tests {
     use super::*;
 
-    #[test]
+    #[test_log::test]
     fn custom_format_config_round_trip() {
         let custom_format_config = FormatConfig::default().trailing_commas(false);
         let analysis_config = Config::default().with_format_config(custom_format_config);
         assert_eq!(analysis_config.format(), &custom_format_config);
     }
 
-    #[test]
+    #[test_log::test]
     fn no_format_config_is_default() {
         let default_format_config = FormatConfig::default();
         let analysis_config = Config::default();

--- a/crates/wdl-analysis/src/document/v1.rs
+++ b/crates/wdl-analysis/src/document/v1.rs
@@ -2935,7 +2935,7 @@ mod tests {
         ]
     }
 
-    #[test]
+    #[test_log::test]
     fn smoke() {
         let scopes = example_scopes();
 
@@ -2972,7 +2972,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[test_log::test]
     fn type_conflicts() {
         // Test scopes with type conflicts
         // if (...) {

--- a/crates/wdl-analysis/src/eval/v1.rs
+++ b/crates/wdl-analysis/src/eval/v1.rs
@@ -1286,7 +1286,7 @@ mod test {
 
     use super::*;
 
-    #[test]
+    #[test_log::test]
     fn test_input_dependency_handling() {
         let source = r#"
         version 1.1

--- a/crates/wdl-analysis/src/graph.rs
+++ b/crates/wdl-analysis/src/graph.rs
@@ -971,7 +971,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[test_log::test]
     fn test_delete_retains_current_state() {
         let DependencyContext {
             mut graph,
@@ -1015,7 +1015,7 @@ mod tests {
         assert!(change.edits.is_empty());
     }
 
-    #[test]
+    #[test_log::test]
     fn test_delete_retains_unapplied_edits() {
         let DependencyContext {
             mut graph,

--- a/crates/wdl-analysis/src/stdlib.rs
+++ b/crates/wdl-analysis/src/stdlib.rs
@@ -5186,7 +5186,7 @@ mod test {
 
     use super::*;
 
-    #[test]
+    #[test_log::test]
     fn verify_stdlib_signatures() {
         let mut signatures = Vec::new();
         for (name, f) in STDLIB.functions() {
@@ -5306,7 +5306,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[test_log::test]
     fn it_binds_a_simple_function() {
         let f = STDLIB.function("floor").expect("should have function");
         assert_eq!(f.minimum_version(), SupportedVersion::V1(V1::Zero));
@@ -5367,7 +5367,7 @@ mod test {
         assert_eq!(binding.return_type().to_string(), "Int");
     }
 
-    #[test]
+    #[test_log::test]
     fn it_binds_a_generic_function() {
         let f = STDLIB.function("values").expect("should have function");
         assert_eq!(f.minimum_version(), SupportedVersion::V1(V1::Two));
@@ -5433,7 +5433,7 @@ mod test {
         assert_eq!(binding.return_type().to_string(), "Array[Object]");
     }
 
-    #[test]
+    #[test_log::test]
     fn it_removes_qualifiers() {
         let f = STDLIB.function("select_all").expect("should have function");
         assert_eq!(f.minimum_version(), SupportedVersion::V1(V1::Zero));
@@ -5472,7 +5472,7 @@ mod test {
         assert_eq!(binding.return_type().to_string(), "Array[Array[String]]");
     }
 
-    #[test]
+    #[test_log::test]
     fn it_binds_concrete_overloads() {
         let f = STDLIB.function("max").expect("should have function");
         assert_eq!(f.minimum_version(), SupportedVersion::V1(V1::One));
@@ -5595,7 +5595,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[test_log::test]
     fn it_binds_generic_overloads() {
         let f = STDLIB
             .function("select_first")

--- a/crates/wdl-analysis/src/stdlib/constraints.rs
+++ b/crates/wdl-analysis/src/stdlib/constraints.rs
@@ -230,7 +230,7 @@ mod test {
     use crate::types::PrimitiveType;
     use crate::types::StructType;
 
-    #[test]
+    #[test_log::test]
     fn test_sizable_constraint() {
         let constraint = SizeableConstraint;
         assert!(!constraint.satisfied(&Type::from(PrimitiveType::Boolean).optional()));
@@ -305,7 +305,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[test_log::test]
     fn test_struct_constraint() {
         let constraint = StructConstraint;
         assert!(!constraint.satisfied(&Type::from(PrimitiveType::Boolean).optional()));
@@ -336,7 +336,7 @@ mod test {
         ));
     }
 
-    #[test]
+    #[test_log::test]
     fn test_json_constraint() {
         let constraint = JsonSerializableConstraint;
         assert!(constraint.satisfied(&Type::from(PrimitiveType::Boolean).optional()));
@@ -373,7 +373,7 @@ mod test {
         ));
     }
 
-    #[test]
+    #[test_log::test]
     fn test_map_key_constraint() {
         let constraint = MapKeyConstraint;
         assert!(constraint.satisfied(&PrimitiveType::Boolean.into()));
@@ -393,7 +393,7 @@ mod test {
         assert!(!constraint.satisfied(&Type::Object));
     }
 
-    #[test]
+    #[test_log::test]
     fn test_primitive_constraint() {
         let constraint = PrimitiveTypeConstraint;
         assert!(constraint.satisfied(&Type::from(PrimitiveType::Boolean).optional()));

--- a/crates/wdl-analysis/src/types.rs
+++ b/crates/wdl-analysis/src/types.rs
@@ -1505,7 +1505,7 @@ mod test {
 
     use super::*;
 
-    #[test]
+    #[test_log::test]
     fn primitive_type_display() {
         assert_eq!(PrimitiveType::Boolean.to_string(), "Boolean");
         assert_eq!(PrimitiveType::Integer.to_string(), "Int");
@@ -1539,7 +1539,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[test_log::test]
     fn array_type_display() {
         assert_eq!(
             ArrayType::new(PrimitiveType::String).to_string(),
@@ -1563,7 +1563,7 @@ mod test {
         assert_eq!(ty.to_string(), "Array[Array[String?]+?]+?");
     }
 
-    #[test]
+    #[test_log::test]
     fn pair_type_display() {
         assert_eq!(
             PairType::new(PrimitiveType::String, PrimitiveType::Boolean).to_string(),
@@ -1591,7 +1591,7 @@ mod test {
         assert_eq!(ty.to_string(), "Pair[Array[File?]+?, Array[File?]+?]?");
     }
 
-    #[test]
+    #[test_log::test]
     fn map_type_display() {
         assert_eq!(
             MapType::new(PrimitiveType::String, PrimitiveType::Boolean).to_string(),
@@ -1616,7 +1616,7 @@ mod test {
         assert_eq!(ty.to_string(), "Map[String, Array[File?]+?]?");
     }
 
-    #[test]
+    #[test_log::test]
     fn struct_type_display() {
         assert_eq!(
             StructType::new("Foobar", std::iter::empty::<(String, Type)>()).to_string(),
@@ -1624,23 +1624,23 @@ mod test {
         );
     }
 
-    #[test]
+    #[test_log::test]
     fn object_type_display() {
         assert_eq!(Type::Object.to_string(), "Object");
         assert_eq!(Type::OptionalObject.to_string(), "Object?");
     }
 
-    #[test]
+    #[test_log::test]
     fn union_type_display() {
         assert_eq!(Type::Union.to_string(), "Union");
     }
 
-    #[test]
+    #[test_log::test]
     fn none_type_display() {
         assert_eq!(Type::None.to_string(), "None");
     }
 
-    #[test]
+    #[test_log::test]
     fn primitive_type_coercion() {
         // All types should be coercible to self, and required should coerce to optional
         // (but not vice versa)
@@ -1667,7 +1667,7 @@ mod test {
         assert!(!PrimitiveType::Float.is_coercible_to(&PrimitiveType::Integer));
     }
 
-    #[test]
+    #[test_log::test]
     fn object_type_coercion() {
         assert!(Type::Object.is_coercible_to(&Type::Object));
         assert!(Type::Object.is_coercible_to(&Type::OptionalObject));
@@ -1719,7 +1719,7 @@ mod test {
         assert!(!Type::OptionalObject.is_coercible_to(&ty));
     }
 
-    #[test]
+    #[test_log::test]
     fn array_type_coercion() {
         // Array[X] -> Array[Y]
         assert!(
@@ -1778,7 +1778,7 @@ mod test {
         assert!(!type2.is_coercible_to(&type1));
     }
 
-    #[test]
+    #[test_log::test]
     fn pair_type_coercion() {
         // Pair[W, X] -> Pair[Y, Z]
         assert!(
@@ -1833,7 +1833,7 @@ mod test {
         assert!(!type2.is_coercible_to(&type1));
     }
 
-    #[test]
+    #[test_log::test]
     fn map_type_coercion() {
         // Map[W, X] -> Map[Y, Z]
         assert!(
@@ -1979,7 +1979,7 @@ mod test {
         assert!(!type1.is_coercible_to(&Type::Object));
     }
 
-    #[test]
+    #[test_log::test]
     fn struct_type_coercion() {
         // S -> S (identical)
         let type1: Type = StructType::new(
@@ -2150,7 +2150,7 @@ mod test {
         assert!(!type1.is_coercible_to(&Type::Object));
     }
 
-    #[test]
+    #[test_log::test]
     fn union_type_coercion() {
         // Union -> anything (ok)
         for ty in [
@@ -2194,7 +2194,7 @@ mod test {
         }
     }
 
-    #[test]
+    #[test_log::test]
     fn none_type_coercion() {
         // None -> optional type (ok)
         for ty in [
@@ -2253,7 +2253,7 @@ mod test {
         }
     }
 
-    #[test]
+    #[test_log::test]
     fn primitive_equality() {
         for ty in [
             Type::from(PrimitiveType::Boolean),
@@ -2274,7 +2274,7 @@ mod test {
         }
     }
 
-    #[test]
+    #[test_log::test]
     fn array_equality() {
         // Array[String] == Array[String]
         let a: Type = ArrayType::new(PrimitiveType::String).into();
@@ -2310,7 +2310,7 @@ mod test {
         assert!(!a.eq(&Type::None));
     }
 
-    #[test]
+    #[test_log::test]
     fn pair_equality() {
         // Pair[String, Int] == Pair[String, Int]
         let a: Type = PairType::new(PrimitiveType::String, PrimitiveType::Integer).into();
@@ -2338,7 +2338,7 @@ mod test {
         assert!(!a.eq(&Type::None));
     }
 
-    #[test]
+    #[test_log::test]
     fn map_equality() {
         // Map[String, Int] == Map[String, Int]
         let a: Type = MapType::new(PrimitiveType::String, PrimitiveType::Integer).into();
@@ -2364,7 +2364,7 @@ mod test {
         assert!(!a.eq(&Type::None));
     }
 
-    #[test]
+    #[test_log::test]
     fn struct_equality() {
         let a: Type = StructType::new("Foo", [("foo", PrimitiveType::String)]).into();
         assert!(a.eq(&a));
@@ -2378,7 +2378,7 @@ mod test {
         assert!(!a.eq(&b));
     }
 
-    #[test]
+    #[test_log::test]
     fn object_equality() {
         assert!(Type::Object.eq(&Type::Object));
         assert!(!Type::OptionalObject.eq(&Type::Object));
@@ -2386,7 +2386,7 @@ mod test {
         assert!(Type::OptionalObject.eq(&Type::OptionalObject));
     }
 
-    #[test]
+    #[test_log::test]
     fn union_equality() {
         assert!(Type::Union.eq(&Type::Union));
         assert!(!Type::None.eq(&Type::Union));
@@ -2394,7 +2394,7 @@ mod test {
         assert!(Type::None.eq(&Type::None));
     }
 
-    #[test]
+    #[test_log::test]
     fn enum_type_new_with_explicit_type() {
         // Create enum with explicit `String` type, all choices coerce to `String`.
         let status = EnumType::new(
@@ -2418,7 +2418,7 @@ mod test {
         assert_eq!(status.choices().len(), 3);
     }
 
-    #[test]
+    #[test_log::test]
     fn enum_type_new_fails_when_not_coercible() {
         // Try to create enum with `Int` type but `String` choices.
         let result = EnumType::new(
@@ -2437,7 +2437,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[test_log::test]
     fn enum_type_infer_finds_common_type() {
         // All `Int` choices should infer `Int` type.
         let priority = EnumType::infer(
@@ -2459,7 +2459,7 @@ mod test {
         assert_eq!(priority.choices().len(), 3);
     }
 
-    #[test]
+    #[test_log::test]
     fn enum_type_infer_coerces_int_to_float() {
         // Mix of `Int` and `Float` should coerce to `Float`.
         let mixed = EnumType::infer(
@@ -2477,7 +2477,7 @@ mod test {
         assert_eq!(mixed.choices().len(), 2);
     }
 
-    #[test]
+    #[test_log::test]
     fn enum_type_infer_fails_without_common_type() {
         // `String` and `Int` have no common type.
         let result = EnumType::infer(
@@ -2494,7 +2494,7 @@ mod test {
         );
     }
 
-    #[test]
+    #[test_log::test]
     fn enum_type_empty_has_union_type() {
         // Empty enum should have `Union` type.
         let result = EnumType::infer("Empty", Vec::<(String, Type)>::new(), &[]);
@@ -2505,7 +2505,7 @@ mod test {
         assert_eq!(empty.choices().len(), 0);
     }
 
-    #[test]
+    #[test_log::test]
     fn enum_type_display() {
         let enum_type = EnumType::new(
             "Color",
@@ -2518,7 +2518,7 @@ mod test {
         assert_eq!(enum_type.to_string(), "Color");
     }
 
-    #[test]
+    #[test_log::test]
     fn enum_type_not_coercible_to_other_enums() {
         let color = EnumType::new(
             "Color",

--- a/crates/wdl-analysis/src/validation.rs
+++ b/crates/wdl-analysis/src/validation.rs
@@ -681,7 +681,7 @@ impl Visitor for Validator {
 mod tests {
     use super::*;
 
-    #[test]
+    #[test_log::test]
     fn test_find_nearest_rule() {
         let validator = Validator::default();
 

--- a/crates/wdl-analysis/tests/format.rs
+++ b/crates/wdl-analysis/tests/format.rs
@@ -19,6 +19,7 @@ fn normalize(s: &str) -> String {
 }
 
 #[tokio::test]
+#[test_log::test]
 async fn spaces() {
     let dir = Path::new("tests").join("format");
     let two_space_wdl_path = dir.join("two_spaces.wdl");


### PR DESCRIPTION
I've been adding more logging to `wdl-analysis` while working on incremental analysis, and it's _really_ helpful to see during tests. Ideally we add this to every crate, but this is where it's needed most

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
