### PR TITLE
fix: include requirements and hints in JSON roundtrip

### DIFF
--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* `WorkflowInputs` serialization no longer drops call-nested inputs.
+  Previously, the `Serialize` impl silently discarded per-call inputs
+  (including task input overrides, requirements, and hints for calls inside a
+  workflow) due to a variable-shadowing bug in the calls-iteration loop
+  ([#1051](https://github.com/stjude-rust-labs/sprocket/issues/1051)).
+
 ## 0.17.1 - 2026-08-05
 
 #### Added

--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Previously, the `Serialize` impl silently discarded per-call inputs
   (including task input overrides, requirements, and hints for calls inside a
   workflow) due to a variable-shadowing bug in the calls-iteration loop
-  ([#1051](https://github.com/stjude-rust-labs/sprocket/issues/1051)).
+  ([#1070](https://github.com/stjude-rust-labs/sprocket/pull/1070)).
 
 ## 0.17.1 - 2026-08-05
 

--- a/crates/wdl-engine/src/inputs.rs
+++ b/crates/wdl-engine/src/inputs.rs
@@ -793,10 +793,9 @@ impl Serialize for WorkflowInputs {
             let serialized = serde_json::to_value(v).map_err(|_| {
                 serde::ser::Error::custom(format!("failed to serialize inputs for call `{k}`"))
             })?;
-            let mut map = serde_json::Map::new();
             if let JsonValue::Object(obj) = serialized {
                 for (inner, value) in obj {
-                    map.insert(format!("{k}.{inner}"), value);
+                    map.serialize_entry(&format!("{k}.{inner}"), &value)?;
                 }
             }
         }
@@ -1157,5 +1156,171 @@ impl Serialize for Inputs {
             Self::Task(inputs) => inputs.serialize(serializer),
             Self::Workflow(inputs) => inputs.serialize(serializer),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression test for issue #1051: `WorkflowInputs::Serialize` was
+    /// dropping call-nested inputs (task input overrides, requirements,
+    /// hints) because of a variable-shadowing bug in the calls-iteration
+    /// loop.
+    #[test]
+    fn workflow_serialize_preserves_call_inputs() {
+        // Workflow with:
+        //   - top-level input `name = "sprocket"`
+        //   - call `hello` with:
+        //       - task input `name = "sprocket"`
+        //       - requirement override `memory = "5 GB"`
+        //       - hint override `some_hint = "value"`
+        let mut workflow = WorkflowInputs::default();
+        workflow.set("name", String::from("sprocket"));
+
+        let mut hello = TaskInputs::default();
+        hello.set("name", String::from("sprocket"));
+        hello.override_requirement("memory", String::from("5 GB"));
+        hello.override_hint("some_hint", String::from("value"));
+        workflow
+            .calls_mut()
+            .insert("hello".to_string(), Inputs::Task(hello));
+
+        let serialized = serde_json::to_value(&workflow).expect("should serialize");
+        let object = serialized
+            .as_object()
+            .expect("workflow inputs should serialize to a JSON object");
+
+        assert_eq!(
+            object.get("name").and_then(|v| v.as_str()),
+            Some("sprocket"),
+            "top-level workflow input `name` should be present"
+        );
+        assert_eq!(
+            object.get("hello.name").and_then(|v| v.as_str()),
+            Some("sprocket"),
+            "call-nested input `hello.name` should be present"
+        );
+        assert_eq!(
+            object
+                .get("hello.requirements.memory")
+                .and_then(|v| v.as_str()),
+            Some("5 GB"),
+            "call-nested requirement `hello.requirements.memory` should be present"
+        );
+        assert_eq!(
+            object.get("hello.hints.some_hint").and_then(|v| v.as_str()),
+            Some("value"),
+            "call-nested hint `hello.hints.some_hint` should be present"
+        );
+    }
+
+    /// Regression check: workflow inputs with no nested calls must still
+    /// serialize correctly (this path was never broken but is worth locking
+    /// in).
+    #[test]
+    fn workflow_serialize_only_workflow_inputs_still_works() {
+        let mut workflow = WorkflowInputs::default();
+        workflow.set("name", String::from("sprocket"));
+        workflow.set("count", 42i64);
+
+        let serialized = serde_json::to_value(&workflow).expect("should serialize");
+        let object = serialized
+            .as_object()
+            .expect("workflow inputs should serialize to a JSON object");
+
+        assert_eq!(object.len(), 2, "should have exactly 2 top-level entries");
+        assert_eq!(object.get("name").and_then(|v| v.as_str()), Some("sprocket"));
+        assert_eq!(object.get("count").and_then(|v| v.as_i64()), Some(42));
+    }
+
+    /// Verifies that multiple calls with disjoint inputs all survive
+    /// serialization.
+    #[test]
+    fn workflow_serialize_multiple_calls() {
+        let mut workflow = WorkflowInputs::default();
+
+        let mut first = TaskInputs::default();
+        first.set("greeting", String::from("hello"));
+        workflow
+            .calls_mut()
+            .insert("first".to_string(), Inputs::Task(first));
+
+        let mut second = TaskInputs::default();
+        second.set("greeting", String::from("bonjour"));
+        second.override_requirement("cpu", 4i64);
+        workflow
+            .calls_mut()
+            .insert("second".to_string(), Inputs::Task(second));
+
+        let serialized = serde_json::to_value(&workflow).expect("should serialize");
+        let object = serialized
+            .as_object()
+            .expect("workflow inputs should serialize to a JSON object");
+
+        assert_eq!(
+            object.get("first.greeting").and_then(|v| v.as_str()),
+            Some("hello"),
+            "first call's input should be present"
+        );
+        assert_eq!(
+            object.get("second.greeting").and_then(|v| v.as_str()),
+            Some("bonjour"),
+            "second call's input should be present"
+        );
+        assert_eq!(
+            object
+                .get("second.requirements.cpu")
+                .and_then(|v| v.as_i64()),
+            Some(4),
+            "second call's requirement override should be present"
+        );
+    }
+
+    /// Verifies the recursive case: a call that is itself a nested workflow.
+    /// The inner `WorkflowInputs::Serialize` must also propagate its call
+    /// entries to the outer serializer.
+    #[test]
+    fn workflow_serialize_nested_workflow_call() {
+        // Outer workflow contains a call to another workflow, which itself
+        // contains a task call. Verify all levels survive the recursion.
+        let mut inner_task = TaskInputs::default();
+        inner_task.override_requirement("memory", String::from("2 GB"));
+
+        let mut inner_workflow = WorkflowInputs::default();
+        inner_workflow.set("greeting", String::from("hi"));
+        inner_workflow
+            .calls_mut()
+            .insert("inner_task".to_string(), Inputs::Task(inner_task));
+
+        let mut outer = WorkflowInputs::default();
+        outer.set("name", String::from("sprocket"));
+        outer
+            .calls_mut()
+            .insert("sub".to_string(), Inputs::Workflow(inner_workflow));
+
+        let serialized = serde_json::to_value(&outer).expect("should serialize");
+        let object = serialized
+            .as_object()
+            .expect("workflow inputs should serialize to a JSON object");
+
+        assert_eq!(
+            object.get("name").and_then(|v| v.as_str()),
+            Some("sprocket"),
+            "outer top-level input should be present"
+        );
+        assert_eq!(
+            object.get("sub.greeting").and_then(|v| v.as_str()),
+            Some("hi"),
+            "inner workflow's top-level input should be present with `sub.` prefix"
+        );
+        assert_eq!(
+            object
+                .get("sub.inner_task.requirements.memory")
+                .and_then(|v| v.as_str()),
+            Some("2 GB"),
+            "doubly-nested requirement should survive recursion through both \
+             `WorkflowInputs::Serialize` calls"
+        );
     }
 }

--- a/crates/wdl-engine/src/inputs.rs
+++ b/crates/wdl-engine/src/inputs.rs
@@ -1230,7 +1230,10 @@ mod tests {
             .expect("workflow inputs should serialize to a JSON object");
 
         assert_eq!(object.len(), 2, "should have exactly 2 top-level entries");
-        assert_eq!(object.get("name").and_then(|v| v.as_str()), Some("sprocket"));
+        assert_eq!(
+            object.get("name").and_then(|v| v.as_str()),
+            Some("sprocket")
+        );
         assert_eq!(object.get("count").and_then(|v| v.as_i64()), Some(42));
     }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -995,3 +995,43 @@ fn initialize_file_logging(handle: FileReloadHandle, run_dir: &Path) -> Result<(
         .reload(layer().with_ansi(false).with_writer(log_file))
         .context("failed to initialize file logging")
 }
+
+#[cfg(test)]
+mod tests {
+    use wdl::engine::Value;
+
+    use super::*;
+
+    /// Regression test for https://github.com/stjude-rust-labs/sprocket/issues/1051.
+    ///
+    /// Reproduces the reported repro: a workflow input (`wf.name`) plus a
+    /// `requirements` override on a nested call
+    /// (`wf.hello.requirements.memory`). Both must survive the
+    /// `inputs_to_json` round-trip used by `dev server submit`/`retry`.
+    #[test]
+    fn inputs_to_json_preserves_nested_call_requirements() {
+        let mut task_inputs = TaskInputs::default();
+        task_inputs.override_requirement("memory", Value::from("2 GB".to_string()));
+
+        let mut workflow_inputs = WorkflowInputs::default();
+        workflow_inputs.set("name", Value::from("sprocket".to_string()));
+        workflow_inputs
+            .calls_mut()
+            .insert("hello".to_string(), Inputs::Task(task_inputs));
+
+        let json = inputs_to_json("wf", &Inputs::Workflow(workflow_inputs))
+            .expect("should serialize to JSON");
+        let value: serde_json::Value = serde_json::from_str(&json).expect("should be valid JSON");
+        let obj = value.as_object().expect("should be a JSON object");
+
+        assert_eq!(
+            obj.get("wf.name").and_then(JsonValue::as_str),
+            Some("sprocket")
+        );
+        assert_eq!(
+            obj.get("wf.hello.requirements.memory")
+                .and_then(JsonValue::as_str),
+            Some("2 GB")
+        );
+    }
+}


### PR DESCRIPTION
Fixes #1051. Serializes `requirements` and `hints` to JSON so that server can transmit from client to server for job submissions.
 
Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
