### PR TITLE
fix(wdl-doc): don't print warning when listing tests

### DIFF
--- a/crates/wdl-doc/tests/ui.rs
+++ b/crates/wdl-doc/tests/ui.rs
@@ -348,7 +348,7 @@ fn main() -> ExitCode {
         .expect("failed to create Tokio runtime");
 
     let args = libtest_mimic::Arguments::from_args();
-    if !should_run_headless() {
+    if !should_run_headless() && !args.list {
         let warning = r#"+------------------------------------+
 |                                    |
 |                                    |
@@ -363,7 +363,9 @@ fn main() -> ExitCode {
         println!("{}\n", warning.red());
         for i in (1..6).rev() {
             println!("The tests will start in {i} seconds.");
-            runtime.block_on(tokio::time::sleep(Duration::from_secs(1)));
+            runtime.block_on(async {
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            });
         }
     }
 


### PR DESCRIPTION
Since `nextest` relies on the output of `--list`, local runs would fail

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
