### PR TITLE
fix: allow unknown escape sequences in `meta` and `parameter_meta`

### DIFF
--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Escape sequence validation no longer reports unknown or malformed escape
+  sequences within `meta` and `parameter_meta` sections; escape sequences are
+  not interpreted in metadata, so their shape is not meaningful there. Literal
+  tab and newline characters are still rejected in metadata strings
+  ([#248](https://github.com/stjude-rust-labs/sprocket/issues/248)).
+
 ## 0.24.0 - 2026-08-05
 
 ### Fixed

--- a/crates/wdl-analysis/src/validation.rs
+++ b/crates/wdl-analysis/src/validation.rs
@@ -318,7 +318,7 @@ impl Default for Validator {
     fn default() -> Self {
         let mut validator = Self::empty();
         validator.add_visitors([
-            Box::new(strings::LiteralTextVisitor) as Box<dyn Visitor>,
+            Box::<strings::LiteralTextVisitor>::default() as Box<dyn Visitor>,
             Box::<counts::CountingVisitor>::default(),
             Box::<keys::UniqueKeysVisitor>::default(),
             Box::<numbers::NumberVisitor>::default(),

--- a/crates/wdl-analysis/src/validation/strings.rs
+++ b/crates/wdl-analysis/src/validation/strings.rs
@@ -78,7 +78,11 @@ fn multiple_placeholder_options(first: Span, additional: Span) -> Diagnostic {
 }
 
 /// Used to check literal text in a string.
-fn check_text(diagnostics: &mut Diagnostics, start: usize, text: &str) {
+///
+/// If `in_metadata` is `true`, the text comes from a `meta` or
+/// `parameter_meta` section, where the shape of an escape sequence is not
+/// checked; see [`LiteralTextVisitor`].
+fn check_text(diagnostics: &mut Diagnostics, start: usize, text: &str, in_metadata: bool) {
     let lexer = EscapeToken::lexer(text).spanned();
     for (token, span) in lexer {
         match token.expect("should lex") {
@@ -87,6 +91,18 @@ fn check_text(diagnostics: &mut Diagnostics, start: usize, text: &str) {
             | EscapeToken::ValidHex
             | EscapeToken::ValidUnicode
             | EscapeToken::Text => continue,
+            // Escape sequences are not interpreted in metadata, so the shape
+            // of an escape sequence is not meaningful there; only the rules
+            // about characters that must be escaped still apply.
+            EscapeToken::InvalidOctal
+            | EscapeToken::InvalidHex
+            | EscapeToken::InvalidShortUnicode
+            | EscapeToken::InvalidUnicode
+            | EscapeToken::Unknown
+                if in_metadata =>
+            {
+                continue;
+            }
             EscapeToken::InvalidOctal => {
                 diagnostics.add(invalid_octal_escape(Span::new(start + span.start, 1)))
             }
@@ -125,10 +141,15 @@ fn check_text(diagnostics: &mut Diagnostics, start: usize, text: &str) {
 /// Ensures that string text:
 ///
 /// * Does not contain characters that must be escaped.
-/// * Does not contain invalid escape sequences.
+/// * Does not contain invalid escape sequences, except within `meta` and
+///   `parameter_meta` sections; escape sequences are not interpreted in
+///   metadata, so an unknown or malformed escape sequence there is just text.
 /// * Strings and command placeholders do not contain more than one option.
 #[derive(Default, Debug)]
-pub struct LiteralTextVisitor;
+pub struct LiteralTextVisitor {
+    /// Whether or not the visitor is within a metadata section.
+    in_metadata: bool,
+}
 
 impl Visitor for LiteralTextVisitor {
     fn reset(&mut self) {
@@ -141,7 +162,12 @@ impl Visitor for LiteralTextVisitor {
             LiteralStringKind::SingleQuoted | LiteralStringKind::DoubleQuoted => {
                 // Check the text of a normal string to ensure escape sequences are correct and
                 // characters that are required to be escaped are actually escaped.
-                check_text(diagnostics, text.span().start(), text.text());
+                check_text(
+                    diagnostics,
+                    text.span().start(),
+                    text.text(),
+                    self.in_metadata,
+                );
             }
             LiteralStringKind::Multiline => {
                 // Don't check the text of multiline strings as they are treated
@@ -151,6 +177,24 @@ impl Visitor for LiteralTextVisitor {
                 // line continuation whitespace is normalized.
             }
         }
+    }
+
+    fn metadata_section(
+        &mut self,
+        _: &mut Diagnostics,
+        reason: VisitReason,
+        _: &v1::MetadataSection,
+    ) {
+        self.in_metadata = reason == VisitReason::Enter;
+    }
+
+    fn parameter_metadata_section(
+        &mut self,
+        _: &mut Diagnostics,
+        reason: VisitReason,
+        _: &v1::ParameterMetadataSection,
+    ) {
+        self.in_metadata = reason == VisitReason::Enter;
     }
 
     fn placeholder(

--- a/crates/wdl-analysis/tests/validation/strings-in-metadata/source.errors
+++ b/crates/wdl-analysis/tests/validation/strings-in-metadata/source.errors
@@ -1,0 +1,20 @@
+error: literal strings cannot contain tab characters
+   ┌─ tests/validation/strings-in-metadata/source.wdl:43:29
+   │
+43 │         raw_tab: "this has a    tab"
+   │                             ^^^^ escape this tab with `/t`
+
+error: literal strings cannot contain newline characters
+   ┌─ tests/validation/strings-in-metadata/source.wdl:44:33
+   │  
+44 │           raw_newline: "this has a
+   │ ╭────────────────────────────────^
+45 │ │             newline"
+   │ ╰^ escape this newline with `/n`
+
+error: unknown escape sequence `/.`
+   ┌─ tests/validation/strings-in-metadata/source.wdl:57:21
+   │
+57 │     String regex = "/.bam$"
+   │                     ^^ this is not a valid WDL escape sequence
+

--- a/crates/wdl-analysis/tests/validation/strings-in-metadata/source.wdl
+++ b/crates/wdl-analysis/tests/validation/strings-in-metadata/source.wdl
@@ -1,0 +1,64 @@
+## This is a test of escape sequences in `meta` and `parameter_meta` sections.
+##
+## Escape sequences are not interpreted in metadata, so the shape of an escape
+## sequence is not validated there; the rules about characters that must be
+## escaped still apply.
+
+version 1.3
+
+struct Foo {
+    meta {
+        # Struct metadata uses the same nodes as task metadata.
+        unknown_dot: "an unknown \. escape"
+    }
+
+    Int a
+}
+
+task t {
+    meta {
+        unknown_dot: "an unknown \. escape"
+        unknown_underscore: "an unknown \_ escape"
+        invalid_hex: "an invalid \x escape"
+        invalid_short_unicode: "an invalid \u12 escape"
+        invalid_octal: "an invalid \8 escape"
+
+        nested_object: {
+            unknown_dot: "an unknown \. escape",
+            unknown_underscore: "an unknown \_ escape",
+            invalid_hex: "an invalid \x escape",
+            invalid_short_unicode: "an invalid \u12 escape",
+            invalid_octal: "an invalid \8 escape"
+        }
+
+        nested_array: [
+            "an unknown \. escape",
+            "an unknown \_ escape",
+            "an invalid \x escape",
+            "an invalid \u12 escape",
+            "an invalid \8 escape"
+        ]
+
+        # Characters that must be escaped are still checked in metadata.
+        raw_tab: "this has a	tab"
+        raw_newline: "this has a
+            newline"
+    }
+
+    parameter_meta {
+        newId: {description: "Assign ID on the fly (e.g. --set-id +'%CHROM\_%POS').", category: "advanced"}
+    }
+
+    input {
+        String newId
+    }
+
+    # Outside of metadata, an unknown escape sequence is still an error.
+    String regex = "\.bam$"
+
+    command <<<>>>
+
+    output {
+        String out = regex + newId
+    }
+}


### PR DESCRIPTION
Closes #248. Escape sequence shape is no longer validated inside `meta` and `parameter_meta`, where escapes are never interpreted.

Before submitting this PR, please make sure:

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).
