### PR TITLE
fix: handle empty arrays in `sep=` placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* `sep=` placeholders now evaluate typed empty primitive arrays as empty strings
+  instead of reporting a type-coercion error
+  ([#1147](https://github.com/stjude-rust-labs/sprocket/pull/1147)).
 * `dev server cancel` no longer reports success for a run this server instance
   is not tracking. Cancelling a run left behind by a previous server process
   silently did nothing while the run stayed `running`; it now returns

--- a/crates/wdl-engine/src/eval/v1/expr.rs
+++ b/crates/wdl-engine/src/eval/v1/expr.rs
@@ -399,9 +399,8 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
                 Value::Compound(CompoundValue::Array(v))
                     if matches!(placeholder.option(), Some(PlaceholderOption::Sep(_)))
                         && v.as_slice()
-                            .first()
-                            .map(|e| !matches!(e, Value::None(_) | Value::Compound(_)))
-                            .unwrap_or(false) =>
+                            .iter()
+                            .all(|e| matches!(e, Value::Primitive(_))) =>
                 {
                     let option = placeholder.option().unwrap().unwrap_sep();
 
@@ -415,7 +414,6 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
                         }
 
                         match e {
-                            Value::None(_) => {}
                             Value::Primitive(v) => {
                                 write!(buffer, "{v}", v = v.raw(Some(&evaluator.context))).unwrap()
                             }
@@ -2184,6 +2182,20 @@ pub(crate) mod test {
             .await
             .unwrap();
         assert_eq!(value.unwrap_string().as_str(), "1+2+3 = 6");
+
+        env.insert_name(
+            "empty",
+            Array::new(ArrayType::new(PrimitiveType::String), Vec::<Value>::new()).unwrap(),
+        );
+        let value = eval_v1_expr(&env, V1::Two, r#""~{sep="+" empty}""#)
+            .await
+            .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "");
+
+        let value = eval_v1_expr(&env, V1::Two, r#""~{sep="+" prefix("-i ", empty)}""#)
+            .await
+            .unwrap();
+        assert_eq!(value.unwrap_string().as_str(), "");
 
         let diagnostic = eval_v1_expr(&env, V1::Two, r#""~{[1, 2, 3]}""#)
             .await


### PR DESCRIPTION
`sep=` placeholders treated empty arrays as non-string values because the evaluator required a first element. This caused correctly typed arrays to fail before task execution.

The rule is consistent across the supported WDL versions. [WDL 1.0](https://github.com/openwdl/wdl/blob/main/versions/1.0/SPEC.md#array-serialization-by-expansion) says the expression “must be declared as an `Array` of primitive types”; an ordinary `Array[P]` may be empty because only `Array[P]+` requires an element. [WDL 1.1](https://github.com/openwdl/wdl/blob/main/versions/1.1/SPEC.md#sep) formalizes the placeholder requirement as `Array[P]`, and its [optional-coercion section](https://github.com/openwdl/wdl/blob/main/versions/1.1/SPEC.md#coercion-of-optional-types) says an `Array[T?]` cannot be passed to `sep`, which requires `Array[T]`. [WDL 1.2](https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#sep-1) retains that type boundary and explicitly states that `sep` returns an empty string when its array is empty. Thus, I've narrow this to accept only Primitive instead of rejecting the inverse (roughly).

Closes #1146.

Before submitting this PR, please make sure:

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).