### PR TITLE
fix: validate map literals against struct members

### DIFF
--- a/crates/gauntlet/Gauntlet.toml
+++ b/crates/gauntlet/Gauntlet.toml
@@ -2304,26 +2304,6 @@ permalink = "https://github.com/broadinstitute/palantir-workflows/blob/636e05e0a
 
 [[diagnostics]]
 document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
-message = "FunctionalEquivalence.wdl:63:190: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/636e05e0ab00515124f9ff74f3566f4f2ea0537f/FunctionalEquivalence/FunctionalEquivalence.wdl/#L63"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
-message = "FunctionalEquivalence.wdl:63:32: error: type mismatch: expected an instance of struct `VcfFile`, but found type `Map[String, String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/636e05e0ab00515124f9ff74f3566f4f2ea0537f/FunctionalEquivalence/FunctionalEquivalence.wdl/#L63"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
-message = "FunctionalEquivalence.wdl:67:190: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/636e05e0ab00515124f9ff74f3566f4f2ea0537f/FunctionalEquivalence/FunctionalEquivalence.wdl/#L67"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
-message = "FunctionalEquivalence.wdl:67:32: error: type mismatch: expected an instance of struct `VcfFile`, but found type `Map[String, String]`"
-permalink = "https://github.com/broadinstitute/palantir-workflows/blob/636e05e0ab00515124f9ff74f3566f4f2ea0537f/FunctionalEquivalence/FunctionalEquivalence.wdl/#L67"
-
-[[diagnostics]]
-document = "broadinstitute/palantir-workflows:/FunctionalEquivalence/FunctionalEquivalence.wdl"
 message = "FunctionalEquivalence.wdl:95:64: error: type mismatch: a type common to both type `String` and type `Int` does not exist"
 permalink = "https://github.com/broadinstitute/palantir-workflows/blob/636e05e0ab00515124f9ff74f3566f4f2ea0537f/FunctionalEquivalence/FunctionalEquivalence.wdl/#L95"
 

--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* Map-to-struct assignments may now omit optional struct members
+  ([#1156](https://github.com/stjude-rust-labs/sprocket/issues/1156)).
+
 ## 0.25.0 - 2026-08-26
 
 #### Added

--- a/crates/wdl-analysis/src/document/v1.rs
+++ b/crates/wdl-analysis/src/document/v1.rs
@@ -2956,9 +2956,19 @@ fn type_check_expr(
 ) {
     let mut context = EvaluationContext::new(document, scope, config.clone());
     let mut evaluator = ExprTypeEvaluator::new(&mut context);
-    let actual = evaluator.evaluate_expr(expr).unwrap_or(Type::Union);
 
-    if !matches!(expected, Type::Union) && !actual.is_coercible_to(expected) {
+    let (actual, coercible) = expected
+        .as_struct()
+        // NOTE: there is a special case where map literals can be coerced to
+        // structs if all of the keys therein map to fields within the struct.
+        .and_then(|target| evaluator.evaluate_map_expr_as_struct(expr, target))
+        .unwrap_or_else(|| {
+            let actual = evaluator.evaluate_expr(expr).unwrap_or(Type::Union);
+            let coercible = actual.is_coercible_to(expected);
+            (actual, coercible)
+        });
+
+    if !matches!(expected, Type::Union) && !coercible {
         document.analysis_diagnostics.add(type_mismatch(
             expected,
             expected_span,

--- a/crates/wdl-analysis/src/types/v1.rs
+++ b/crates/wdl-analysis/src/types/v1.rs
@@ -813,6 +813,97 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
         PairType::new(left, right).into()
     }
 
+    /// Evaluates a map expression in the context of a target struct.
+    pub(crate) fn evaluate_map_expr_as_struct<N: TreeNode + Exceptable>(
+        &mut self,
+        expr: &Expr<N>,
+        target: &StructType,
+    ) -> Option<(Type, bool)> {
+        match expr {
+            Expr::Literal(LiteralExpr::Map(map)) => {
+                self.evaluate_literal_map_as_struct(map, target)
+            }
+            Expr::Parenthesized(expr) => self.evaluate_map_expr_as_struct(&expr.expr(), target),
+            _ => None,
+        }
+    }
+
+    /// Evaluates a static-keyed map literal in the context of a target struct.
+    ///
+    /// Returns `None` when a key is not a static string, in which case ordinary
+    /// homogeneous map inference applies. Otherwise, the returned Boolean
+    /// indicates whether every entry matches its named member and every
+    /// required member is present.
+    fn evaluate_literal_map_as_struct<N: TreeNode + Exceptable>(
+        &mut self,
+        map: &LiteralMap<N>,
+        target: &StructType,
+    ) -> Option<(Type, bool)> {
+        if !map.items().all(|item| {
+            matches!(
+                item.key_value().0,
+                Expr::Literal(LiteralExpr::String(string)) if string.text().is_some()
+            )
+        }) {
+            return None;
+        }
+
+        let mut key = String::new();
+        let mut present = vec![false; target.members().len()];
+        let mut value_type: Option<Type> = None;
+        let mut values_have_common_type = true;
+        let mut valid = true;
+
+        for item in map.items() {
+            let (key_expr, value_expr) = item.key_value();
+            let Expr::Literal(LiteralExpr::String(string)) = key_expr else {
+                unreachable!("map keys were checked above");
+            };
+            let text = string.text().expect("map keys were checked above");
+            key.clear();
+            text.unescape_to(&mut key);
+
+            let actual = self.evaluate_expr(&value_expr).unwrap_or(Type::Union);
+            if values_have_common_type {
+                value_type = match value_type {
+                    Some(ref previous) => match previous.common_type(&actual) {
+                        Some(common) => Some(common),
+                        None => {
+                            values_have_common_type = false;
+                            Some(Type::Union)
+                        }
+                    },
+                    None => Some(actual.clone()),
+                };
+            }
+
+            match target.members().get_full(&key) {
+                Some((index, _, expected)) => {
+                    present[index] = true;
+                    valid &= actual.is_coercible_to(expected);
+                }
+                None => valid = false,
+            }
+        }
+
+        valid &= target
+            .members()
+            .iter()
+            .enumerate()
+            .all(|(index, (_, ty))| ty.is_optional() || present[index]);
+
+        let actual = MapType::new(
+            if value_type.is_some() {
+                Type::from(PrimitiveType::String)
+            } else {
+                Type::Union
+            },
+            value_type.unwrap_or(Type::Union),
+        )
+        .into();
+        Some((actual, valid))
+    }
+
     /// Evaluates the type of a literal map expression.
     fn evaluate_literal_map<N: TreeNode + Exceptable>(&mut self, expr: &LiteralMap<N>) -> Type {
         let map_item_type = |item: LiteralMapItem<N>| {

--- a/crates/wdl-analysis/tests/analysis/map-to-struct-optional-member/source.diagnostics
+++ b/crates/wdl-analysis/tests/analysis/map-to-struct-optional-member/source.diagnostics
@@ -1,0 +1,23 @@
+error: type mismatch: expected an instance of struct `Outer`, but found type `Map[String, Inner]`
+   ┌─ tests/analysis/map-to-struct-optional-member/source.wdl:18:21
+   │
+18 │     Outer invalid = {"inner": inner, "label": inner}
+   │           -------   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this is type `Map[String, Inner]`
+   │           │
+   │           this expects an instance of struct `Outer`
+
+error: type mismatch: expected an instance of struct `Outer`, but found type `Map[String, String]`
+   ┌─ tests/analysis/map-to-struct-optional-member/source.wdl:19:30
+   │
+19 │     Outer missing_required = {"label": "x"}
+   │           ----------------   ^^^^^^^^^^^^^^ this is type `Map[String, String]`
+   │           │
+   │           this expects an instance of struct `Outer`
+
+error: type mismatch: expected an instance of struct `Outer`, but found type `Map[Union, Union]`
+   ┌─ tests/analysis/map-to-struct-optional-member/source.wdl:20:19
+   │
+20 │     Outer empty = {}
+   │           -----   ^^ this is type `Map[Union, Union]`
+   │           │
+   │           this expects an instance of struct `Outer`

--- a/crates/wdl-analysis/tests/analysis/map-to-struct-optional-member/source.wdl
+++ b/crates/wdl-analysis/tests/analysis/map-to-struct-optional-member/source.wdl
@@ -1,0 +1,26 @@
+#@ except: UnusedDeclaration
+version 1.0
+
+struct Inner {
+    File? value
+    File? other
+}
+
+struct Outer {
+    Inner inner
+    String? label
+}
+
+workflow reproduce {
+    Inner inner = {"value": "example.txt"}
+    Outer outer = {"inner": inner}
+    Outer complete = {"inner": inner, "label": "x"}
+    Outer invalid = {"inner": inner, "label": inner}
+    Outer missing_required = {"label": "x"}
+    Outer empty = {}
+
+    output {
+        File? value = outer.inner.value
+        String? label = complete.label
+    }
+}


### PR DESCRIPTION
WDL 1.0 permits a map literal to omit optional struct members, but analysis compared the map's homogeneous value type with every member. This rejected valid assignments and could not distinguish omitted members from provided members.

I evaluated static-keyed map literals against the target struct member by member. The analysis now accepts omitted optional members while rejecting incompatible provided values and missing required members. It also handles valid heterogeneous member values without emitting a map common-type diagnostic.

Closes #1156.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.