### PR TITLE
fix: clean up Docker task work directories after cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+* `sprocket run` and `sprocket dev test` now warn on a second Ctrl-C that
+  terminating Sprocket leaves Docker containers running
+  ([#1020](https://github.com/stjude-rust-labs/sprocket/issues/1020)).
+
 ## 0.30.0 - 2026-08-26
 
 ### Added

--- a/crates/wdl-engine/CHANGELOG.md
+++ b/crates/wdl-engine/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* The Docker backend now hands a task's work directory back to the user
+  performing evaluation after a canceled or failed task, not only a completed
+  one ([#1020](https://github.com/stjude-rust-labs/sprocket/issues/1020)).
+
 ## 0.17.2 - 2026-08-26
 
 #### Added

--- a/crates/wdl-engine/src/backend/docker.rs
+++ b/crates/wdl-engine/src/backend/docker.rs
@@ -2,6 +2,8 @@
 
 use std::fs;
 use std::path::Path;
+#[cfg(unix)]
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -26,6 +28,8 @@ use crankshaft::engine::task::output::Type as OutputType;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use nonempty::NonEmpty;
+#[cfg(unix)]
+use tokio_util::sync::CancellationToken;
 use tracing::debug;
 use tracing::info;
 use tracing::warn;
@@ -338,40 +342,40 @@ impl ManagedTask for DockerTask<'_> {
     }
 }
 
-/// Represents a cleanup task that is run upon successful completion of a Docker
-/// task.
+/// Represents a cleanup task that is run after a Docker task, whatever the
+/// outcome of that task was.
 ///
 /// On Unix systems, this is used to recursively run `chown` on the work
 /// directory so that files created by a container user (e.g. `root`) are
 /// changed to be owned by the user performing evaluation.
 #[cfg(unix)]
 struct CleanupTask<'a> {
-    /// The task execution request.
-    request: &'a ExecuteTaskRequest<'a>,
     /// The name of the task.
     name: String,
     /// The work directory to `chown`.
-    work_dir: &'a EvaluationPath,
+    ///
+    /// The Docker backend always runs with a local work directory.
+    work_dir: PathBuf,
     /// The underlying Crankshaft backend.
     backend: &'a docker::Backend,
+    /// The token that cancels the cleanup.
+    ///
+    /// This is never the evaluation's cancellation token: the cleanup matters
+    /// most for a task that was canceled, and by then that token is canceled
+    /// and Docker would refuse to start the container.
+    token: CancellationToken,
 }
 
 #[cfg(unix)]
-impl ManagedTask for CleanupTask<'_> {
-    type Output = ();
+impl CleanupTask<'_> {
+    /// Runs the cleanup task.
+    async fn run(self) -> Result<()> {
+        assert!(
+            self.work_dir.is_absolute(),
+            "work directory should be absolute"
+        );
 
-    fn request(&self) -> &ExecuteTaskRequest<'_> {
-        self.request
-    }
-
-    async fn run(self) -> Result<Option<()>> {
-        use crankshaft::engine::service::runner::backend::TaskRunError;
-        use tracing::debug;
-
-        // SAFETY: the work directory is always local for the Docker backend
-        let work_dir = self.work_dir.as_local().expect("path should be local");
-        assert!(work_dir.is_absolute(), "work directory should be absolute");
-
+        // SAFETY: `geteuid` and `getegid` are always safe to call and cannot fail.
         let (uid, gid) = unsafe { (libc::geteuid(), libc::getegid()) };
         let ownership = format!("{uid}:{gid}");
 
@@ -391,7 +395,7 @@ impl ManagedTask for CleanupTask<'_> {
             ))
             .inputs([Input::builder()
                 .path(GUEST_WORK_DIR)
-                .contents(Contents::Path(work_dir.to_path_buf()))
+                .contents(Contents::Path(self.work_dir.clone()))
                 .ty(InputType::Directory)
                 // need write access to chown
                 .read_only(false)
@@ -407,31 +411,31 @@ impl ManagedTask for CleanupTask<'_> {
         debug!(
             "running cleanup task `{name}` to change ownership of `{path}` to `{ownership}`",
             name = self.name,
-            path = work_dir.display(),
+            path = self.work_dir.display(),
         );
 
+        // Passing no event sender keeps the cleanup off the event stream entirely, so
+        // no consumer can observe it, and none can cancel the token Crankshaft
+        // publishes with `TaskCreated` after the user has canceled evaluation.
         match self
             .backend
-            .run(
-                task,
-                self.request.events.crankshaft().cloned(),
-                self.request.cancellation.second(),
-            )
+            .run(task, None, self.token)
             .context("failed to submit cleanup task")?
             .await
         {
             Ok(results) => {
-                let result = results.first();
-                if result.status.success() {
-                    Ok(Some(()))
+                if results.first().status.success() {
+                    Ok(())
                 } else {
                     bail!(
                         "failed to chown task work directory `{path}`",
-                        path = work_dir.display()
+                        path = self.work_dir.display()
                     );
                 }
             }
-            Err(TaskRunError::Canceled) => Ok(None),
+            Err(TaskRunError::Canceled) => {
+                bail!("cleanup task `{name}` was canceled", name = self.name)
+            }
             Err(e) => Err(e).context("failed to run cleanup task"),
         }
     }
@@ -493,6 +497,13 @@ pub struct DockerBackend {
     max_memory: u64,
     /// The task manager for the backend.
     manager: TaskManager,
+    /// The token that cancels work directory cleanup.
+    ///
+    /// Cleanup deliberately does not observe the evaluation's cancellation, as
+    /// a canceled task is exactly when its work directory needs handing back.
+    /// This token is canceled only by an explicit request to stop cleaning up.
+    #[cfg(unix)]
+    cleanup_token: CancellationToken,
 }
 
 impl DockerBackend {
@@ -543,6 +554,8 @@ impl DockerBackend {
             max_cpu,
             max_memory,
             manager,
+            #[cfg(unix)]
+            cleanup_token: CancellationToken::new(),
         })
     }
 }
@@ -667,36 +680,38 @@ impl TaskExecutionBackend for DockerBackend {
                 gpu,
             };
 
-            match self.manager.run(cpu, memory, task).await? {
-                Some(res) => {
-                    // The task completed, perform cleanup on unix platforms
-                    #[cfg(unix)]
-                    {
-                        let name = format!(
+            let result = self.manager.run(cpu, memory, task).await;
+
+            // A container ordinarily runs as `root`, so on Unix the files it leaves in
+            // the work directory are owned by another user and cannot be removed by the
+            // user performing evaluation. Hand ownership back whatever the outcome of
+            // the task was: a task that was canceled or that failed leaves the same
+            // files behind as one that completed.
+            //
+            // This is awaited here rather than submitted to the task manager, which
+            // abandons a task that has to wait for resources once evaluation has been
+            // canceled.
+            #[cfg(unix)]
+            {
+                let work_dir = request.work_dir();
+                if work_dir.exists() {
+                    let task = CleanupTask {
+                        name: format!(
                             "{CLEANUP_TASK_NAME_PREFIX}chown-{name}",
                             name = request.name
-                        );
+                        ),
+                        work_dir,
+                        backend: self.inner.as_ref(),
+                        token: self.cleanup_token.clone(),
+                    };
 
-                        let task = CleanupTask {
-                            request,
-                            name,
-                            work_dir: &res.work_dir.clone(),
-                            backend: self.inner.as_ref(),
-                        };
-
-                        if let Err(e) = self
-                            .manager
-                            .run(CLEANUP_TASK_CPU, CLEANUP_TASK_MEMORY, task)
-                            .await
-                        {
-                            tracing::error!("Docker backend cleanup failed: {e:#}");
-                        }
+                    if let Err(e) = task.run().await {
+                        tracing::error!("Docker backend cleanup failed: {e:#}");
                     }
-
-                    Ok(Some(res))
                 }
-                None => Ok(None),
             }
+
+            result
         }
         .boxed()
     }
@@ -761,5 +776,179 @@ mod tests {
         assert!(message.contains("File Sharing"));
         // The underlying Docker error is preserved for diagnosis.
         assert!(message.contains("status code 400"));
+    }
+
+    /// Cancels a task while its container is running and confirms that the
+    /// ownership cleanup still ran, and that it stayed off the event stream.
+    ///
+    /// Without the cleanup, the container's files remain owned by `root` and
+    /// the user performing evaluation cannot delete them.
+    ///
+    /// The ownership assertion only distinguishes a missing cleanup where the
+    /// host sees the ownership the container wrote, which is the case on Linux.
+    /// Docker Desktop remaps a bind mount to the calling user, so on macOS this
+    /// test checks the cancellation result and the absence of cleanup events
+    /// but cannot observe whether ownership was handed back.
+    #[cfg(all(unix, not(docker_tests_disabled)))]
+    #[tokio::test]
+    async fn cleanup_runs_after_a_cancellation() {
+        use std::os::unix::fs::MetadataExt;
+        use std::time::Duration;
+
+        use crankshaft::events::Event as CrankshaftEvent;
+        use indexmap::IndexMap;
+
+        use crate::CancellationContext;
+        use crate::Engine;
+        use crate::Events;
+        use crate::config::FailureMode;
+
+        let root = TempDir::new().unwrap();
+        let attempt_dir = root.path().join("attempts").join("0");
+        let temp_dir = root.path().join("tmp");
+        fs::create_dir_all(&attempt_dir).unwrap();
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let mut config = Config::default();
+        // `alpine` has no `bash`
+        config.task.shell = "/bin/sh".to_string();
+
+        let engine = Engine::new(config.clone())
+            .await
+            .expect("engine should initialize");
+        let backend = DockerBackend::new(Arc::new(config))
+            .await
+            .expect("Docker backend should initialize");
+
+        let events = Events::new(1024);
+        let mut receiver = events
+            .subscribe_crankshaft()
+            .expect("Crankshaft events should be enabled");
+        let cancellation = CancellationContext::new(FailureMode::Fast);
+
+        let env = IndexMap::new();
+        let inputs = TaskInputs::default();
+        let requirements = Object::empty();
+        let hints = Object::empty();
+        let base_dir = EvaluationPath::from_local_path(root.path().into());
+        let constraints = TaskExecutionConstraints {
+            sources: vec!["docker://alpine:latest".parse().unwrap()],
+            cpu: 1.0,
+            memory: ONE_GIBIBYTE as u64,
+            gpu: Default::default(),
+            fpga: Default::default(),
+            disks: Default::default(),
+        };
+
+        let request = ExecuteTaskRequest {
+            engine: &engine,
+            name: "cleanup-after-cancellation-0",
+            command: "mkdir -p testdir && echo hello > testdir/hello.txt && sleep 60",
+            inputs: &inputs,
+            backend_inputs: &[],
+            requirements: &requirements,
+            hints: &hints,
+            env: &env,
+            constraints: &constraints,
+            base_dir: &base_dir,
+            attempt_dir: &attempt_dir,
+            temp_dir: &temp_dir,
+            events: &events,
+            cancellation: &cancellation,
+        };
+
+        let work_dir = request.work_dir();
+        // The container creates this before it sleeps, so its presence means there is
+        // something for the cleanup to hand back
+        let marker = work_dir.join("testdir").join("hello.txt");
+
+        let mut execute = std::pin::pin!(backend.execute(&request));
+        let result = tokio::time::timeout(Duration::from_secs(300), async {
+            loop {
+                tokio::select! {
+                    result = &mut execute => break result,
+                    _ = tokio::time::sleep(Duration::from_millis(100)) => {
+                        if marker.exists() {
+                            let _ = cancellation.cancel();
+                        }
+                    }
+                }
+            }
+        })
+        .await
+        .expect("the task should be canceled well within the timeout")
+        .expect("execution should not fail");
+
+        assert!(result.is_none(), "the task should have been canceled");
+        assert!(
+            marker.exists(),
+            "the container should have created its file before the cancellation"
+        );
+
+        // SAFETY: `geteuid` and `getegid` are always safe to call and cannot fail.
+        let (uid, gid) = unsafe { (libc::geteuid(), libc::getegid()) };
+        let mut dirs = vec![work_dir];
+        while let Some(dir) = dirs.pop() {
+            for entry in fs::read_dir(&dir).expect("work directory should be readable") {
+                let path = entry.expect("directory entry should be readable").path();
+                let metadata = path
+                    .symlink_metadata()
+                    .expect("entry metadata should be readable");
+
+                assert_eq!(
+                    (metadata.uid(), metadata.gid()),
+                    (uid, gid),
+                    "`{path}` should be owned by the user performing evaluation",
+                    path = path.display()
+                );
+
+                if metadata.is_dir() {
+                    dirs.push(path);
+                }
+            }
+        }
+
+        // The cleanup is the backend's own bookkeeping, so it emits no events at all:
+        // every event on the stream belongs to the task itself. Requiring the task's
+        // own events keeps this from passing on a stream that carried nothing.
+        let mut task_id = None;
+        while let Ok(event) = receiver.try_recv() {
+            let id = match &event {
+                CrankshaftEvent::TaskCreated { id, name, .. } => {
+                    assert!(
+                        !name.starts_with(CLEANUP_TASK_NAME_PREFIX),
+                        "cleanup task `{name}` should not appear on the event stream"
+                    );
+
+                    assert_eq!(name, request.name, "an unexpected task was reported");
+                    task_id = Some(*id);
+                    *id
+                }
+                CrankshaftEvent::TaskStarted { id }
+                | CrankshaftEvent::TaskContainerCreated { id, .. }
+                | CrankshaftEvent::TaskContainerExited { id, .. }
+                | CrankshaftEvent::TaskCompleted { id, .. }
+                | CrankshaftEvent::TaskFailed { id, .. }
+                | CrankshaftEvent::TaskCanceled { id }
+                | CrankshaftEvent::TaskPreempted { id }
+                | CrankshaftEvent::TaskStdout { id, .. }
+                | CrankshaftEvent::TaskStderr { id, .. }
+                | CrankshaftEvent::ImagePullStarted { id, .. }
+                | CrankshaftEvent::ImagePullFailed { id, .. }
+                | CrankshaftEvent::ImagePullFinished { id, .. } => *id,
+            };
+
+            assert_eq!(
+                Some(id),
+                task_id,
+                "an event was reported for a task other than `{name}`: {event:?}",
+                name = request.name
+            );
+        }
+
+        assert!(
+            task_id.is_some(),
+            "the task itself should have been reported on the event stream"
+        );
     }
 }

--- a/crates/wdl-engine/src/backend/docker.rs
+++ b/crates/wdl-engine/src/backend/docker.rs
@@ -2,8 +2,6 @@
 
 use std::fs;
 use std::path::Path;
-#[cfg(unix)]
-use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex;
 
@@ -342,102 +340,80 @@ impl ManagedTask for DockerTask<'_> {
     }
 }
 
-/// Represents a cleanup task that is run after a Docker task, whatever the
-/// outcome of that task was.
+/// Hands a task's work directory back to the user performing evaluation.
 ///
-/// On Unix systems, this is used to recursively run `chown` on the work
-/// directory so that files created by a container user (e.g. `root`) are
-/// changed to be owned by the user performing evaluation.
+/// On Unix systems, this recursively runs `chown` in a container so that files
+/// created by a container user (e.g. `root`) become owned by the user
+/// performing evaluation, which is the only user that can then remove them.
+///
+/// This runs after a Docker task whatever the outcome of that task was.
 #[cfg(unix)]
-struct CleanupTask<'a> {
-    /// The name of the task.
-    name: String,
-    /// The work directory to `chown`.
-    ///
-    /// The Docker backend always runs with a local work directory.
-    work_dir: PathBuf,
-    /// The underlying Crankshaft backend.
-    backend: &'a docker::Backend,
-    /// The token that cancels the cleanup.
-    ///
-    /// This is never the evaluation's cancellation token: the cleanup matters
-    /// most for a task that was canceled, and by then that token is canceled
-    /// and Docker would refuse to start the container.
-    token: CancellationToken,
-}
+async fn chown_work_dir(backend: &docker::Backend, name: &str, work_dir: &Path) -> Result<()> {
+    assert!(work_dir.is_absolute(), "work directory should be absolute");
 
-#[cfg(unix)]
-impl CleanupTask<'_> {
-    /// Runs the cleanup task.
-    async fn run(self) -> Result<()> {
-        assert!(
-            self.work_dir.is_absolute(),
-            "work directory should be absolute"
-        );
+    // SAFETY: `geteuid` and `getegid` are always safe to call and cannot fail.
+    let (uid, gid) = unsafe { (libc::geteuid(), libc::getegid()) };
+    let ownership = format!("{uid}:{gid}");
 
-        // SAFETY: `geteuid` and `getegid` are always safe to call and cannot fail.
-        let (uid, gid) = unsafe { (libc::geteuid(), libc::getegid()) };
-        let ownership = format!("{uid}:{gid}");
+    let task = Task::builder()
+        .name(name)
+        .executions(NonEmpty::new(
+            Execution::builder()
+                // SAFETY: there is at least one image in the list
+                .images(["alpine:latest"])?
+                .program("chown")
+                .args([
+                    "-R".to_string(),
+                    ownership.clone(),
+                    GUEST_WORK_DIR.to_string(),
+                ])
+                .build(),
+        ))
+        .inputs([Input::builder()
+            .path(GUEST_WORK_DIR)
+            .contents(Contents::Path(work_dir.to_path_buf()))
+            .ty(InputType::Directory)
+            // need write access to chown
+            .read_only(false)
+            .build()])
+        .resources(
+            Resources::builder()
+                .cpu(CLEANUP_TASK_CPU)
+                .ram(CLEANUP_TASK_MEMORY as f64 / ONE_GIBIBYTE)
+                .build(),
+        )
+        .build();
 
-        let task = Task::builder()
-            .name(&self.name)
-            .executions(NonEmpty::new(
-                Execution::builder()
-                    // SAFETY: there is at least one image in the list
-                    .images(["alpine:latest"])?
-                    .program("chown")
-                    .args([
-                        "-R".to_string(),
-                        ownership.clone(),
-                        GUEST_WORK_DIR.to_string(),
-                    ])
-                    .build(),
-            ))
-            .inputs([Input::builder()
-                .path(GUEST_WORK_DIR)
-                .contents(Contents::Path(self.work_dir.clone()))
-                .ty(InputType::Directory)
-                // need write access to chown
-                .read_only(false)
-                .build()])
-            .resources(
-                Resources::builder()
-                    .cpu(CLEANUP_TASK_CPU)
-                    .ram(CLEANUP_TASK_MEMORY as f64 / ONE_GIBIBYTE)
-                    .build(),
-            )
-            .build();
+    debug!(
+        "running cleanup task `{name}` to change ownership of `{path}` to `{ownership}`",
+        path = work_dir.display(),
+    );
 
-        debug!(
-            "running cleanup task `{name}` to change ownership of `{path}` to `{ownership}`",
-            name = self.name,
-            path = self.work_dir.display(),
-        );
-
-        // Passing no event sender keeps the cleanup off the event stream entirely, so
-        // no consumer can observe it, and none can cancel the token Crankshaft
-        // publishes with `TaskCreated` after the user has canceled evaluation.
-        match self
-            .backend
-            .run(task, None, self.token)
-            .context("failed to submit cleanup task")?
-            .await
-        {
-            Ok(results) => {
-                if results.first().status.success() {
-                    Ok(())
-                } else {
-                    bail!(
-                        "failed to chown task work directory `{path}`",
-                        path = self.work_dir.display()
-                    );
-                }
+    // The cleanup runs on a token of its own that nothing cancels: it matters most
+    // for a task that was canceled, and by then the evaluation's tokens are
+    // canceled and Docker would refuse to start the container. Dropping this
+    // future is the only way to stop waiting for the cleanup.
+    //
+    // Passing no event sender keeps the cleanup off the event stream entirely, so
+    // no consumer can observe it, and none can cancel the token Crankshaft
+    // publishes with `TaskCreated` after the user has canceled evaluation.
+    match backend
+        .run(task, None, CancellationToken::new())
+        .context("failed to submit cleanup task")?
+        .await
+    {
+        Ok(results) => {
+            if results.first().status.success() {
+                Ok(())
+            } else {
+                bail!(
+                    "failed to chown task work directory `{path}`",
+                    path = work_dir.display()
+                );
             }
-            Err(TaskRunError::Canceled) => {
-                bail!("cleanup task `{name}` was canceled", name = self.name)
-            }
-            Err(e) => Err(e).context("failed to run cleanup task"),
         }
+        Err(TaskRunError::Canceled) => bail!("cleanup task `{name}` was canceled"),
+        Err(e) => Err(e).context("failed to run cleanup task"),
     }
 }
 
@@ -497,13 +473,6 @@ pub struct DockerBackend {
     max_memory: u64,
     /// The task manager for the backend.
     manager: TaskManager,
-    /// The token that cancels work directory cleanup.
-    ///
-    /// Cleanup deliberately does not observe the evaluation's cancellation, as
-    /// a canceled task is exactly when its work directory needs handing back.
-    /// This token is canceled only by an explicit request to stop cleaning up.
-    #[cfg(unix)]
-    cleanup_token: CancellationToken,
 }
 
 impl DockerBackend {
@@ -554,8 +523,6 @@ impl DockerBackend {
             max_cpu,
             max_memory,
             manager,
-            #[cfg(unix)]
-            cleanup_token: CancellationToken::new(),
         })
     }
 }
@@ -695,17 +662,12 @@ impl TaskExecutionBackend for DockerBackend {
             {
                 let work_dir = request.work_dir();
                 if work_dir.exists() {
-                    let task = CleanupTask {
-                        name: format!(
-                            "{CLEANUP_TASK_NAME_PREFIX}chown-{name}",
-                            name = request.name
-                        ),
-                        work_dir,
-                        backend: self.inner.as_ref(),
-                        token: self.cleanup_token.clone(),
-                    };
+                    let name = format!(
+                        "{CLEANUP_TASK_NAME_PREFIX}chown-{name}",
+                        name = request.name
+                    );
 
-                    if let Err(e) = task.run().await {
+                    if let Err(e) = chown_work_dir(self.inner.as_ref(), &name, &work_dir).await {
                         tracing::error!("Docker backend cleanup failed: {e:#}");
                     }
                 }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -50,9 +50,9 @@ pub fn uses_docker_backend(engine: &EngineConfig) -> bool {
 /// exit without waiting for executing tasks to cancel.
 pub fn warn_docker_termination() {
     warn!(
-        "terminating Sprocket does not remove Docker containers that are still running: files \
-         those containers created may be owned by another user (e.g. `root`) and require elevated \
-         privileges to remove"
+        "terminating Sprocket does not remove Docker containers that are still running; files \
+         that were created by containers may remain owned by another user (e.g. `root`) and \
+         require elevated privileges to remove"
     );
 }
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -7,6 +7,8 @@ use std::sync::Arc;
 use clap::Subcommand;
 use colored::Colorize;
 use nonempty::NonEmpty;
+use tracing::warn;
+use wdl::engine::Config as EngineConfig;
 
 pub mod analyzer;
 pub mod cancel;
@@ -29,6 +31,30 @@ pub mod status;
 pub mod submit;
 pub mod test;
 pub mod validate;
+
+/// Determines whether the engine is configured to run tasks with Docker.
+///
+/// A misnamed backend is reported as not using Docker; the configuration is
+/// validated before evaluation starts, which is where that is diagnosed.
+pub fn uses_docker_backend(engine: &EngineConfig) -> bool {
+    engine
+        .backend()
+        .map(|config| config.as_docker().is_some())
+        .unwrap_or(false)
+}
+
+/// Warns that terminating Sprocket leaves Docker containers, and the files
+/// those containers created, behind.
+///
+/// Call this only when [`uses_docker_backend`] holds and Sprocket is about to
+/// exit without waiting for executing tasks to cancel.
+pub fn warn_docker_termination() {
+    warn!(
+        "terminating Sprocket does not remove Docker containers that are still running: files \
+         those containers created may be owned by another user (e.g. `root`) and require elevated \
+         privileges to remove"
+    );
+}
 
 /// Represents an error that may result from a command.
 ///

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -62,6 +62,8 @@ use crate::analysis::Analysis;
 use crate::analysis::Source;
 use crate::commands::CommandError;
 use crate::commands::CommandResult;
+use crate::commands::uses_docker_backend;
+use crate::commands::warn_docker_termination;
 use crate::inputs::Invocation;
 use crate::system::v1::db::Database;
 use crate::system::v1::db::SprocketCommand;
@@ -1009,6 +1011,8 @@ pub async fn run(
         setup_run_context(handle, &args, &config, &source, &target, &inputs).await?;
 
     let cancellation = CancellationContext::new(config.run.engine.failure_mode);
+    // Determined here as the engine configuration is moved into evaluation below.
+    let uses_docker = uses_docker_backend(&config.run.engine);
     let events = Events::new(
         config
             .run
@@ -1080,6 +1084,10 @@ pub async fn run(
                     },
                     CancellationContextState::Canceling => {
                         error!("waiting for executing tasks to cancel: use Ctrl-C to immediately terminate Sprocket");
+
+                        if uses_docker {
+                            warn_docker_termination();
+                        }
                     },
                 }
             },

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -70,6 +70,8 @@ use crate::analysis::Analysis;
 use crate::analysis::Source;
 use crate::commands::CommandError;
 use crate::commands::CommandResult;
+use crate::commands::uses_docker_backend;
+use crate::commands::warn_docker_termination;
 use crate::config::TestConfig;
 use crate::eval::Evaluator;
 use crate::system::v1::fs::RUNS_DIR;
@@ -1136,6 +1138,8 @@ pub async fn test(
     config.run.engine.task.memory_limit_behavior = TaskResourceLimitBehavior::TryWithMax;
     config.validate()?;
 
+    // Determined here as the engine configuration is moved into the engine below.
+    let uses_docker = uses_docker_backend(&config.run.engine);
     let engine = Engine::new(config.run.engine)
         .await
         .context("failed to create WDL evaluation engine")?;
@@ -1183,6 +1187,10 @@ pub async fn test(
 
             _ = tokio::signal::ctrl_c() => {
                 if cancellation.state() == CancellationContextState::Canceling {
+                    if uses_docker {
+                        warn_docker_termination();
+                    }
+
                     return Err(anyhow!("evaluation was interrupted").into());
                 }
 


### PR DESCRIPTION
Closes #1020.

Canceling a Docker task left its work directory owned by `root`, which the user running evaluation cannot delete, because the `chown` cleanup ran only for a task that completed. It now runs whatever the outcome was, with a cancellation token of its own, awaited outside the task manager, and with no event sender. A second Ctrl-C also warns that terminating Sprocket leaves running containers behind.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).
