### PR TITLE
fix: don't panic formatting dotted keys in `input` hints

### DIFF
--- a/crates/wdl-format/CHANGELOG.md
+++ b/crates/wdl-format/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* Formatting no longer panics on `input` hints keys that use dotted struct
+  member paths, such as `foo.bar` ([#854](https://github.com/stjude-rust-labs/sprocket/issues/854)).
+
 ## 0.20.1 - 2026-08-05
 
 #### Fixed

--- a/crates/wdl-format/src/v1.rs
+++ b/crates/wdl-format/src/v1.rs
@@ -291,14 +291,16 @@ pub fn format_literal_input_item(
 ) {
     let mut children = element.children().expect("literal input item children");
 
-    let key = children.next().expect("literal input item key");
-    assert_eq!(key.element().kind(), SyntaxKind::Ident);
-    (&key).write(stream, config);
-
-    let colon = children.next().expect("literal input item colon");
-    assert_eq!(colon.element().kind(), SyntaxKind::Colon);
-    (&colon).write(stream, config);
-    stream.end_word();
+    for child in children.by_ref() {
+        if matches!(child.element().kind(), SyntaxKind::Ident | SyntaxKind::Dot) {
+            (&child).write(stream, config);
+        } else {
+            assert_eq!(child.element().kind(), SyntaxKind::Colon);
+            (&child).write(stream, config);
+            stream.end_word();
+            break;
+        }
+    }
 
     let hints_node = children.next().expect("literal input item hints node");
     assert_eq!(hints_node.element().kind(), SyntaxKind::LiteralHintsNode);

--- a/crates/wdl-format/tests/format/issue-854/source.formatted.wdl
+++ b/crates/wdl-format/tests/format/issue-854/source.formatted.wdl
@@ -1,0 +1,24 @@
+version 1.3
+
+task foo {
+    command <<<
+    >>>
+
+    hints {
+        inputs: input {
+            foo.bar: hints {
+            },
+            baz: hints {
+                localization_optional: true,
+            },
+            a.b.c: hints {
+                localization_optional: false,
+            },
+        }
+        outputs: output {
+            out.field: hints {
+                x: 1,
+            },
+        }
+    }
+}

--- a/crates/wdl-format/tests/format/issue-854/source.wdl
+++ b/crates/wdl-format/tests/format/issue-854/source.wdl
@@ -1,0 +1,22 @@
+version 1.3
+
+task foo {
+    command <<<>>>
+
+    hints {
+        inputs: input {
+            foo.bar: hints {},
+            baz: hints {
+                localization_optional: true
+            },
+            a.b.c: hints {
+                localization_optional: false
+            }
+        }
+        outputs: output {
+            out.field: hints {
+                x: 1
+            }
+        }
+    }
+}


### PR DESCRIPTION
Formatting a `hints` section panicked whenever an `inputs: input { ... }` key used the dotted struct member path the WDL spec allows, e.g. `foo.bar: hints {}`. `format_literal_input_item` consumed one `Ident` and then asserted the next child was a `Colon`, so the `Dot` token tripped the assertion; the child iterator's drop guard then panicked a second time because its remaining items went unconsumed. The grammar has accepted `Ident (Dot Ident)* Colon expr` all along, and `format_literal_output_item` already handled it.

`format_literal_input_item` now writes `Ident` and `Dot` tokens until it reaches the `Colon`, mirroring the output item function, and a new `issue-854` format test covers dotted keys in both the `inputs` and `outputs` positions along with the idempotency check the harness applies to every fixture.

Closes #854.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).