### PR TITLE
refactor(wdl-format): extract shared v1 formatting helpers

### DIFF
--- a/crates/wdl-format/CHANGELOG.md
+++ b/crates/wdl-format/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Extraneous tokens (e.g. trailing commas and empty call input blocks) are dropped from the output ([#1034](https://github.com/stjude-rust-labs/sprocket/pull/1034)).
 
+#### Changed
+
+* Deduplicated repeated comma-list and infix-expression formatting patterns in the `v1` module via shared helpers ([#1098](https://github.com/stjude-rust-labs/sprocket/issues/1098)).
+
 #### Fixed
 
 * Duplicate sections in a task, workflow, or struct are no longer dropped; every section is retained in the order it was written. A task that has both a `requirements` and a `runtime` section now retains both ([#1112](https://github.com/stjude-rust-labs/sprocket/pull/1112)).

--- a/crates/wdl-format/src/v1.rs
+++ b/crates/wdl-format/src/v1.rs
@@ -39,6 +39,57 @@ pub(crate) fn write_sections(
     }
 }
 
+/// Writes comma-separated items, one per line when more than one remains.
+///
+/// Prefers commas from the source AST so associated trivia is preserved.
+/// Extraneous trailing commas are dropped unless they carry a comment. When an
+/// item has no corresponding source comma (or the source comma was dropped),
+/// inserts a trailing comma if `config.trailing_commas` is enabled.
+pub(crate) fn write_comma_separated_items<'a>(
+    items: impl IntoIterator<Item = &'a FormatElement>,
+    commas: impl IntoIterator<Item = &'a FormatElement>,
+    stream: &mut TokenStream<PreToken>,
+    config: &Config,
+) {
+    let mut items = items.into_iter().peekable();
+    let mut commas = commas.into_iter();
+    while let Some(item) = items.next() {
+        item.write(stream, config);
+        if let Some(comma) = commas.next()
+            && (items.peek().is_some() || comma.has_comment())
+        {
+            comma.write(stream, config);
+            if items.peek().is_some() {
+                stream.end_line();
+            }
+        } else if config.trailing_commas {
+            stream.push_literal(",".into(), SyntaxKind::Comma);
+        }
+    }
+}
+
+/// Formats an infix expression whose operator token is whitespace-wrapped.
+///
+/// Each child is written in order. When a child matches `operator`, a word
+/// boundary is inserted on both sides so the operator is spaced like `a + b`.
+pub(crate) fn format_infix_expr(
+    element: &FormatElement,
+    stream: &mut TokenStream<PreToken>,
+    config: &Config,
+    operator: SyntaxKind,
+) {
+    for child in element.children().expect("infix expression children") {
+        let wrap = child.element().kind() == operator;
+        if wrap {
+            stream.end_word();
+        }
+        (&child).write(stream, config);
+        if wrap {
+            stream.end_word();
+        }
+    }
+}
+
 pub mod decl;
 pub mod r#enum;
 pub mod expr;
@@ -362,21 +413,12 @@ pub fn format_literal_input(
         }
     }
 
-    let mut items = items.iter().peekable();
-    let mut commas = commas.iter();
-    while let Some(item) = items.next() {
-        (item).write(stream, config);
-        if let Some(comma) = commas.next()
-            && (items.peek().is_some() || comma.has_comment())
-        {
-            (comma).write(stream, config);
-            if items.peek().is_some() {
-                stream.end_line();
-            }
-        } else if config.trailing_commas {
-            stream.push_literal(",".into(), SyntaxKind::Comma);
-        }
-    }
+    write_comma_separated_items(
+        items.iter().copied(),
+        commas.iter().copied(),
+        stream,
+        config,
+    );
 
     stream.decrement_indent();
     (&close_brace.expect("literal input close brace")).write(stream, config);
@@ -444,21 +486,12 @@ pub fn format_literal_hints(
         }
     }
 
-    let mut items = items.iter().peekable();
-    let mut commas = commas.iter();
-    while let Some(item) = items.next() {
-        (item).write(stream, config);
-        if let Some(comma) = commas.next()
-            && (items.peek().is_some() || comma.has_comment())
-        {
-            (comma).write(stream, config);
-            if items.peek().is_some() {
-                stream.end_line();
-            }
-        } else if config.trailing_commas {
-            stream.push_literal(",".into(), SyntaxKind::Comma);
-        }
-    }
+    write_comma_separated_items(
+        items.iter().copied(),
+        commas.iter().copied(),
+        stream,
+        config,
+    );
 
     stream.decrement_indent();
     (&close_brace.expect("literal hints close brace")).write(stream, config);
@@ -528,21 +561,12 @@ pub fn format_literal_output(
         }
     }
 
-    let mut items = items.iter().peekable();
-    let mut commas = commas.iter();
-    while let Some(item) = items.next() {
-        (item).write(stream, config);
-        if let Some(comma) = commas.next()
-            && (items.peek().is_some() || comma.has_comment())
-        {
-            (comma).write(stream, config);
-            if items.peek().is_some() {
-                stream.end_line();
-            }
-        } else if config.trailing_commas {
-            stream.push_literal(",".into(), SyntaxKind::Comma);
-        }
-    }
+    write_comma_separated_items(
+        items.iter().copied(),
+        commas.iter().copied(),
+        stream,
+        config,
+    );
 
     stream.decrement_indent();
     (&close_brace.expect("literal output close brace")).write(stream, config);

--- a/crates/wdl-format/src/v1/enum.rs
+++ b/crates/wdl-format/src/v1/enum.rs
@@ -7,6 +7,7 @@ use crate::PreToken;
 use crate::TokenStream;
 use crate::Writable as _;
 use crate::element::FormatElement;
+use crate::v1::write_comma_separated_items;
 
 /// Formats an [`EnumDefinition`](wdl_ast::v1::EnumDefinition).
 ///
@@ -62,21 +63,7 @@ pub fn format_enum_definition(
         }
     }
 
-    let mut choices = choices.iter().peekable();
-    let mut commas = commas.iter();
-    while let Some(choice) = choices.next() {
-        (&choice).write(stream, config);
-        if let Some(comma) = commas.next()
-            && (choices.peek().is_some() || comma.has_comment())
-        {
-            (comma).write(stream, config);
-            if choices.peek().is_some() {
-                stream.end_line();
-            }
-        } else if config.trailing_commas {
-            stream.push_literal(",".into(), SyntaxKind::Comma);
-        }
-    }
+    write_comma_separated_items(&choices, &commas, stream, config);
 
     stream.decrement_indent();
     (&close_brace.expect("enum definition close brace")).write(stream, config);

--- a/crates/wdl-format/src/v1/expr.rs
+++ b/crates/wdl-format/src/v1/expr.rs
@@ -7,6 +7,8 @@ use crate::PreToken;
 use crate::TokenStream;
 use crate::Writable as _;
 use crate::element::FormatElement;
+use crate::v1::format_infix_expr;
+use crate::v1::write_comma_separated_items;
 
 /// Formats a [`SepOption`](wdl_ast::v1::SepOption).
 ///
@@ -396,22 +398,7 @@ pub fn format_literal_array(
     if !empty {
         stream.increment_indent();
     }
-
-    let mut items = items.iter().peekable();
-    let mut commas = commas.iter();
-    while let Some(item) = items.next() {
-        (item).write(stream, config);
-        if let Some(comma) = commas.next()
-            && (items.peek().is_some() || comma.has_comment())
-        {
-            (comma).write(stream, config);
-            if items.peek().is_some() {
-                stream.end_line();
-            }
-        } else if config.trailing_commas {
-            stream.push_literal(",".into(), SyntaxKind::Comma);
-        }
-    }
+    write_comma_separated_items(&items, &commas, stream, config);
 
     if !empty {
         stream.decrement_indent();
@@ -478,22 +465,7 @@ pub fn format_literal_map(
         }
     }
 
-    let mut items = items.iter().peekable();
-    let mut commas = commas.iter();
-    while let Some(item) = items.next() {
-        (item).write(stream, config);
-
-        if let Some(comma) = commas.next()
-            && (items.peek().is_some() || comma.has_comment())
-        {
-            (comma).write(stream, config);
-            if items.peek().is_some() {
-                stream.end_line();
-            }
-        } else if config.trailing_commas {
-            stream.push_literal(",".into(), SyntaxKind::Comma);
-        }
-    }
+    write_comma_separated_items(&items, &commas, stream, config);
 
     stream.decrement_indent();
     (&close_brace.expect("literal map close brace")).write(stream, config);
@@ -564,22 +536,7 @@ pub fn format_literal_object(
         }
     }
 
-    let mut items = members.iter().peekable();
-    let mut commas = commas.iter();
-    while let Some(item) = items.next() {
-        (item).write(stream, config);
-
-        if let Some(comma) = commas.next()
-            && (items.peek().is_some() || comma.has_comment())
-        {
-            (comma).write(stream, config);
-            if items.peek().is_some() {
-                stream.end_line();
-            }
-        } else if config.trailing_commas {
-            stream.push_literal(",".into(), SyntaxKind::Comma);
-        }
-    }
+    write_comma_separated_items(&members, &commas, stream, config);
 
     stream.decrement_indent();
     (&close_brace.expect("literal object close brace")).write(stream, config);
@@ -643,16 +600,7 @@ pub fn format_addition_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("addition expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::Plus;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::Plus);
 }
 
 /// Formats a [`SubtractionExpr`](wdl_ast::v1::SubtractionExpr).
@@ -665,16 +613,7 @@ pub fn format_subtraction_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("subtraction expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::Minus;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::Minus);
 }
 
 /// Formats a [`MultiplicationExpr`](wdl_ast::v1::MultiplicationExpr).
@@ -687,16 +626,7 @@ pub fn format_multiplication_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("multiplication expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::Asterisk;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::Asterisk);
 }
 
 /// Formats a [`DivisionExpr`](wdl_ast::v1::DivisionExpr).
@@ -709,16 +639,7 @@ pub fn format_division_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("division expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::Slash;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::Slash);
 }
 
 /// Formats a [`ModuloExpr`](wdl_ast::v1::ModuloExpr).
@@ -731,16 +652,7 @@ pub fn format_modulo_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("modulo expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::Percent;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::Percent);
 }
 
 /// Formats an [`ExponentiationExpr`](wdl_ast::v1::ExponentiationExpr).
@@ -753,16 +665,7 @@ pub fn format_exponentiation_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("exponentiation expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::Exponentiation;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::Exponentiation);
 }
 
 /// Formats a [`LogicalAndExpr`](wdl_ast::v1::LogicalAndExpr).
@@ -775,16 +678,7 @@ pub fn format_logical_and_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("logical and expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::LogicalAnd;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::LogicalAnd);
 }
 
 /// Formats a [`LogicalNotExpr`](wdl_ast::v1::LogicalNotExpr).
@@ -816,16 +710,7 @@ pub fn format_logical_or_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("logical or expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::LogicalOr;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::LogicalOr);
 }
 
 /// Formats an [`EqualityExpr`](wdl_ast::v1::EqualityExpr).
@@ -838,16 +723,7 @@ pub fn format_equality_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("equality expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::Equal;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::Equal);
 }
 
 /// Formats a [`InequalityExpr`](wdl_ast::v1::InequalityExpr).
@@ -860,16 +736,7 @@ pub fn format_inequality_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("inequality expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::NotEqual;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::NotEqual);
 }
 
 /// Formats a [`LessExpr`](wdl_ast::v1::LessExpr).
@@ -882,16 +749,7 @@ pub fn format_less_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("less expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::Less;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::Less);
 }
 
 /// Formats a [`LessEqualExpr`](wdl_ast::v1::LessEqualExpr).
@@ -904,16 +762,7 @@ pub fn format_less_equal_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("less equal expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::LessEqual;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::LessEqual);
 }
 
 /// Formats a [`GreaterExpr`](wdl_ast::v1::GreaterExpr).
@@ -926,16 +775,7 @@ pub fn format_greater_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("greater expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::Greater;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::Greater);
 }
 
 /// Formats a [`GreaterEqualExpr`](wdl_ast::v1::GreaterEqualExpr).
@@ -948,16 +788,7 @@ pub fn format_greater_equal_expr(
     stream: &mut TokenStream<PreToken>,
     config: &Config,
 ) {
-    for child in element.children().expect("greater equal expr children") {
-        let whitespace_wrapped = child.element().kind() == SyntaxKind::GreaterEqual;
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-        (&child).write(stream, config);
-        if whitespace_wrapped {
-            stream.end_word();
-        }
-    }
+    format_infix_expr(element, stream, config, SyntaxKind::GreaterEqual);
 }
 
 /// Formats a [`ParenthesizedExpr`](wdl_ast::v1::ParenthesizedExpr).

--- a/crates/wdl-format/src/v1/meta.rs
+++ b/crates/wdl-format/src/v1/meta.rs
@@ -7,6 +7,7 @@ use crate::PreToken;
 use crate::TokenStream;
 use crate::Writable as _;
 use crate::element::FormatElement;
+use crate::v1::write_comma_separated_items;
 
 /// Formats a [`LiteralNull`](wdl_ast::v1::LiteralNull).
 ///
@@ -62,21 +63,7 @@ pub fn format_metadata_array(
         stream.increment_indent();
     }
 
-    let mut items = items.iter().peekable();
-    let mut commas = commas.iter();
-    while let Some(item) = items.next() {
-        (item).write(stream, config);
-        if let Some(comma) = commas.next()
-            && (items.peek().is_some() || comma.has_comment())
-        {
-            (comma).write(stream, config);
-            if items.peek().is_some() {
-                stream.end_line();
-            }
-        } else if config.trailing_commas {
-            stream.push_literal(",".into(), SyntaxKind::Comma);
-        }
-    }
+    write_comma_separated_items(&items, &commas, stream, config);
 
     if !empty {
         stream.decrement_indent();
@@ -127,21 +114,7 @@ pub fn format_metadata_object(
         stream.increment_indent();
     }
 
-    let mut items = items.iter().peekable();
-    let mut commas = commas.iter();
-    while let Some(item) = items.next() {
-        (item).write(stream, config);
-        if let Some(comma) = commas.next()
-            && (items.peek().is_some() || comma.has_comment())
-        {
-            (comma).write(stream, config);
-            if items.peek().is_some() {
-                stream.end_line();
-            }
-        } else if config.trailing_commas {
-            stream.push_literal(",".into(), SyntaxKind::Comma);
-        }
-    }
+    write_comma_separated_items(&items, &commas, stream, config);
 
     if !empty {
         stream.decrement_indent();

--- a/crates/wdl-format/src/v1/struct.rs
+++ b/crates/wdl-format/src/v1/struct.rs
@@ -7,6 +7,7 @@ use crate::PreToken;
 use crate::TokenStream;
 use crate::Writable as _;
 use crate::element::FormatElement;
+use crate::v1::write_comma_separated_items;
 use crate::v1::write_sections;
 
 /// Formats a [`StructDefinition`](wdl_ast::v1::StructDefinition).
@@ -151,21 +152,7 @@ pub fn format_literal_struct(
         }
     }
 
-    let mut items = members.iter().peekable();
-    let mut commas = commas.iter();
-    while let Some(item) = items.next() {
-        (item).write(stream, config);
-        if let Some(comma) = commas.next()
-            && (items.peek().is_some() || comma.has_comment())
-        {
-            (comma).write(stream, config);
-            if items.peek().is_some() {
-                stream.end_line();
-            }
-        } else if config.trailing_commas {
-            stream.push_literal(",".into(), SyntaxKind::Comma);
-        }
-    }
+    write_comma_separated_items(&members, &commas, stream, config);
 
     stream.decrement_indent();
     (&close_brace.expect("literal struct close brace")).write(stream, config);

--- a/crates/wdl-format/src/v1/workflow/call.rs
+++ b/crates/wdl-format/src/v1/workflow/call.rs
@@ -7,6 +7,7 @@ use crate::PreToken;
 use crate::TokenStream;
 use crate::Writable as _;
 use crate::element::FormatElement;
+use crate::v1::write_comma_separated_items;
 
 /// Formats a [`CallTarget`](wdl_ast::v1::CallTarget).
 ///
@@ -179,21 +180,7 @@ pub fn format_call_statement(
         }
         stream.increment_indent();
 
-        let mut inputs = inputs.iter().peekable();
-        let mut commas = commas.iter();
-        while let Some(input) = inputs.next() {
-            (&input).write(stream, config);
-            if let Some(comma) = commas.next()
-                && (inputs.peek().is_some() || comma.has_comment())
-            {
-                (comma).write(stream, config);
-                if inputs.peek().is_some() {
-                    stream.end_line();
-                }
-            } else if config.trailing_commas {
-                stream.push_literal(",".into(), SyntaxKind::Comma);
-            }
-        }
+        write_comma_separated_items(&inputs, &commas, stream, config);
 
         stream.decrement_indent();
         (&close_brace.expect("close brace")).write(stream, config);


### PR DESCRIPTION
## Summary

Fixes #1098 by extracting two shared helpers used across `wdl_format::v1`:

- `write_comma_separated_items` — single place for the repeated “write item, then source comma or configured trailing comma, then end line” pattern (literal arrays/maps/objects/structs, metadata arrays/objects, enum choices, call inputs, literal input/hints/output).
- `format_infix_expr` — shared path for whitespace-wrapped binary operators (`+`, `-`, `*`, `/`, `%`, `**`, logical and comparison operators).

Behavior is unchanged; this is an internal refactor only. Public API is stable.

## Checklist

For external contributors:

- [x] You have read the contributing guide in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate). *(no new tests; existing format fixtures cover behavior)*
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate). *(N/A)*
- [x] You have made a PR to the `next` branch in the sprocket.bio repository (when appropriate). *(N/A)*

## Testing

- `cargo test -p wdl-format` (unit + 38 format fixtures)
- `cargo fmt -p wdl-format`
- `cargo clippy -p wdl-format -- -D warnings`