### PR TITLE
chore: prepare `sprocket` v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## 0.28.1 - 2026-08-05
+## 0.29.0 - 2026-08-05
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5013,7 +5013,7 @@ dependencies = [
 
 [[package]]
 name = "sprocket"
-version = "0.28.1"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ manual_assert_eq = "warn"
 
 [package]
 name = "sprocket"
-version = "0.28.1"
+version = "0.29.0"
 description = "A command line tool for working with Workflow Description Language (WDL) documents"
 authors.workspace = true
 license.workspace = true

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ brew install sprocket
 Sprocket is available as a Docker [image](https://github.com/stjude-rust-labs/sprocket/pkgs/container/sprocket).
 
 ```bash
-docker pull ghcr.io/stjude-rust-labs/sprocket:v0.28.1
+docker pull ghcr.io/stjude-rust-labs/sprocket:v0.29.0
 ```
 
 ### Nix Flake

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -7,6 +7,7 @@ git_tag_name = "{{ package }}-v{{ version }}"
 
 [[package]]
 name = "sprocket"
+features_always_increment_minor = true
 git_release_enable = true
 git_release_name = "v{{ version }}"
 git_tag_name = "v{{ version }}"


### PR DESCRIPTION
The `v0.28.1` release represented feature-level changes as a patch release because pre-1.0 `feat` commits default to patch increments. This prepared `sprocket` `v0.29.0`, renamed the existing changelog section, and configured future `feat` commits to increment the minor version.

The full local suite was skipped by request; GitHub CI is the review gate before merge and publication. This PR supersedes the automated `v0.28.2` release PR.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
