### PR TITLE
chore: update `cloud-copy` to `0.10.1`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+* Updated `cloud-copy` dependency to 0.10.1 to pick up an important fix for
+  downloading files from Azure Blob Storage ([#1155](https://github.com/stjude-rust-labs/sprocket/pull/1155)).
+
 ## 0.30.0 - 2026-08-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,9 +768,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cloud-copy"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8047a634e8f01272014ac0e8dcee248339b3f96ac4bb2334f44d6d5160bda9fd"
+checksum = "675f585630ec6de3fe672b87964bbe535d732977bbc19c8b07c8d520cfdec262"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ chrono = "0.4.43"
 clap = { version = "4.5.57", features = ["derive", "string"] }
 clap-verbosity-flag = { version = "3.0.4", features = ["tracing"] }
 clap_complete = "4.5.65"
-cloud-copy = { version = "0.10.0", features = ["cli"] }
+cloud-copy = { version = "0.10.1", features = ["cli"] }
 codespan-reporting = "0.13.1"
 colored = "3.1.1"
 convert_case = "0.11.0"


### PR DESCRIPTION
This picks up an important fix for downloading files from Azure Blob Storage.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [x] You have updated any and all effected entries within `RULES.md`.
- [x] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
