### PR TITLE
fix: omit empty `Outputs` sections

### DIFF
--- a/crates/wdl-doc/CHANGELOG.md
+++ b/crates/wdl-doc/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* Task and workflow pages no longer render an empty Outputs section when no outputs are declared ([#199](https://github.com/stjude-rust-labs/sprocket/issues/199)).
+
 ## 0.16.0 - 2026-08-05
 
 ## 0.15.3 - 2026-07-15

--- a/crates/wdl-doc/src/runnable.rs
+++ b/crates/wdl-doc/src/runnable.rs
@@ -278,14 +278,23 @@ pub(crate) trait Runnable: DefinitionMeta {
         (markup, headers)
     }
 
-    /// Render the outputs of the runnable.
-    fn render_outputs(&self, assets: &Path, links: &PageLinkIndex, page_dir: &Path) -> Markup {
-        html! {
+    /// Render the outputs of the runnable when any exist.
+    fn render_outputs(
+        &self,
+        assets: &Path,
+        links: &PageLinkIndex,
+        page_dir: &Path,
+    ) -> Option<Markup> {
+        if self.outputs().is_empty() {
+            return None;
+        }
+
+        Some(html! {
             div class="main__section" {
                 h2 id="outputs" class="main__section-header" { "Outputs" }
                 (render_non_required_parameters_table(self.outputs().iter(), assets, links, page_dir))
             }
-        }
+        })
     }
 }
 

--- a/crates/wdl-doc/src/runnable/task.rs
+++ b/crates/wdl-doc/src/runnable/task.rs
@@ -180,6 +180,10 @@ impl Task {
 
         let (input_markup, inner_headers) = self.render_inputs(assets, links, page_dir);
         headers.extend(inner_headers);
+        let output_markup = self.render_outputs(assets, links, page_dir);
+        if output_markup.is_some() {
+            headers.push(Header::Header("Outputs".to_string(), "outputs".to_string()));
+        }
 
         let mut hero = DeclarationHero::new("Task", self.name(), self.render_description(false))
             .kind_class("text-brand-violet-400")
@@ -201,11 +205,12 @@ impl Task {
                 }
             }
             (input_markup)
-            (self.render_outputs(assets, links, page_dir))
+            @if let Some(output_markup) = output_markup {
+                (output_markup)
+            }
             (self.render_runtime_section())
             (self.render_command_section())
         };
-        headers.push(Header::Header("Outputs".to_string(), "outputs".to_string()));
         headers.push(Header::Header("Runtime".to_string(), "runtime".to_string()));
         headers.push(Header::Header("Command".to_string(), "command".to_string()));
 
@@ -432,6 +437,61 @@ mod tests {
                 .text()
                 .unwrap(),
             "The generated greeting."
+        );
+    }
+
+    #[test]
+    fn render_omits_outputs_when_task_has_none() {
+        let task = task_at_path(
+            r#"
+            version 1.0
+            task my_task {
+                command <<<
+                echo hello
+                >>>
+            }
+            "#,
+            "tasks.wdl",
+        );
+        let links = PageLinkIndex::default();
+        let (markup, sections) = task.render(Path::new("assets"), &links, Path::new(""));
+
+        assert!(!markup.into_string().contains("id=\"outputs\""));
+        assert!(
+            !sections
+                .render()
+                .into_string()
+                .contains("href=\"#outputs\"")
+        );
+    }
+
+    #[test]
+    fn render_includes_outputs_when_task_has_any() {
+        let task = task_at_path(
+            r#"
+            version 1.0
+            task my_task {
+                command <<<
+                echo hello
+                >>>
+                output {
+                    String greeting = "hello"
+                }
+            }
+            "#,
+            "tasks.wdl",
+        );
+        let links = PageLinkIndex::default();
+        let (markup, sections) = task.render(Path::new("assets"), &links, Path::new(""));
+        let html = markup.into_string();
+
+        assert!(html.contains("id=\"outputs\""));
+        assert!(html.contains("Expression"));
+        assert!(
+            sections
+                .render()
+                .into_string()
+                .contains("href=\"#outputs\"")
         );
     }
 }

--- a/crates/wdl-doc/src/runnable/workflow.rs
+++ b/crates/wdl-doc/src/runnable/workflow.rs
@@ -195,6 +195,10 @@ impl Workflow {
         let (input_markup, inner_headers) = self.render_inputs(assets, links, page_dir);
 
         headers.extend(inner_headers);
+        let output_markup = self.render_outputs(assets, links, page_dir);
+        if output_markup.is_some() {
+            headers.push(Header::Header("Outputs".to_string(), "outputs".to_string()));
+        }
 
         let name_override = self.name_override();
         let (title, title_kind) = match name_override.as_deref() {
@@ -226,10 +230,10 @@ impl Workflow {
                 }
             }
             (input_markup)
-            (self.render_outputs(assets, links, page_dir))
+            @if let Some(output_markup) = output_markup {
+                (output_markup)
+            }
         };
-
-        headers.push(Header::Header("Outputs".to_string(), "outputs".to_string()));
 
         (
             main_container("workflow", self.wdl_path.is_none(), markup),
@@ -522,5 +526,72 @@ mod tests {
         assert!(html.contains("<svg"));
         assert!(html.contains("M2.146 2.854a"));
         assert!(html.contains("Nested Inputs Not Allowed"));
+    }
+
+    #[test]
+    fn render_omits_outputs_when_workflow_has_none() {
+        let (doc, _) = Document::parse(
+            r#"
+            version 1.0
+            workflow test {
+            }
+            "#,
+            None,
+        );
+        let doc_item = doc.ast().into_v1().unwrap().items().next().unwrap();
+        let ast_workflow = doc_item.into_workflow_definition().unwrap();
+        let workflow = Workflow::new(
+            ast_workflow.name().text().to_string(),
+            SupportedVersion::V1(V1::Zero),
+            ast_workflow,
+            None,
+            false,
+        );
+        let links = PageLinkIndex::default();
+        let (markup, sections) = workflow.render(Path::new("assets"), &links, Path::new(""));
+
+        assert!(!markup.into_string().contains("id=\"outputs\""));
+        assert!(
+            !sections
+                .render()
+                .into_string()
+                .contains("href=\"#outputs\"")
+        );
+    }
+
+    #[test]
+    fn render_includes_outputs_when_workflow_has_any() {
+        let (doc, _) = Document::parse(
+            r#"
+            version 1.0
+            workflow test {
+                output {
+                    String greeting = "hello"
+                }
+            }
+            "#,
+            None,
+        );
+        let doc_item = doc.ast().into_v1().unwrap().items().next().unwrap();
+        let ast_workflow = doc_item.into_workflow_definition().unwrap();
+        let workflow = Workflow::new(
+            ast_workflow.name().text().to_string(),
+            SupportedVersion::V1(V1::Zero),
+            ast_workflow,
+            None,
+            false,
+        );
+        let links = PageLinkIndex::default();
+        let (markup, sections) = workflow.render(Path::new("assets"), &links, Path::new(""));
+        let html = markup.into_string();
+
+        assert!(html.contains("id=\"outputs\""));
+        assert!(html.contains("Expression"));
+        assert!(
+            sections
+                .render()
+                .into_string()
+                .contains("href=\"#outputs\"")
+        );
     }
 }


### PR DESCRIPTION
Generated task and workflow pages rendered an empty `Outputs` heading and navigation entry when the runnable declared no outputs.

Changed `Runnable::render_outputs` to return no markup for an empty output list and kept `PageSections` in sync. Added task and workflow regressions covering empty and nonempty outputs.

Closes #199.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).
