### PR TITLE
fix: remove double `.` in apptainer image cache entry lock files.

### DIFF
--- a/crates/wdl-engine/src/backend/apptainer.rs
+++ b/crates/wdl-engine/src/backend/apptainer.rs
@@ -327,7 +327,7 @@ impl ApptainerRuntime {
             path.add_extension("sif");
 
             // Take an exclusive lock to prevent another process from also attempting a pull for this cache entry
-            let _lock = LockedFile::acquire_exclusive(path.with_extension(LOCK_FILE_NAME)).await?;
+            let _lock = LockedFile::acquire_exclusive(path.with_extension("lock")).await?;
 
             // If the image already exists, then a previous pull was successful
             if path.exists() {


### PR DESCRIPTION
The call to `with_extension` was passed a string with a `.` prefix, which functions as the global lock file name for the cache.

The entry's `with_extension` call should just use "lock" to prevent the lock file path from having `..lock` in it.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
