### PR TITLE
chore: reformat with nightly rustfmt

### DIFF
--- a/benches/analysis/mod.rs
+++ b/benches/analysis/mod.rs
@@ -99,14 +99,15 @@ fn bench_analyze_workflows_document<M: Measurement>(
 /// Benchmarks of `wdl-analysis` functions.
 pub fn bench(c: &mut Criterion) {
     let workflows_repo = get_workflows_repo().unwrap();
-    // NOTE ACF 2025-12-03: these "analyze the whole repo" benchmarks are disabled
-    // for now, as the inclusion of `import https://` statements means the runtime is dominated by fetching those
+    // NOTE ACF 2025-12-03: these "analyze the whole repo" benchmarks are
+    // disabled for now, as the inclusion of `import https://` statements means the runtime is dominated by fetching those
     // resources. In the future, if these dependencies change or some caching
     // mechanism is introduced for remote imports, this would be a decent metric
     // for "analyze as much real WDL as possible".
     if false {
-        // Analyze the whole workflows repo with a varying number of Tokio worker
-        // threads and the system default number of blocking threads.
+        // Analyze the whole workflows repo with a varying number of Tokio
+        // worker threads and the system default number of blocking
+        // threads.
         let mut workers_group = c.benchmark_group("analyze_workflows_with_worker_threads");
         for worker_threads in 1..=std::thread::available_parallelism().unwrap().get() {
             let analyze = AnalyzeWorkflows::new(&workflows_repo, Some(worker_threads), None);
@@ -117,8 +118,8 @@ pub fn bench(c: &mut Criterion) {
         workers_group.finish();
     }
     if false {
-        // Analyze the whole workflows repo with a single worker thread and a varying
-        // number of Tokio blocking threads.
+        // Analyze the whole workflows repo with a single worker thread and a
+        // varying number of Tokio blocking threads.
         let mut blocking_group = c.benchmark_group("analyze_workflows_with_blocking_threads");
         for blocking_threads_exponent in 0..10 {
             let blocking_threads = 2usize.pow(blocking_threads_exponent);
@@ -136,9 +137,9 @@ pub fn bench(c: &mut Criterion) {
     // Add a bench target to analyze each WDL file in the workflows repo.
     //
     // This includes WDL files that directly or transitively `import https://` documents. The timing
-    // of these benchmarks should not be considered stable. The time to fetch remote
-    // resources dominates the overall benchmark time, and can vary dramatically
-    // based on whether they're run on wifi, with a VPN, etc.
+    // of these benchmarks should not be considered stable. The time to fetch
+    // remote resources dominates the overall benchmark time, and can vary
+    // dramatically based on whether they're run on wifi, with a VPN, etc.
     let mut standalone_documents = c.benchmark_group("analyze_standalone_documents");
     for entry in walkdir::WalkDir::new(workflows_repo.path()) {
         if let Ok(e) = entry

--- a/crates/gauntlet/src/lib.rs
+++ b/crates/gauntlet/src/lib.rs
@@ -288,7 +288,8 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                         .trim()
                         .to_string();
 
-                    // Normalize the diagnostic message to handle platform-specific differences
+                    // Normalize the diagnostic message to handle
+                    // platform-specific differences
                     let message = normalize_diagnostic(&message);
 
                     if !actual.insert((message.clone(), line_no)) {
@@ -300,14 +301,15 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                 }
             }
 
-            // As the list of diagnostics has been sorted by document identifier, do
-            // a binary search and collect the matching messages
+            // As the list of diagnostics has been sorted by document
+            // identifier, do a binary search and collect the
+            // matching messages
             let diagnostics = config.inner().diagnostics();
             let expected: IndexSet<String> = diagnostics
                 .binary_search_by_key(&document_identifier, |d| d.document().clone())
                 .map(|mut start_index| {
-                    // As binary search may return any matching index, back up until we find the
-                    // start of the range
+                    // As binary search may return any matching index, back up
+                    // until we find the start of the range
                     for i in (0..start_index).rev() {
                         if diagnostics[i].document() != &document_identifier {
                             break;
@@ -320,7 +322,8 @@ pub async fn gauntlet(args: Args) -> Result<()> {
                         .iter()
                         .map_while(|d| {
                             if d.document() == &document_identifier {
-                                // Normalize the diagnostic message from config to handle
+                                // Normalize the diagnostic message from config
+                                // to handle
                                 // platform-specific differences
                                 Some(normalize_diagnostic(d.message()))
                             } else {

--- a/crates/sprocket-py-macros/src/ast/enum_.rs
+++ b/crates/sprocket-py-macros/src/ast/enum_.rs
@@ -46,8 +46,8 @@ pub(super) fn build(original: &mut ItemEnum, args: Args) -> Result<TokenStream> 
 
     // We only need to modify the variants if some of them aren't unit variants.
     if !only_unit_variants {
-        // Strip generics from all variants, add "Py" prefix to all contained types,
-        // convert unit variants to empty tuple variants.
+        // Strip generics from all variants, add "Py" prefix to all contained
+        // types, convert unit variants to empty tuple variants.
         make_py_variants(&mut py_enum)?;
     }
 
@@ -181,17 +181,20 @@ fn make_py_variant_attrs(
                 let attr = &original_variant.attrs[i];
 
                 if attr.path().is_ident("pyo3") {
-                    // Move the `#[pyo3(...)]` attribute from the original to the Python enum.
+                    // Move the `#[pyo3(...)]` attribute from the original to
+                    // the Python enum.
                     py_variant.attrs.push(original_variant.attrs.remove(i));
                 } else if let Meta::List(ref meta_list) = attr.meta
                 && meta_list.path.is_ident("cfg_attr")
                 // Extract `pyo3(...)` from `#[cfg_attr(feature = "unstable-python", pyo3(...))]`.
                 && let Ok(meta) = parse_cfg_attr_tokens.parse2(meta_list.tokens.clone())
                 {
-                    // Remove the `#[cfg_attr(...)]` attribute from the original enum.
+                    // Remove the `#[cfg_attr(...)]` attribute from the original
+                    // enum.
                     original_variant.attrs.remove(i);
 
-                    // Push the extracted `#[pyo3(...)]` attribute to the Python enum.
+                    // Push the extracted `#[pyo3(...)]` attribute to the Python
+                    // enum.
                     py_variant.attrs.push(Attribute {
                         pound_token: <Token![#]>::default(),
                         style: AttrStyle::Outer,
@@ -289,8 +292,9 @@ fn make_py_variants(py_enum: &mut ItemEnum) -> Result<()> {
         let fields = match variant.fields {
             Fields::Unnamed(ref mut fields) => fields,
             Fields::Unit => {
-                // PyO3 doesn't support mixing tuple and unit variants in the same struct, so we
-                // convert unit variants to tuple variants.
+                // PyO3 doesn't support mixing tuple and unit variants in the
+                // same struct, so we convert unit variants to
+                // tuple variants.
                 variant.fields = Fields::Unnamed(FieldsUnnamed {
                     paren_token: Paren::default(),
                     unnamed: Punctuated::new(),

--- a/crates/sprocket-py-macros/src/ast/mod.rs
+++ b/crates/sprocket-py-macros/src/ast/mod.rs
@@ -124,8 +124,8 @@ mod tests {
 
         assert!(str_default_args.str_);
 
-        // This is supported by `#[pyclass]`, but is incompatible with `#[pyclass(name =
-        // ...)]` so we don't allow it.
+        // This is supported by `#[pyclass]`, but is incompatible with
+        // `#[pyclass(name = ...)]` so we don't allow it.
         let str_format_stream = quote!(str = "Hello, {name:?}!");
         let result = Args::parse(str_format_stream);
 

--- a/crates/sprocket-py-macros/src/ast_methods.rs
+++ b/crates/sprocket-py-macros/src/ast_methods.rs
@@ -69,7 +69,8 @@ pub(crate) fn ast_methods(
     // Remove the first generic (`impl<N: TreeNode> Ast<N>` into `impl Ast<N>`).
     py_impl.generics = Generics::default();
 
-    // Remove second generic and add "Py" prefix (`impl Ast<N>` into `impl PyAst`).
+    // Remove second generic and add "Py" prefix (`impl Ast<N>` into `impl
+    // PyAst`).
     let original_type_path = make_py_self_ty(&mut py_impl.self_ty)?;
 
     // Create the Python methods from the original methods.
@@ -238,9 +239,10 @@ fn remove_skip_attributes(attrs: &mut Vec<Attribute>) -> bool {
         Ok(())
     }
 
-    // Iterator that removes `#[skip]` and `#[cfg_attr(feature = "unstable-python",
-    // skip)]` from the list of attributes. This iterator must be fully consumed
-    // or not all `#[skip]` attributes will be removed.
+    // Iterator that removes `#[skip]` and `#[cfg_attr(feature =
+    // "unstable-python", skip)]` from the list of attributes. This iterator
+    // must be fully consumed or not all `#[skip]` attributes will be
+    // removed.
     let mut skip_attrs = attrs.extract_if(.., |attr| {
         // Check for `#[skip]`.
         if let Meta::Path(ref path) = attr.meta
@@ -295,8 +297,8 @@ fn make_py_method(
     let mut impl_iterator = false;
 
     if let ReturnType::Type(_, ref mut type_) = py_fn.sig.output {
-        // If the return type is `impl Iterator<...>`, mark this method as a special
-        // case.
+        // If the return type is `impl Iterator<...>`, mark this method as a
+        // special case.
         if is_impl_iterator(type_)? {
             impl_iterator = true;
         } else {
@@ -373,17 +375,18 @@ fn is_impl_iterator(type_: &Type) -> Result<bool> {
 
 /// Replaces all instances of `Self` with `original_ident` in a type.
 fn replace_self_with_original_type_path(type_: &mut Type, original_type_path: &Path) -> Result<()> {
-    // Replaces `Self` with `original_type_path` for all path segments and generic
-    // parameters.
+    // Replaces `Self` with `original_type_path` for all path segments and
+    // generic parameters.
     fn process_path(path: &mut Path, original_type_path: &Path) -> Result<()> {
         // `Self` must be the first segment, so we don't need to check any later
         // segments. <https://doc.rust-lang.org/reference/paths.html#r-paths.qualifiers.type-self.allowed-positions>
         if let Some(first) = path.segments.first()
             && first.ident == "Self"
         {
-            // Actually replace `Self`. If `original_type_path` is `::foo::Bar` and the
-            // current type path is `Self::baz::qux`, we perform the replacement by cloning
-            // `::foo::Bar` and then appending `baz::qux`. The final result is
+            // Actually replace `Self`. If `original_type_path` is `::foo::Bar`
+            // and the current type path is `Self::baz::qux`, we
+            // perform the replacement by cloning `::foo::Bar` and
+            // then appending `baz::qux`. The final result is
             // `::foo::Bar::baz::qux`.
             let mut new_path = original_type_path.clone();
 
@@ -442,8 +445,9 @@ fn replace_self_with_original_type_path(type_: &mut Type, original_type_path: &P
             | Type::TraitObject(TypeTraitObject { bounds, .. }) => {
                 for bound in bounds.iter_mut() {
                     if let TypeParamBound::Trait(trait_bound) = bound {
-                        // The trait itself cannot be `Self`, but `Self` may be in its generic
-                        // parameters, so we process the path anyways.
+                        // The trait itself cannot be `Self`, but `Self` may be
+                        // in its generic parameters, so
+                        // we process the path anyways.
                         process_path(&mut trait_bound.path, original_type_path)?;
                     }
                 }
@@ -499,8 +503,8 @@ fn strip_path_generic(type_: &mut Type, generic_ident: &Ident) -> Result<()> {
         Type::Path(type_path) => {
             for segments in &mut type_path.path.segments {
                 if let PathArguments::AngleBracketed(ref mut path_arguments) = segments.arguments {
-                    // Generics with default types must be last, so we start looking for them at
-                    // the end.
+                    // Generics with default types must be last, so we start
+                    // looking for them at the end.
                     for i in (0..path_arguments.args.len()).rev() {
                         if let GenericArgument::Type(ref type_) = path_arguments.args[i]
                             && let Type::Path(TypePath {
@@ -511,7 +515,8 @@ fn strip_path_generic(type_: &mut Type, generic_ident: &Ident) -> Result<()> {
                         {
                             path_arguments.args.pop();
                         } else {
-                            // If the last argument isn't what we're looking for, it may not be a
+                            // If the last argument isn't what we're looking
+                            // for, it may not be a
                             // generic with a default type. Exit out.
                             break;
                         }
@@ -523,7 +528,8 @@ fn strip_path_generic(type_: &mut Type, generic_ident: &Ident) -> Result<()> {
                         }
                     }
 
-                    // If we ended up removing all arguments, convert `AngleBracketed` into `None`.
+                    // If we ended up removing all arguments, convert
+                    // `AngleBracketed` into `None`.
                     if path_arguments.args.is_empty() {
                         segments.arguments = PathArguments::None;
                     }
@@ -688,8 +694,8 @@ fn make_py_method_body_impl_iterator(
     let method_ident = &py_fn.sig.ident;
     // Convert function inputs into function arguments. (Ex. turn `a: usize, b:
     // String` into `a, b`.) This is purposefully called before we add `py:
-    // Python<'py>` to the function input, as the Python marker token is not passed
-    // to the original method.
+    // Python<'py>` to the function input, as the Python marker token is not
+    // passed to the original method.
     let method_args = fn_inputs_to_args(&py_fn.sig.inputs)?;
 
     // Add `'py` lifetime.
@@ -1297,8 +1303,8 @@ mod tests {
 
     #[test]
     fn replace_self_long_original_type() {
-        // Testing when the original type path has more than one segment and generic
-        // parameters.
+        // Testing when the original type path has more than one segment and
+        // generic parameters.
         let original_type_path = parse_quote!(foo::Bar<String>);
         let mut type_ = parse_quote!(Self::baz);
 
@@ -1313,8 +1319,8 @@ mod tests {
     fn strip_path_generic() {
         let generic_ident = Ident::new("N", Span::call_site());
 
-        // The first item in each tuple will be fed into `strip_path_generic()`, and the
-        // result will be compared with the second item.
+        // The first item in each tuple will be fed into `strip_path_generic()`,
+        // and the result will be compared with the second item.
         let test_cases: [(Type, Type); _] = [
             // Paths
             (parse_quote!(Ast), parse_quote!(Ast)),

--- a/crates/sprocket-test-types/src/lib.rs
+++ b/crates/sprocket-test-types/src/lib.rs
@@ -28,8 +28,8 @@ use crate::yaml::spanned_fields;
 
 /// Convert a [`serde_saphyr::Span`] to our [`Span`] type.
 pub(crate) fn convert_yaml_span(span: serde_saphyr::Span) -> Span {
-    // SAFETY: `serde-saphyr` guarantees that byte-level information is available
-    //         when parsing from a string, which we always do.
+    // SAFETY: `serde-saphyr` guarantees that byte-level information is
+    // available         when parsing from a string, which we always do.
     Span::new(
         span.byte_offset().expect("byte info should be available") as usize,
         span.byte_len().expect("byte info should be available") as usize,
@@ -89,7 +89,8 @@ impl DocumentTests {
         let raw: RawDocumentTests = match serde_saphyr::from_str(source) {
             Ok(map) => map,
             Err(_e) => {
-                // TODO(serial): create nice diagnostics from serde-saphyr errors
+                // TODO(serial): create nice diagnostics from serde-saphyr
+                // errors
                 diagnostics.add(Diagnostic::error(
                     "expected test document to be a YAML mapping from target names to test \
                      definitions",

--- a/crates/wdl-analysis/src/analyzer.rs
+++ b/crates/wdl-analysis/src/analyzer.rs
@@ -594,8 +594,8 @@ where
         // walk at nested module boundaries: a subdirectory with its own
         // `module.json` is a separate (local-path dependency) module whose WDL
         // files reach the analyzer through symbolic-import materialization, not
-        // directory scanning. Outside an active module there is nothing to scope
-        // to, so scan everything.
+        // directory scanning. Outside an active module there is nothing to
+        // scope to, so scan everything.
         let stop_at_module_boundaries = self
             .resolution
             .module_root()
@@ -1431,8 +1431,8 @@ workflow something_else {
         let uri = path_to_uri(&path).expect("should convert to URI");
         analyzer.notify_change(uri.clone(), false).unwrap();
 
-        // Analyze again and ensure the analysis result id is changed and the issue
-        // fixed
+        // Analyze again and ensure the analysis result id is changed and the
+        // issue fixed
         let id = results[0].document.id().clone();
         let results = analyzer.analyze(()).await.unwrap();
         assert_eq!(results.len(), 1);
@@ -1506,8 +1506,8 @@ workflow test {
             )
             .unwrap();
 
-        // Analyze again and ensure the analysis result id is changed and the issue was
-        // fixed
+        // Analyze again and ensure the analysis result id is changed and the
+        // issue was fixed
         let id = results[0].document.id().clone();
         let results = analyzer.analyze_document((), uri).await.unwrap();
         assert_eq!(results.len(), 1);
@@ -1949,8 +1949,8 @@ workflow test {}
 
         // Now delete bar.wdl, which foo.wdl depends on.
         //
-        // Unlike removal, this should *force* the deletion of bar.wdl in the graph (and
-        // thus cause errors in foo.wdl)
+        // Unlike removal, this should *force* the deletion of bar.wdl in the
+        // graph (and thus cause errors in foo.wdl)
         fs::remove_file(&bar).expect("should delete file");
         analyzer
             .delete_documents(vec![path_to_uri(&bar).expect("should convert to URI")])

--- a/crates/wdl-analysis/src/diagnostics.rs
+++ b/crates/wdl-analysis/src/diagnostics.rs
@@ -441,9 +441,9 @@ pub fn recursive_struct(name: &str, span: Span, member: Span) -> Diagnostic {
 
 /// Creates a "recursive enum" diagnostic.
 pub fn recursive_enum(name: &str, span: Span, ty: &str) -> Diagnostic {
-    // Unlike `recursive_struct`, which labels individual members, an `enum` has a
-    // single type for all of its choices. Just highlight the `enum` name, as
-    // its type as a *whole* is recursive.
+    // Unlike `recursive_struct`, which labels individual members, an `enum` has
+    // a single type for all of its choices. Just highlight the `enum` name,
+    // as its type as a *whole* is recursive.
     Diagnostic::error(format!("enum `{name}` has a recursive definition"))
         .with_highlight(span)
         .with_help(format!("the type `{ty}` participates in the recursion"))

--- a/crates/wdl-analysis/src/document.rs
+++ b/crates/wdl-analysis/src/document.rs
@@ -459,7 +459,8 @@ impl<'a> ScopeUnion<'a> {
                     continue;
                 }
 
-                // If this name is not in the current clause's scope, mark as optional
+                // If this name is not in the current clause's scope, mark as
+                // optional
                 if scope_ref.local(name).is_none() {
                     info.ty = info.ty.optional();
                 }
@@ -937,8 +938,9 @@ impl Document {
                 *wdl_version,
             ),
             _ => {
-                // Don't process a document with a missing version statement or an unsupported
-                // version unless a fallback version is configured
+                // Don't process a document with a missing version statement or
+                // an unsupported version unless a fallback
+                // version is configured
                 return Self {
                     data: Arc::new(DocumentData::new(
                         config.clone(),
@@ -1211,7 +1213,8 @@ impl Document {
             let mut index = match scopes.binary_search_by_key(&position, |s| s.span.start()) {
                 Ok(index) => index,
                 Err(index) => {
-                    // This indicates that we couldn't find a match and the match would go _before_
+                    // This indicates that we couldn't find a match and the
+                    // match would go _before_
                     // the first scope, so there is no containing scope.
                     if index == 0 {
                         return None;
@@ -1222,7 +1225,8 @@ impl Document {
             };
 
             // We now have the index to start looking up the list of scopes
-            // We walk up the list to try to find a span that contains the position
+            // We walk up the list to try to find a span that contains the
+            // position
             loop {
                 let scope = &scopes[index];
                 if scope.span.contains(position) {
@@ -1252,8 +1256,9 @@ impl Document {
         {
             Ok(index) => &self.data.tasks[index],
             Err(index) => {
-                // This indicates that we couldn't find a match and the match would go _before_
-                // the first task, so there is no containing task.
+                // This indicates that we couldn't find a match and the match
+                // would go _before_ the first task, so there is
+                // no containing task.
                 if index == 0 {
                     return None;
                 }

--- a/crates/wdl-analysis/src/document/v1.rs
+++ b/crates/wdl-analysis/src/document/v1.rs
@@ -153,8 +153,8 @@ fn add_scope(scopes: &mut Vec<Scope>, scope: Scope) -> ScopeIndex {
 ///
 /// This handles remapping any parent indexes in each scope.
 fn sort_scopes(scopes: &mut Vec<Scope>) {
-    // To sort the scopes, we need to start by mapping the old indexes to scope span
-    // start
+    // To sort the scopes, we need to start by mapping the old indexes to scope
+    // span start
     let mut remapped = scopes
         .iter()
         .enumerate()
@@ -207,9 +207,10 @@ pub(crate) fn populate_document(
             .flatten(),
     );
 
-    // First start by processing imports, struct definitions, and enum definitions
-    // This needs to be performed before processing tasks and workflows as
-    // declarations might reference an imported or locally-defined struct or enum
+    // First start by processing imports, struct definitions, and enum
+    // definitions This needs to be performed before processing tasks and
+    // workflows as declarations might reference an imported or
+    // locally-defined struct or enum
     let mut import_nodes_by_namespace = HashMap::new();
     for item in ast.items() {
         match item {
@@ -251,8 +252,9 @@ pub(crate) fn populate_document(
                 add_task(config, document, &task);
             }
             DocumentItem::Workflow(w) => {
-                // Note that this doesn't populate the workflow; we delay that until after
-                // we've seen every task in the document so that we can resolve call targets
+                // Note that this doesn't populate the workflow; we delay that
+                // until after we've seen every task in the
+                // document so that we can resolve call targets
                 if add_workflow(document, &w) {
                     workflow = Some(w.clone());
                 }
@@ -337,8 +339,9 @@ fn add_namespace(
             }
         }
         None => {
-            // Invalid import namespaces are caught during validation, so there is already a
-            // diagnostic for this issue; ignore the import here
+            // Invalid import namespaces are caught during validation, so there
+            // is already a diagnostic for this issue; ignore the
+            // import here
             return false;
         }
     };
@@ -1404,8 +1407,9 @@ fn add_task(config: &Config, document: &mut DocumentData, definition: &TaskDefin
                 if let Some(severity) = config.diagnostics_config().unused_input
                     && decl.env().is_none()
                 {
-                    // For any input that isn't an environment variable, check to see if there's
-                    // a single implicit dependency edge; if so, it might be unused
+                    // For any input that isn't an environment variable, check
+                    // to see if there's a single implicit
+                    // dependency edge; if so, it might be unused
                     let mut edges = graph.edges_directed(index, Direction::Outgoing);
 
                     if edges.all(|e| *e.weight()) {
@@ -1451,7 +1455,8 @@ fn add_task(config: &Config, document: &mut DocumentData, definition: &TaskDefin
 
                 let name = decl.name();
 
-                // Don't warn for environment variables as they are always implicitly used
+                // Don't warn for environment variables as they are always
+                // implicitly used
                 if decl.env().is_none()
                     && graph
                         .edges_directed(index, Direction::Outgoing)
@@ -1553,7 +1558,8 @@ fn add_task(config: &Config, document: &mut DocumentData, definition: &TaskDefin
                     )
                 });
 
-                // Perform type checking on the requirements section's expressions
+                // Perform type checking on the requirements section's
+                // expressions
                 let mut context = EvaluationContext::new(
                     document,
                     ScopeRef::new(&task.scopes, scope_index),
@@ -1643,7 +1649,8 @@ fn add_workflow(document: &mut DocumentData, workflow: &WorkflowDefinition) -> b
         return false;
     }
 
-    // An imported workflow already occupies local scope; reject this definition.
+    // An imported workflow already occupies local scope; reject this
+    // definition.
     if let Some(imported) = document.imported_workflows.values().next() {
         document.analysis_diagnostics.add(workflow_conflict(
             name.text(),
@@ -1675,9 +1682,9 @@ fn add_workflow(document: &mut DocumentData, workflow: &WorkflowDefinition) -> b
         return false;
     }
 
-    // Note: we delay populating the workflow until later on so that we can populate
-    // all tasks in the document first; it is done this way so we can resolve local
-    // task call targets.
+    // Note: we delay populating the workflow until later on so that we can
+    // populate all tasks in the document first; it is done this way so we
+    // can resolve local task call targets.
 
     document.workflow = Some(Workflow {
         name_span: name.span(),
@@ -1708,8 +1715,8 @@ fn populate_workflow(config: &Config, document: &mut DocumentData, workflow: &Wo
         None => Default::default(),
     };
 
-    // Keep a map of scopes from syntax node that introduced the scope to the scope
-    // index
+    // Keep a map of scopes from syntax node that introduced the scope to the
+    // scope index
     let mut scope_indexes: HashMap<SyntaxNode, ScopeIndex> = HashMap::new();
     let mut scopes = vec![Scope::new(
         None,
@@ -1719,8 +1726,8 @@ fn populate_workflow(config: &Config, document: &mut DocumentData, workflow: &Wo
     )];
     let mut output_scope = None;
 
-    // For static analysis, we don't need to provide inputs to the workflow graph
-    // builder
+    // For static analysis, we don't need to provide inputs to the workflow
+    // graph builder
     let graph = WorkflowGraphBuilder::default().build(
         workflow,
         &mut document.analysis_diagnostics,
@@ -1826,8 +1833,9 @@ fn populate_workflow(config: &Config, document: &mut DocumentData, workflow: &Wo
                 );
             }
             WorkflowGraphNode::ConditionalClause(..) => {
-                // Conditional clause nodes are intermediate nodes used for subgraph splitting
-                // during evaluation. They don't need to be processed here as the
+                // Conditional clause nodes are intermediate nodes used for
+                // subgraph splitting during evaluation. They
+                // don't need to be processed here as the
                 // conditional node already handles all clauses.
                 continue;
             }
@@ -1923,9 +1931,11 @@ fn populate_workflow(config: &Config, document: &mut DocumentData, workflow: &Wo
                     .expect("should have scope");
                 let variable = statement.variable();
 
-                // We need to split the scopes as we want to read from one part of the slice and
-                // write to another; the left side will contain the parent at its index and the
-                // right side will contain the child scope at its index minus the parent's
+                // We need to split the scopes as we want to read from one part
+                // of the slice and write to another; the left
+                // side will contain the parent at its index and the
+                // right side will contain the child scope at its index minus
+                // the parent's
                 let parent = scopes[scope_index.0]
                     .parent
                     .expect("should have a parent scope");
@@ -2528,8 +2538,8 @@ fn populate_types(document: &mut DocumentData) {
         }
     }
 
-    // Populate a type dependency graph; any edges that would form cycles are turned
-    // into diagnostics.
+    // Populate a type dependency graph; any edges that would form cycles are
+    // turned into diagnostics.
     let mut graph: DiGraphMap<_, _, RandomState> = DiGraphMap::new();
     let mut space = Default::default();
 
@@ -2608,8 +2618,8 @@ fn populate_types(document: &mut DocumentData) {
         }
     }
 
-    // At this point the graph is guaranteed acyclic; now calculate the struct and
-    // enum types in topological order
+    // At this point the graph is guaranteed acyclic; now calculate the struct
+    // and enum types in topological order
     for index in toposort(&graph, Some(&mut space)).expect("graph should be acyclic") {
         match index {
             TypeIndex::Struct(index) => {
@@ -2859,7 +2869,8 @@ impl crate::types::v1::EvaluationContext for EvaluationContext<'_> {
             return Some(var);
         }
 
-        // If the name is a reference to a struct, return it as a [`Type::TypeNameRef`].
+        // If the name is a reference to a struct, return it as a
+        // [`Type::TypeNameRef`].
         if let Some(s) = self.document.structs.get(name).and_then(|s| s.ty()) {
             return Some(
                 TypeNameRef::new(
@@ -2873,7 +2884,8 @@ impl crate::types::v1::EvaluationContext for EvaluationContext<'_> {
             );
         }
 
-        // If the name is a reference to an enum, return it as a [`Type::TypeNameRef`].
+        // If the name is a reference to an enum, return it as a
+        // [`Type::TypeNameRef`].
         if let Some(e) = self.document.enums.get(name).and_then(|e| e.ty()) {
             return Some(
                 TypeNameRef::new(
@@ -3007,10 +3019,10 @@ mod tests {
         //   String always_available = "baz"
         // }
         //
-        // Both `a` and `b` can be `None` or unevaluated, so they both promote as a
-        // `String?`. `c` is missing from the first scope, so it must also be
-        // marked as `String?`. `always_available` is always available, so it
-        // will be promoted as a `String`.
+        // Both `a` and `b` can be `None` or unevaluated, so they both promote
+        // as a `String?`. `c` is missing from the first scope, so it
+        // must also be marked as `String?`. `always_available` is
+        // always available, so it will be promoted as a `String`.
         vec![
             example_scope(vec![
                 ("a", Type::Primitive(PrimitiveType::String, false)),
@@ -3070,7 +3082,8 @@ mod tests {
             Type::Primitive(PrimitiveType::String, true)
         );
 
-        // `always_available` is in all clauses with the same type, so it's non-optional
+        // `always_available` is in all clauses with the same type, so it's
+        // non-optional
         assert_eq!(
             results["always_available"].ty,
             Type::Primitive(PrimitiveType::String, false)
@@ -3086,8 +3099,8 @@ mod tests {
         //   String bad = "baz"
         // }
         //
-        // `bad` will return an error, as there is no common type between a `String`
-        // and an `Int`.
+        // `bad` will return an error, as there is no common type between a
+        // `String` and an `Int`.
         let bad_scopes = vec![
             example_scope(vec![(
                 "bad",

--- a/crates/wdl-analysis/src/eval/v1.rs
+++ b/crates/wdl-analysis/src/eval/v1.rs
@@ -236,8 +236,8 @@ impl<N: TreeNode> TaskGraphBuilder<N> {
                 graph.update_edge(hints, command, true);
             }
 
-            // The command section depends on any input or environment variable declaration
-            // All outputs depend on the command
+            // The command section depends on any input or environment variable
+            // declaration All outputs depend on the command
             for index in self.names.values() {
                 match &graph[*index] {
                     TaskGraphNode::Input(_) => {
@@ -355,7 +355,8 @@ impl<N: TreeNode> TaskGraphBuilder<N> {
                     }
                 }
                 TaskGraphNode::Command(section) => {
-                    // Add name references from the command section to any decls in scope
+                    // Add name references from the command section to any decls
+                    // in scope
                     let section = section.clone();
                     for part in section.parts() {
                         if let CommandPart::Placeholder(p) = part {
@@ -371,7 +372,8 @@ impl<N: TreeNode> TaskGraphBuilder<N> {
                     }
                 }
                 TaskGraphNode::Runtime(section) => {
-                    // Add name references from the runtime section to any decls in scope
+                    // Add name references from the runtime section to any decls
+                    // in scope
                     let section = section.clone();
                     for item in section.items() {
                         self.add_section_edges(
@@ -385,7 +387,8 @@ impl<N: TreeNode> TaskGraphBuilder<N> {
                     }
                 }
                 TaskGraphNode::Requirements(section) => {
-                    // Add name references from the requirements section to any decls in scope
+                    // Add name references from the requirements section to any
+                    // decls in scope
                     let section = section.clone();
                     for item in section.items() {
                         self.add_section_edges(
@@ -399,7 +402,8 @@ impl<N: TreeNode> TaskGraphBuilder<N> {
                     }
                 }
                 TaskGraphNode::Hints(section) => {
-                    // Add name references from the hints section to any decls in scope
+                    // Add name references from the hints section to any decls
+                    // in scope
                     let section = section.clone();
                     for item in section.items() {
                         self.add_section_edges(
@@ -785,7 +789,8 @@ impl<N: TreeNode> WorkflowGraphBuilder<N> {
                 self.entry_exits
                     .insert(statement.inner().clone(), (entry, exit));
 
-                // Push the scatter variable onto the stack if it isn't already conflicting
+                // Push the scatter variable onto the stack if it isn't already
+                // conflicting
                 let variable = statement.variable();
                 let pushed = match self.names.get(variable.text()) {
                     Some(existing) => {
@@ -848,8 +853,8 @@ impl<N: TreeNode> WorkflowGraphBuilder<N> {
                 .map(|i| (i, i)),
         };
 
-        // Add (reverse) dependency edges to parent entry from child entry and to child
-        // exit from parent exit
+        // Add (reverse) dependency edges to parent entry from child entry and
+        // to child exit from parent exit
         if let (Some((entry, exit)), Some((parent_entry, parent_exit))) =
             (entry_exit, parent_entry_exit)
         {
@@ -866,8 +871,8 @@ impl<N: TreeNode> WorkflowGraphBuilder<N> {
         graph: &mut DiGraph<WorkflowGraphNode<N>, ()>,
         diagnostics: &mut Diagnostics,
     ) -> Option<NodeIndex> {
-        // Check for a conflicting name, either from a declaration or from a scatter
-        // variable
+        // Check for a conflicting name, either from a declaration or from a
+        // scatter variable
         let (context, cont) = match self.names.get(name.text()) {
             Some(existing) => {
                 let mut conflicting_context = None;
@@ -904,7 +909,8 @@ impl<N: TreeNode> WorkflowGraphBuilder<N> {
             _ => {
                 match self.variables.iter().find(|i| i.text() == name.text()) {
                     Some(existing) => {
-                        // Conflict with a scatter variable; we continue to add the node so that any
+                        // Conflict with a scatter variable; we continue to add
+                        // the node so that any
                         // declaration overrides the scatter variable
                         (Some(NameContext::ScatterVariable(existing.span())), true)
                     }
@@ -954,7 +960,8 @@ impl<N: TreeNode> WorkflowGraphBuilder<N> {
         for from in graph.node_indices().skip(skip.unwrap_or(0)) {
             match graph[from].clone() {
                 WorkflowGraphNode::Input(decl) => {
-                    // Only add edges for default expressions if the input wasn't provided
+                    // Only add edges for default expressions if the input
+                    // wasn't provided
                     if !input_present(decl.name().text())
                         && let Some(expr) = decl.expr()
                     {
@@ -988,7 +995,8 @@ impl<N: TreeNode> WorkflowGraphBuilder<N> {
                 }
                 WorkflowGraphNode::Call(statement) => {
                     // Add edges for the input expressions
-                    // If an input does not have an expression, add an edge to the name
+                    // If an input does not have an expression, add an edge to
+                    // the name
                     for input in statement.inputs() {
                         let name = input.name();
                         match input.expr() {
@@ -1113,7 +1121,8 @@ impl<N: TreeNode> WorkflowGraphBuilder<N> {
                     }
                 }
                 _ => {
-                    // Check if name points to a custom type(a struct or an enum).
+                    // Check if name points to a custom type(a struct or an
+                    // enum).
                     if !custom_type_present(name.text()) {
                         diagnostics.add(unknown_name(name.text(), name.span()));
                     }
@@ -1168,7 +1177,8 @@ impl<N: TreeNode> WorkflowGraphBuilder<N> {
 
         if from == to {
             // No need to add an edge when the entry and exit are the same node
-            // This can occur for scatter variables referenced within the scatter body
+            // This can occur for scatter variables referenced within the
+            // scatter body
             return;
         }
 
@@ -1184,10 +1194,10 @@ impl<N: TreeNode> WorkflowGraphBuilder<N> {
         name: &str,
         expr: N,
     ) -> Option<SmallVec<[NodeIndex; SMALLVEC_DECLS_LEN]>> {
-        // We need to walk up the parent chain looking for a scatter variable with a
-        // matching name before looking at names in scope; a scatter variable may shadow
-        // names declared outside of it, but an inner declaration cannot shadow an outer
-        // scatter variable
+        // We need to walk up the parent chain looking for a scatter variable
+        // with a matching name before looking at names in scope; a
+        // scatter variable may shadow names declared outside of it, but
+        // an inner declaration cannot shadow an outer scatter variable
         let mut current = expr;
         while let Some(parent) = current.parent() {
             if let SyntaxKind::ScatterStatementNode = parent.kind() {
@@ -1389,7 +1399,8 @@ mod test {
 
         assert!(graph.contains_edge(y_input, t2), "t2 should depend on y");
 
-        // Testing with providing input y i.e. runtime analysis - case for wdl_engine
+        // Testing with providing input y i.e. runtime analysis - case for
+        // wdl_engine
         let mut diagnostics = Diagnostics::default();
         let graph = WorkflowGraphBuilder::default().build(
             &workflow,

--- a/crates/wdl-analysis/src/graph.rs
+++ b/crates/wdl-analysis/src/graph.rs
@@ -358,7 +358,8 @@ impl DocumentGraphNode {
             return Ok(None);
         };
 
-        // The document has been edited; if there is start source, apply the edits to it
+        // The document has been edited; if there is start source, apply the
+        // edits to it
         let (mut source, mut lines) = if let Some(start) = &change.start {
             let source = start.clone();
             let lines = Arc::new(LineIndex::new(&source));
@@ -374,8 +375,8 @@ impl DocumentGraphNode {
             }
         };
 
-        // We keep track of the last line we've processed so we only rebuild the line
-        // index when there is a change that crosses a line
+        // We keep track of the last line we've processed so we only rebuild the
+        // line index when there is a change that crosses a line
         let mut last_line = !0u32;
         for edit in &change.edits {
             let range = edit.range();
@@ -406,12 +407,15 @@ impl DocumentGraphNode {
             Some(IncrementalChange { start: None, .. }) => {
                 // TODO: implement incremental parsing
                 // For each edit:
-                //   * determine if the edit is to a token; if so, replace it in the tree
-                //   * otherwise, find a reparsable ancestor for the covering element and ask it
-                //     to reparse; if one is found, reparse and replace the node
-                //   * if a reparsable node can't be found, return an error to trigger a full
-                //     reparse
-                //   * incrementally update the parse diagnostics depending on the result
+                //   * determine if the edit is to a token; if so, replace it in
+                //     the tree
+                //   * otherwise, find a reparsable ancestor for the covering
+                //     element and ask it to reparse; if one is found, reparse
+                //     and replace the node
+                //   * if a reparsable node can't be found, return an error to
+                //     trigger a full reparse
+                //   * incrementally update the parse diagnostics depending on
+                //     the result
                 None
             }
         }
@@ -454,9 +458,9 @@ impl DocumentGraphNode {
         let mut diagnostics = Diagnostics::default();
         diagnostics.extend(parse_diagnostics);
 
-        // Apply version fallback logic at this point, so that appropriate diagnostics
-        // will prevent subsequent analysis from occurring on an unexpected
-        // version
+        // Apply version fallback logic at this point, so that appropriate
+        // diagnostics will prevent subsequent analysis from occurring
+        // on an unexpected version
         let mut wdl_version = None;
         if let Some(version_statement) = document.version_statement() {
             let version_token = version_statement.version();
@@ -629,7 +633,8 @@ impl DocumentGraph {
             Err(_) => return,
         };
 
-        // As the URI might be a directory containing WDL files, look for prefixed files
+        // As the URI might be a directory containing WDL files, look for
+        // prefixed files
         let mut removed = Vec::new();
         for (uri, index) in &self.indexes {
             let path = match uri.to_file_path() {
@@ -645,8 +650,9 @@ impl DocumentGraph {
         for index in removed {
             let node = &mut self.inner[index];
 
-            // We don't actually remove nodes from the graph, just remove it as a root.
-            // If the node has no outgoing edges, it will be collected in the next GC.
+            // We don't actually remove nodes from the graph, just remove it as
+            // a root. If the node has no outgoing edges, it will be
+            // collected in the next GC.
             if !self.roots.swap_remove(&index) {
                 debug!(
                     "document `{uri}` is no longer rooted in the graph",
@@ -824,8 +830,8 @@ impl DocumentGraph {
 
     /// Removes all dependency edges from the given node.
     pub fn remove_dependency_edges(&mut self, index: NodeIndex) {
-        // Retain all edges where the target isn't the given node (i.e. an incoming
-        // edge)
+        // Retain all edges where the target isn't the given node (i.e. an
+        // incoming edge)
         self.inner.retain_edges(|g, e| {
             let (_, target) = g.edge_endpoints(e).expect("edge should be valid");
             target != index
@@ -842,8 +848,8 @@ impl DocumentGraph {
         kind: EdgeKind,
         space: &mut DfsSpace,
     ) {
-        // Check to see if there is already a path between the nodes; if so, there's a
-        // cycle
+        // Check to see if there is already a path between the nodes; if so,
+        // there's a cycle
         if has_path_connecting(&self.inner, from, to, Some(space)) {
             // Adding the edge would cause a cycle, so record the cycle instead
             debug!(
@@ -859,8 +865,8 @@ impl DocumentGraph {
                 to = self.inner[to].uri
             );
 
-            // Note that we store inverse dependency edges in the graph, so the relationship
-            // is reversed
+            // Note that we store inverse dependency edges in the graph, so the
+            // relationship is reversed
             self.inner.add_edge(to, from, kind);
         }
     }
@@ -998,8 +1004,8 @@ mod tests {
         let dep_uri = graph.get(dependency_index).uri().clone();
         graph.delete(&dep_uri);
 
-        // Deletion should retain the current source as a pending change and demote the
-        // dependent node to NotParsed
+        // Deletion should retain the current source as a pending change and
+        // demote the dependent node to NotParsed
         let dependent_graph_node = graph.get(dependent_index);
         assert!(matches!(
             dependent_graph_node.parse_state,

--- a/crates/wdl-analysis/src/handlers/completions.rs
+++ b/crates/wdl-analysis/src/handlers/completions.rs
@@ -136,9 +136,10 @@ pub fn completion(
             return Ok(items);
         }
 
-        // NOTE: Custom handling for version completion. If the token to the immediate
-        // left of the cursor (ignoring whitespace) is the `version` keyword, we are
-        // very likely completing the version number.
+        // NOTE: Custom handling for version completion. If the token to the
+        // immediate left of the cursor (ignoring whitespace) is the
+        // `version` keyword, we are very likely completing the version
+        // number.
         let mut non_trivia = token.clone();
         if non_trivia.kind().is_trivia()
             && let Some(prev) = non_trivia.prev_token()

--- a/crates/wdl-analysis/src/handlers/document_symbol.rs
+++ b/crates/wdl-analysis/src/handlers/document_symbol.rs
@@ -57,8 +57,8 @@ pub fn document_symbol(graph: &DocumentGraph, uri: &Url) -> Result<Option<Docume
         return Ok(None);
     };
 
-    // NOTE: the reason for using `Ast` here is we don't want to wait for analysis
-    // to complete and call `structs`, `tasks` and `workflow` on
+    // NOTE: the reason for using `Ast` here is we don't want to wait for
+    // analysis to complete and call `structs`, `tasks` and `workflow` on
     // `analysis::Document`. Doing so will break the outline while the user is
     // typing.
     for item in ast.items() {

--- a/crates/wdl-analysis/src/handlers/find_all_references.rs
+++ b/crates/wdl-analysis/src/handlers/find_all_references.rs
@@ -144,11 +144,11 @@ fn collect_references_from_document(
         //
         // - All members of a namespace must be unique within that namespace.
         // - When the user makes a declaration within a nested scope, they are
-        //   essentially reserving that name in all of the higher-level scopes so that
-        //   it cannot be reused.
+        //   essentially reserving that name in all of the higher-level scopes
+        //   so that it cannot be reused.
         //
-        // This means name matching combined with definition resolution is safe and
-        // won't produce false positives from shadowed variables.
+        // This means name matching combined with definition resolution is safe
+        // and won't produce false positives from shadowed variables.
         if token.kind() == SyntaxKind::Ident && token.text() == target.name {
             let token_pos = position(lines, token.text_range().start())
                 .context("failed to convert token position")?;

--- a/crates/wdl-analysis/src/handlers/goto_definition.rs
+++ b/crates/wdl-analysis/src/handlers/goto_definition.rs
@@ -113,8 +113,8 @@ pub fn goto_definition(
                     .find_map(v1::CallStatement::cast)
                 && call_stmt.alias().is_none()
             {
-                // NOTE: implicit alias found, resolving call target instead of the
-                // alias
+                // NOTE: implicit alias found, resolving call target instead of
+                // the alias
                 let target = call_stmt.target();
                 let callee_name = target.names().last().expect("call target must have a name");
                 return resolve_call_target(
@@ -282,8 +282,8 @@ fn resolve_type_reference(
         }
     }
 
-    // Fallback search in case the struct is not in the current document's analysis
-    // map
+    // Fallback search in case the struct is not in the current document's
+    // analysis map
     for (_, ns) in analysis_doc.namespaces() {
         let node = graph.get(graph.get_index(ns.source()).unwrap());
         let Some(imported_doc) = node.document() else {
@@ -472,9 +472,9 @@ fn resolve_global_identifier(
     }
 
     for (_, ns) in analysis_doc.namespaces() {
-        // SAFETY: we know `get_index` will return `Some` as `ns.source` comes from
-        // `analysis_doc.namespaces` which only contains namespaces for documents that
-        // are guaranteed to be present in the graph.
+        // SAFETY: we know `get_index` will return `Some` as `ns.source` comes
+        // from `analysis_doc.namespaces` which only contains namespaces
+        // for documents that are guaranteed to be present in the graph.
         let node = graph.get(graph.get_index(ns.source()).unwrap());
         let Some(imported_doc) = node.document() else {
             continue;
@@ -589,9 +589,9 @@ fn resolve_access_expression(
                 continue;
             };
 
-            // SAFETY: we know `lines` will return Some as we only reach here when
-            // `node.document` is fully parsed and in `ParsedState::Parse`
-            // state.
+            // SAFETY: we know `lines` will return Some as we only reach here
+            // when `node.document` is fully parsed and in
+            // `ParsedState::Parse` state.
             let imported_lines = node.parse_state().lines().unwrap();
 
             let struct_node =
@@ -954,12 +954,14 @@ fn resolve_call_input_item(
         return Ok(None);
     }
 
-    // For LHS identifier, resolve to the target task/workflow's input parameter.
+    // For LHS identifier, resolve to the target task/workflow's input
+    // parameter.
     let mut current = parent_node.parent();
 
     // Walk up the CST to find the containing `CallStatement`.
-    // This traversal is necessary because call input parameters are not part of the
-    // local scope - they refer to the called task/workflow's parameter definitions.
+    // This traversal is necessary because call input parameters are not part of
+    // the local scope - they refer to the called task/workflow's parameter
+    // definitions.
     while let Some(node) = current {
         if node.kind() == SyntaxKind::CallStatementNode {
             let Some(call_stmt) = wdl_ast::v1::CallStatement::cast(node) else {

--- a/crates/wdl-analysis/src/handlers/hover.rs
+++ b/crates/wdl-analysis/src/handlers/hover.rs
@@ -153,9 +153,9 @@ fn resolve_hover_content(
     }
 
     for (_, ns) in document.namespaces() {
-        // SAFETY: we know `get_index` will return `Some` as `ns.source` comes from
-        // `document.namespaces` which only contains namespaces for documents that
-        // are guaranteed to be present in the graph.
+        // SAFETY: we know `get_index` will return `Some` as `ns.source` comes
+        // from `document.namespaces` which only contains namespaces for
+        // documents that are guaranteed to be present in the graph.
         let node = graph.get(graph.get_index(ns.source()).unwrap());
         let Some(imported_doc) = node.document() else {
             continue;
@@ -178,8 +178,8 @@ fn resolve_hover_by_context(
     document: &Document,
     graph: &DocumentGraph,
 ) -> Result<Option<String>> {
-    // Hovering doc comments of an item produces the same content as hovering the
-    // identifier of the item
+    // Hovering doc comments of an item produces the same content as hovering
+    // the identifier of the item
     if token.kind() == SyntaxKind::Comment {
         let comment = Comment::cast(token.clone()).expect("should cast");
         if comment.kind() != CommentKind::Documentation {
@@ -344,7 +344,8 @@ fn resolve_hover_by_context(
                     };
 
                     if enum_ty.choices().iter().any(|text| text == member.text()) {
-                        // Try to find the enum definition to get the actual value
+                        // Try to find the enum definition to get the actual
+                        // value
                         if let Some(enum_entry) = document.enum_by_name(ty.name()) {
                             let definition = enum_entry.definition();
 
@@ -409,7 +410,8 @@ fn resolve_hover_by_context(
                 },
                 Type::Compound(CompoundType::Custom(CustomType::Enum(e)), _) => {
                     if e.choices().iter().any(|text| text == member.text()) {
-                        // Try to find the enum definition to get the actual value
+                        // Try to find the enum definition to get the actual
+                        // value
                         if let Some(enum_entry) = document.enum_by_name(e.name()) {
                             let definition = enum_entry.definition();
 

--- a/crates/wdl-analysis/src/handlers/inlay_hints.rs
+++ b/crates/wdl-analysis/src/handlers/inlay_hints.rs
@@ -70,7 +70,8 @@ pub fn inlay_hints(
 
         let definition = enum_entry.definition();
 
-        // Calculate the enum name end position (where the type hint would appear)
+        // Calculate the enum name end position (where the type hint would
+        // appear)
         let name_span = definition.name().span();
         let absolute_end = enum_entry.offset() + name_span.end();
         let enum_name_end_pos = position(&lines, TextSize::try_from(absolute_end)?)?;

--- a/crates/wdl-analysis/src/queue.rs
+++ b/crates/wdl-analysis/src/queue.rs
@@ -727,7 +727,8 @@ where
                                         lines, diagnostics, ..
                                     } => {
                                         // If there are any diagnostics that are
-                                        // errors, we shouldn't attempt to format the
+                                        // errors, we shouldn't attempt to
+                                        // format the
                                         // document.
                                         if diagnostics
                                             .iter()
@@ -1187,9 +1188,10 @@ where
     ) -> Cancelable<Result<Vec<AnalysisResult>>> {
         // Analysis works by building a subgraph of what needs to be analyzed.
         // We start with the requested node or all roots. We then perform a
-        // breadth-first traversal maintaining the set of nodes that compromises the
-        // subgraph. At each step of the traversal, we reparse what has changed. The
-        // traversal is complete when no new nodes are added to the subgraph node set.
+        // breadth-first traversal maintaining the set of nodes that compromises
+        // the subgraph. At each step of the traversal, we reparse what
+        // has changed. The traversal is complete when no new nodes are
+        // added to the subgraph node set.
 
         let mut subgraph = {
             let graph = self.graph.read();
@@ -1224,7 +1226,8 @@ where
                 .get_range(offset..)
                 .expect("offset should be valid");
 
-            // If there's no more nodes to process, we're done building the subgraph
+            // If there's no more nodes to process, we're done building the
+            // subgraph
             if slice.is_empty() {
                 break;
             }
@@ -1273,7 +1276,8 @@ where
                 return Cancelable::Canceled;
             }
 
-            // Build a set of nodes with no incoming edges (i.e. no unanalyzed dependencies)
+            // Build a set of nodes with no incoming edges (i.e. no unanalyzed
+            // dependencies)
             set.clear();
             for node in subgraph.node_indices() {
                 if subgraph
@@ -1519,8 +1523,8 @@ where
     ) -> Result<(Vec<NodeIndex>, SymbolicWorkSet)> {
         // Handle parse completion and URI imports under graph.write(). Symbolic
         // imports are collected (and deduplicated by module identity plus
-        // symbolic path) for concurrent materialization outside the lock, so the
-        // write lock is held for as short a time as possible.
+        // symbolic path) for concurrent materialization outside the lock, so
+        // the write lock is held for as short a time as possible.
         let mut uri_import_modules: Vec<(Url, Arc<Module>)> = Vec::new();
         let (parsed_indices, symbolic_work): (Vec<NodeIndex>, SymbolicWorkSet) = {
             let mut graph = self.graph.write();
@@ -1604,28 +1608,32 @@ where
                                         None => continue,
                                     };
 
-                                    let symbolic_path: SymbolicPath =
-                                        match module_path.text().parse() {
-                                            Ok(path) => path,
-                                            Err(e) => {
-                                                // Record the syntax failure so the
-                                                // import surfaces a precise diagnostic
-                                                // instead of the generic "not in a
-                                                // module" message during analysis.
-                                                graph.insert_failed_symbolic_import(
-                                                    index,
-                                                    module_path.text().to_string(),
-                                                    e.to_string(),
-                                                );
-                                                continue;
-                                            }
-                                        };
+                                    let symbolic_path: SymbolicPath = match module_path
+                                        .text()
+                                        .parse()
+                                    {
+                                        Ok(path) => path,
+                                        Err(e) => {
+                                            // Record the syntax failure so the
+                                            // import surfaces a precise
+                                            // diagnostic
+                                            // instead of the generic "not in a
+                                            // module" message during analysis.
+                                            graph.insert_failed_symbolic_import(
+                                                index,
+                                                module_path.text().to_string(),
+                                                e.to_string(),
+                                            );
+                                            continue;
+                                        }
+                                    };
 
                                     // Collapse imports of the same dependency
                                     // from the same module into one
                                     // materialization, keyed on full module
                                     // identity plus the symbolic path, so each
-                                    // dependency is resolved once and the result
+                                    // dependency is resolved once and the
+                                    // result
                                     // fanned out to every importer.
                                     work.entry((consumer_module.id(), symbolic_path.clone()))
                                         .or_insert_with(|| MaterializeWork {
@@ -1675,9 +1683,10 @@ where
             count = unique_work.len(),
             "resolving symbolic imports concurrently",
         );
-        // SAFETY: symbolic work is only collected when a consumer module governs
-        // a document, which only happens when resolution is enabled with a
-        // resolver; a disabled context produces no work and returned above.
+        // SAFETY: symbolic work is only collected when a consumer module
+        // governs a document, which only happens when resolution is
+        // enabled with a resolver; a disabled context produces no work
+        // and returned above.
         let resolver = Arc::clone(self.resolver.as_ref().unwrap());
         let stream = futures::stream::iter(unique_work.into_values().map(|work| {
             let resolver = Arc::clone(&resolver);
@@ -1750,8 +1759,9 @@ where
 
                         // Ask the resolved file for the module that owns it,
                         // extending the consumer module captured during
-                        // collection. The queue does not reassemble module state
-                        // from the file's raw manifest and root itself.
+                        // collection. The queue does not reassemble module
+                        // state from the file's raw
+                        // manifest and root itself.
                         let import_module = materialized
                             .child_module(&consumer_module, symbolic_path.dep_name().clone());
 

--- a/crates/wdl-analysis/src/stdlib.rs
+++ b/crates/wdl-analysis/src/stdlib.rs
@@ -1107,8 +1107,9 @@ impl FunctionSignature {
         for (i, (parameter, argument)) in self.parameters.iter().zip(arguments.iter()).enumerate() {
             match parameter.ty.realize(&type_parameters) {
                 Some(ty) => {
-                    // If a coercion hasn't occurred yet, check for type equivalence
-                    // For the purpose of this check, also accept equivalence of `T` if the
+                    // If a coercion hasn't occurred yet, check for type
+                    // equivalence For the purpose of this
+                    // check, also accept equivalence of `T` if the
                     // parameter type is `T?`; otherwise, fall back to coercion
                     if !coerced && argument != &ty && argument != &ty.require() {
                         coerced = true;
@@ -1144,9 +1145,10 @@ impl FunctionSignature {
             }
         }
 
-        // Finally, realize the return type; if it fails to realize, it means there was
-        // at least one uninferred type parameter; we return `Union` instead to indicate
-        // that the return value is indeterminate.
+        // Finally, realize the return type; if it fails to realize, it means
+        // there was at least one uninferred type parameter; we return
+        // `Union` instead to indicate that the return value is
+        // indeterminate.
         let ret = self.ret().realize(&type_parameters).unwrap_or(Type::Union);
 
         if coerced {
@@ -1266,7 +1268,8 @@ impl FunctionSignatureBuilder {
             "too many parameters"
         );
 
-        // Ensure any generic type parameters indexes are in range for the parameters
+        // Ensure any generic type parameters indexes are in range for the
+        // parameters
         for parameter in sig.parameters.iter() {
             parameter.ty.assert_type_parameters(&sig.type_parameters)
         }
@@ -1371,8 +1374,8 @@ impl Function {
             Self::Polymorphic(f) => {
                 let mut ty = None;
 
-                // For polymorphic functions, the calculated return type must be the same for
-                // each overload
+                // For polymorphic functions, the calculated return type must be
+                // the same for each overload
                 for signature in &f.signatures {
                     let type_parameters = signature.infer_type_parameters(arguments, true);
                     let ret_ty = signature
@@ -1525,7 +1528,8 @@ impl PolymorphicFunction {
         version: SupportedVersion,
         arguments: &[Type],
     ) -> Result<Binding<'a>, FunctionBindError> {
-        // Ensure that there is at least one signature with a matching minimum version.
+        // Ensure that there is at least one signature with a matching minimum
+        // version.
         let min_version = self.minimum_version();
         if version < min_version {
             return Err(FunctionBindError::RequiresVersion(min_version));
@@ -1543,7 +1547,8 @@ impl PolymorphicFunction {
             return Err(FunctionBindError::TooManyArguments(max));
         }
 
-        // Overload resolution precedence is from most specific to least specific:
+        // Overload resolution precedence is from most specific to least
+        // specific:
         // * Non-generic exact match
         // * Non-generic with coercion
         // * Generic exact match
@@ -1582,8 +1587,10 @@ impl PolymorphicFunction {
                         exact = Some((index, ty));
                     }
                     Ok(BindingKind::Coercion(ty)) => {
-                        // If this is the first coercion, store it; otherwise, store the second
-                        // coercion index; if there's more than one coercion, we'll report an error
+                        // If this is the first coercion, store it; otherwise,
+                        // store the second
+                        // coercion index; if there's more than one coercion,
+                        // we'll report an error
                         // below after ensuring there's no exact match
                         if coercion1.is_none() {
                             coercion1 = Some((index, ty));
@@ -1592,7 +1599,8 @@ impl PolymorphicFunction {
                         }
                     }
                     Err(FunctionBindError::ArgumentTypeMismatch { index, expected }) => {
-                        // We'll report an argument mismatch for the greatest argument index
+                        // We'll report an argument mismatch for the greatest
+                        // argument index
                         if index > max_mismatch_index {
                             max_mismatch_index = index;
                             expected_types.clear();

--- a/crates/wdl-analysis/src/stdlib/constraints.rs
+++ b/crates/wdl-analysis/src/stdlib/constraints.rs
@@ -61,7 +61,8 @@ impl Constraint for SizeableConstraint {
                 Type::Primitive(ty, _) => primitive_type_is_sizable(*ty),
                 Type::Compound(ty, _) => compound_type_is_sizable(ty),
                 Type::Object | Type::OptionalObject => {
-                    // Note: checking the types of an object's members is a runtime constraint
+                    // Note: checking the types of an object's members is a
+                    // runtime constraint
                     true
                 }
                 // Treat unions as sizable as they can only be checked at runtime

--- a/crates/wdl-analysis/src/types.rs
+++ b/crates/wdl-analysis/src/types.rs
@@ -321,7 +321,8 @@ impl Type {
     /// For most types, this wraps them in an array. For call types, this
     /// promotes each output type into an array.
     pub fn promote_scatter(&self) -> Self {
-        // For calls, the outputs of the call are promoted instead of the call itself
+        // For calls, the outputs of the call are promoted instead of the call
+        // itself
         if let Self::Call(ty) = self {
             return Self::Call(ty.promote_scatter());
         }
@@ -343,13 +344,14 @@ impl Type {
             return Some(other.clone());
         }
 
-        // If the other type is `None`, then the common type would be an optional this
-        // type
+        // If the other type is `None`, then the common type would be an
+        // optional this type
         if other.is_none() {
             return Some(self.optional());
         }
 
-        // If this type is `None`, then the common type would be an optional other type
+        // If this type is `None`, then the common type would be an optional
+        // other type
         if self.is_none() {
             return Some(other.optional());
         }
@@ -570,7 +572,8 @@ impl Coercible for Type {
                         Type::from(PrimitiveType::String).is_coercible_to(target.key_type())
                     }
                     CompoundType::Custom(CustomType::Struct(_)) => {
-                        // Note: checking object keys and values is a runtime constraint
+                        // Note: checking object keys and values is a runtime
+                        // constraint
                         true
                     }
                     _ => false,
@@ -799,8 +802,8 @@ impl CompoundType {
     /// This method does not attempt coercion; it only attempts to find common
     /// inner types for the same outer type.
     fn common_type(&self, other: &Self) -> Option<CompoundType> {
-        // Check to see if the types are both `Array`, `Pair`, or `Map`; if so, attempt
-        // to find a common type for their inner types
+        // Check to see if the types are both `Array`, `Pair`, or `Map`; if so,
+        // attempt to find a common type for their inner types
         match (self, other) {
             (Self::Array(this), Self::Array(other)) => {
                 let element_type = this.element_type().common_type(other.element_type())?;
@@ -869,7 +872,8 @@ impl Coercible for CompoundType {
                     return false;
                 }
 
-                // Ensure the value type is coercible to every struct member type
+                // Ensure the value type is coercible to every struct member
+                // type
                 if !target
                     .members()
                     .values()
@@ -1005,7 +1009,8 @@ impl fmt::Display for ArrayType {
 
 impl Coercible for ArrayType {
     fn is_coercible_to(&self, target: &Self) -> bool {
-        // Note: non-empty constraints are enforced at runtime and are not checked here.
+        // Note: non-empty constraints are enforced at runtime and are not
+        // checked here.
         self.0.element_type.is_coercible_to(&target.0.element_type)
     }
 }
@@ -1710,8 +1715,8 @@ mod test {
 
     #[test_log::test]
     fn primitive_type_coercion() {
-        // All types should be coercible to self, and required should coerce to optional
-        // (but not vice versa)
+        // All types should be coercible to self, and required should coerce to
+        // optional (but not vice versa)
         for ty in [
             Type::from(PrimitiveType::Boolean),
             PrimitiveType::Directory.into(),
@@ -2464,7 +2469,8 @@ mod test {
 
     #[test_log::test]
     fn enum_type_new_with_explicit_type() {
-        // Create enum with explicit `String` type, all choices coerce to `String`.
+        // Create enum with explicit `String` type, all choices coerce to
+        // `String`.
         let status = EnumType::new(
             "Status",
             Span::new(0, 0),

--- a/crates/wdl-analysis/src/types/v1.rs
+++ b/crates/wdl-analysis/src/types/v1.rs
@@ -720,8 +720,8 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
     ) {
         self.placeholders += 1;
 
-        // Evaluate the placeholder expression and check that the resulting type is
-        // coercible to string for interpolation
+        // Evaluate the placeholder expression and check that the resulting type
+        // is coercible to string for interpolation
         let expr = placeholder.expr();
         if let Some(ty) = self.evaluate_expr(&expr) {
             if let Some(option) = placeholder.option() {
@@ -851,7 +851,8 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
                     if let Some(actual_key) = self.evaluate_expr(&key)
                         && let Some(actual_value) = self.evaluate_expr(&value)
                     {
-                        // The key must be a non-optional primitive type or union
+                        // The key must be a non-optional primitive type or
+                        // union
                         match actual_key {
                             Type::Primitive(_, false) | Type::Union => {
                                 match expected_key.common_type(&actual_key) {
@@ -1011,14 +1012,15 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
     ) {
         let expr_ty = self.evaluate_expr(expr).unwrap_or(Type::Union);
 
-        // The `cpu`, `gpu`, `disks`, `maxRetries`, and `returnCodes` keys are not
-        // formally typed until WDL 1.1 (see the WDL 1.0 specification's runtime
-        // section, which only gives recommended conventions for `docker` and
-        // `memory`). Some of these names are shared with differently-typed
-        // `hints` keys (e.g. `gpu` and `disks`), so simply letting the
-        // `task_requirement_types` lookup fail for WDL 1.0 documents isn't
-        // sufficient; doing so would incorrectly fall through to checking
-        // against the `hints` types below. Instead, skip type checking for
+        // The `cpu`, `gpu`, `disks`, `maxRetries`, and `returnCodes` keys are
+        // not formally typed until WDL 1.1 (see the WDL 1.0
+        // specification's runtime section, which only gives recommended
+        // conventions for `docker` and `memory`). Some of these names
+        // are shared with differently-typed `hints` keys (e.g. `gpu`
+        // and `disks`), so simply letting the `task_requirement_types`
+        // lookup fail for WDL 1.0 documents isn't sufficient; doing so
+        // would incorrectly fall through to checking against the
+        // `hints` types below. Instead, skip type checking for
         // these keys entirely when the document version is older than 1.1.
         // See https://github.com/stjude-rust-labs/sprocket/issues/811.
         if self.context.version() < SupportedVersion::V1(V1::One)
@@ -1035,8 +1037,9 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
         }
 
         if !self.evaluate_requirement(name, expr, &expr_ty) {
-            // Always use object types for `runtime` section `inputs` and `outputs` keys as
-            // only `hints` sections can use input/output hidden types
+            // Always use object types for `runtime` section `inputs` and
+            // `outputs` keys as only `hints` sections can use
+            // input/output hidden types
             if let Some(expected) = task_hint_types(self.context.version(), name.text(), false)
                 && !expected
                     .iter()
@@ -1170,8 +1173,8 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
         let mut names = names.enumerate().peekable();
         let expr_ty = self.evaluate_expr(&expr).unwrap_or(Type::Union);
 
-        // The first name should be an input/output and then the remainder should be a
-        // struct member
+        // The first name should be an input/output and then the remainder
+        // should be a struct member
         let mut span = None;
         let mut s: Option<&StructType> = None;
         while let Some((i, name)) = names.next() {
@@ -1317,7 +1320,8 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
         if !ty.is_coercible_to(&PrimitiveType::Float.into()) {
             self.context
                 .add_diagnostic(negation_mismatch(&ty, operand.span()));
-            // Type is indeterminate as the expression may evaluate to more than one type
+            // Type is indeterminate as the expression may evaluate to more than
+            // one type
             return None;
         }
 
@@ -1386,7 +1390,8 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
             return Some(PrimitiveType::Boolean.into());
         }
 
-        // Check LHS and RHS for being coercible to one of the supported primitive types
+        // Check LHS and RHS for being coercible to one of the supported
+        // primitive types
         for expected in [
             Type::from(PrimitiveType::Boolean),
             PrimitiveType::Integer.into(),
@@ -1395,7 +1400,8 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
             PrimitiveType::File.into(),
             PrimitiveType::Directory.into(),
         ] {
-            // Only support equality/inequality comparisons for `File` and `Directory`
+            // Only support equality/inequality comparisons for `File` and
+            // `Directory`
             if op != ComparisonOperator::Equality
                 && op != ComparisonOperator::Inequality
                 && (matches!(
@@ -1419,7 +1425,8 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
             }
         }
 
-        // For equality comparisons, check LHS and RHS being object and compound types
+        // For equality comparisons, check LHS and RHS being object and compound
+        // types
         if op == ComparisonOperator::Equality || op == ComparisonOperator::Inequality {
             // Check for object
             if (lhs_ty.is_coercible_to(&Type::Object) && rhs_ty.is_coercible_to(&Type::Object))
@@ -1496,9 +1503,9 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
             return Some(PrimitiveType::Float.into());
         }
 
-        // For addition, also support `String` on one or both sides of any primitive
-        // type that isn't `Boolean`; in placeholder expressions, allow the
-        // other side to also be optional
+        // For addition, also support `String` on one or both sides of any
+        // primitive type that isn't `Boolean`; in placeholder
+        // expressions, allow the other side to also be optional
         if op == NumericOperator::Addition {
             let allow_optional = self.placeholders > 0;
             let other = if (!lhs_ty.is_optional() || allow_optional)
@@ -1804,8 +1811,8 @@ impl<'a, C: EvaluationContext> ExprTypeEvaluator<'a, C> {
             _ => {}
         }
 
-        // Check to see if it's coercible to object; if so, treat as `Union` as it's
-        // indeterminate
+        // Check to see if it's coercible to object; if so, treat as `Union` as
+        // it's indeterminate
         if ty.is_coercible_to(&Type::OptionalObject) {
             return Some(Type::Union);
         }

--- a/crates/wdl-analysis/src/validation.rs
+++ b/crates/wdl-analysis/src/validation.rs
@@ -242,8 +242,8 @@ impl Validator {
 
         let visitor_known_rules = self.rules();
 
-        // `ExceptDirectiveValid` does a different job of checking whether a lint
-        // exception is *ever* applicable to the applied node.
+        // `ExceptDirectiveValid` does a different job of checking whether a
+        // lint exception is *ever* applicable to the applied node.
         // `MeaninglessLintDirective` should only fire if the exception
         // comment is valid to begin with.
         let invalid_directives = diagnostics

--- a/crates/wdl-analysis/src/validation/exprs.rs
+++ b/crates/wdl-analysis/src/validation/exprs.rs
@@ -136,7 +136,8 @@ impl ScopedExprVisitor {
                 diagnostics.add(literal_cannot_nest(&literal, outer));
             }
         } else {
-            // Any use of these literals outside of a `hints` section is prohibited
+            // Any use of these literals outside of a `hints` section is
+            // prohibited
             diagnostics.add(hints_scope_required(&literal));
         }
 

--- a/crates/wdl-analysis/src/validation/keys.rs
+++ b/crates/wdl-analysis/src/validation/keys.rs
@@ -298,8 +298,8 @@ impl Visitor for UniqueKeysVisitor {
             return;
         }
 
-        // As metadata objects are nested inside of metadata sections and objects,
-        // use a different set to check the keys
+        // As metadata objects are nested inside of metadata sections and
+        // objects, use a different set to check the keys
         let mut keys = HashSet::new();
         check_duplicate_keys(
             &mut keys,

--- a/crates/wdl-analysis/src/validation/numbers.rs
+++ b/crates/wdl-analysis/src/validation/numbers.rs
@@ -52,17 +52,18 @@ impl Visitor for NumberVisitor {
             return;
         }
 
-        // Check for either a literal integer, literal float, or a negation with an
-        // immediate literal integer or literal float operand.
+        // Check for either a literal integer, literal float, or a negation with
+        // an immediate literal integer or literal float operand.
         //
-        // In the case of floats, we can simply check if `value` returns `is_none`,
-        // which will indicate that the literal is not in range.
+        // In the case of floats, we can simply check if `value` returns
+        // `is_none`, which will indicate that the literal is not in
+        // range.
         //
-        // For integers, we need to call the `negate` method if the literal is part
-        // of a negation expression; otherwise, we use `value`.
+        // For integers, we need to call the `negate` method if the literal is
+        // part of a negation expression; otherwise, we use `value`.
         //
-        // If a value is not in range and an operand to a negation expression, we start
-        // the error span at the minus token.
+        // If a value is not in range and an operand to a negation expression,
+        // we start the error span at the minus token.
         match expr {
             Expr::Literal(LiteralExpr::Integer(i)) => {
                 let in_range = if self.negation_start.is_some() {
@@ -104,7 +105,8 @@ impl Visitor for NumberVisitor {
                 diagnostics.add(float_not_in_range(span));
             }
             Expr::Negation(negation) => {
-                // Check to see if the very next expression is a literal integer or float
+                // Check to see if the very next expression is a literal integer
+                // or float
                 if matches!(
                     negation.operand(),
                     Expr::Literal(LiteralExpr::Integer(_)) | Expr::Literal(LiteralExpr::Float(_))

--- a/crates/wdl-analysis/src/validation/strings.rs
+++ b/crates/wdl-analysis/src/validation/strings.rs
@@ -139,8 +139,9 @@ impl Visitor for LiteralTextVisitor {
         let string: v1::LiteralString<_> = text.parent().expect("should have a parent");
         match string.kind() {
             LiteralStringKind::SingleQuoted | LiteralStringKind::DoubleQuoted => {
-                // Check the text of a normal string to ensure escape sequences are correct and
-                // characters that are required to be escaped are actually escaped.
+                // Check the text of a normal string to ensure escape sequences
+                // are correct and characters that are required
+                // to be escaped are actually escaped.
                 check_text(diagnostics, text.span().start(), text.text());
             }
             LiteralStringKind::Multiline => {

--- a/crates/wdl-analysis/src/validation/version.rs
+++ b/crates/wdl-analysis/src/validation/version.rs
@@ -174,8 +174,8 @@ impl Visitor for VersionVisitor {
             return;
         }
 
-        // Emit a deprecation warning if the user explicitly disabled WDL 1.3 and we
-        // encounter a WDL 1.3 document.
+        // Emit a deprecation warning if the user explicitly disabled WDL 1.3
+        // and we encounter a WDL 1.3 document.
         if let Some(version) = self.version {
             match version {
                 SupportedVersion::V1(V1::Three)

--- a/crates/wdl-analysis/tests/analysis.rs
+++ b/crates/wdl-analysis/tests/analysis.rs
@@ -173,7 +173,8 @@ fn compare_results(test: &Path, results: Vec<AnalysisResult>) -> Result<()> {
 /// Run a test either in whole-directory or single-document mode based on
 /// whether the test name appears in the `SINGLE_DOCUMENT_TESTS` list.
 async fn run_test(test: &Path) -> Result<(), anyhow::Error> {
-    // Set up a new analyzer for this test, reading in a custom config if present.
+    // Set up a new analyzer for this test, reading in a custom config if
+    // present.
     let base = absolute(test).expect("should be made absolute").clean();
     let config_path = base.join("config.toml");
     let config = if config_path.exists() {
@@ -197,8 +198,8 @@ async fn run_test(test: &Path) -> Result<(), anyhow::Error> {
                 .await
                 .context("analyzing document")?
         } else {
-            // If it's not specified as a single-document test, add and analyze the whole
-            // directory
+            // If it's not specified as a single-document test, add and analyze
+            // the whole directory
             analyzer
                 .add_directory(&base)
                 .await

--- a/crates/wdl-analysis/tests/validation.rs
+++ b/crates/wdl-analysis/tests/validation.rs
@@ -128,8 +128,8 @@ fn compare_result(path: &Path, result: &str, is_error: bool) -> Result<(), anyho
 
 /// Run a single test.
 async fn run_test(test: &Path) -> Result<(), anyhow::Error> {
-    // Add this test's directory to a new analyzer, reading in a custom config if
-    // present.
+    // Add this test's directory to a new analyzer, reading in a custom config
+    // if present.
     let base = absolute(test).expect("should be made absolute").clean();
     let source_path = base.join("source.wdl");
     let errors_path = base.join("source.errors");

--- a/crates/wdl-ast/src/lib.rs
+++ b/crates/wdl-ast/src/lib.rs
@@ -614,8 +614,8 @@ impl<N: TreeNode> Document<N> {
         let Some(stmt) = self.version_statement() else {
             return Ast::Unsupported;
         };
-        // Parse the version statement, fall back to the fallback, and finally give up
-        // if neither of those works.
+        // Parse the version statement, fall back to the fallback, and finally
+        // give up if neither of those works.
         let Some(version) = stmt
             .version()
             .text()
@@ -866,8 +866,8 @@ impl Comment {
 
     /// Gets whether the comment is an inline comment or not.
     pub fn is_inline_comment(&self) -> bool {
-        // If there is a preceding token that isn't whitespace with a newline, then
-        // the comment is not alone on this line.
+        // If there is a preceding token that isn't whitespace with a newline,
+        // then the comment is not alone on this line.
         if let Some(prev) = self.inner().prev_sibling_or_token() {
             if prev.kind() == SyntaxKind::Whitespace {
                 !prev

--- a/crates/wdl-ast/src/python.rs
+++ b/crates/wdl-ast/src/python.rs
@@ -206,8 +206,8 @@ mod tests {
 
     use super::*;
 
-    // Assert `ThreadSafeSyntaxNode` and `ThreadSafeSyntaxToken` are actually thread
-    // safe.
+    // Assert `ThreadSafeSyntaxNode` and `ThreadSafeSyntaxToken` are actually
+    // thread safe.
     const _: () = {
         const fn assert_send<T: Send>() {}
         const fn assert_sync<T: Sync>() {}

--- a/crates/wdl-ast/src/v1/expr.rs
+++ b/crates/wdl-ast/src/v1/expr.rs
@@ -2086,8 +2086,8 @@ impl<N: TreeNode> LiteralString<N> {
             }
         }
 
-        // Now that the string has been unescaped and the first and last lines trimmed,
-        // we can detect any leading whitespace and trim it.
+        // Now that the string has been unescaped and the first and last lines
+        // trimmed, we can detect any leading whitespace and trim it.
         let mut leading_whitespace = usize::MAX;
         let mut parsing_leading_whitespace = true;
         let mut iter = result.iter().peekable();
@@ -2109,7 +2109,8 @@ impl<N: TreeNode> LiteralString<N> {
                                 }
                             }
 
-                            // Don't include blank lines in determining leading whitespace, unless
+                            // Don't include blank lines in determining leading
+                            // whitespace, unless
                             // the next part is a placeholder
                             if ws_count == line.len()
                                 && iter
@@ -2131,8 +2132,8 @@ impl<N: TreeNode> LiteralString<N> {
         }
 
         // Finally, strip the leading whitespace on each line
-        // This is done in place using the `replace_range` method; the method will
-        // internally do moves without allocations
+        // This is done in place using the `replace_range` method; the method
+        // will internally do moves without allocations
         let mut strip_leading_whitespace = whole_first_line_trimmed;
         for part in &mut result {
             match part {

--- a/crates/wdl-ast/src/v1/task.rs
+++ b/crates/wdl-ast/src/v1/task.rs
@@ -1151,8 +1151,9 @@ impl<N: TreeNode> CommandSection<N> {
             return None;
         }
 
-        // Exactly one of the two will be equal to usize::MAX because it never appeared.
-        // The other will be the number of leading spaces or tabs to strip.
+        // Exactly one of the two will be equal to usize::MAX because it never
+        // appeared. The other will be the number of leading spaces or
+        // tabs to strip.
         let final_leading_whitespace = if min_leading_spaces < min_leading_tabs {
             min_leading_spaces
         } else {
@@ -1218,8 +1219,8 @@ impl<N: TreeNode> CommandSection<N> {
         }
 
         // Finally, strip the leading whitespace on each line
-        // This is done in place using the `replace_range` method; the method will
-        // internally do moves without allocations
+        // This is done in place using the `replace_range` method; the method
+        // will internally do moves without allocations
         let mut strip_leading_whitespace = whole_first_line_trimmed;
         for part in &mut result {
             match part {
@@ -1391,8 +1392,8 @@ impl<N: TreeNode> RequirementsSection<N> {
     /// [`Container`](requirements::item::Container) (if it exists).
     #[cfg_attr(feature = "unstable-python", skip)]
     pub fn container(&self) -> Option<requirements::item::Container<N>> {
-        // NOTE: validation should ensure that, at most, one `container` item exists in
-        // the `requirements` section.
+        // NOTE: validation should ensure that, at most, one `container` item
+        // exists in the `requirements` section.
         self.child()
     }
 
@@ -1555,8 +1556,8 @@ impl<N: TreeNode> RuntimeSection<N> {
     /// (if it exists).
     #[cfg_attr(feature = "unstable-python", skip)]
     pub fn container(&self) -> Option<runtime::item::Container<N>> {
-        // NOTE: validation should ensure that, at most, one `container`/`docker` item
-        // exists in the `runtime` section.
+        // NOTE: validation should ensure that, at most, one
+        // `container`/`docker` item exists in the `runtime` section.
         self.child()
     }
 }
@@ -2256,7 +2257,8 @@ then name
             StrippedCommandPart::Placeholder(p) => p,
             _ => panic!("expected placeholder"),
         };
-        // not testing anything with the placeholder, just making sure it's there
+        // not testing anything with the placeholder, just making sure it's
+        // there
 
         let text = match &stripped[2] {
             StrippedCommandPart::Text(text) => text,
@@ -2306,7 +2308,8 @@ task test {
             StrippedCommandPart::Placeholder(p) => p,
             _ => panic!("expected placeholder"),
         };
-        // not testing anything with the placeholder, just making sure it's there
+        // not testing anything with the placeholder, just making sure it's
+        // there
 
         let text = match &stripped[2] {
             StrippedCommandPart::Text(text) => text,
@@ -2318,7 +2321,8 @@ task test {
             StrippedCommandPart::Placeholder(p) => p,
             _ => panic!("expected placeholder"),
         };
-        // not testing anything with the placeholder, just making sure it's there
+        // not testing anything with the placeholder, just making sure it's
+        // there
 
         let text = match &stripped[4] {
             StrippedCommandPart::Text(text) => text,
@@ -2330,7 +2334,8 @@ task test {
             StrippedCommandPart::Placeholder(p) => p,
             _ => panic!("expected placeholder"),
         };
-        // not testing anything with the placeholder, just making sure it's there
+        // not testing anything with the placeholder, just making sure it's
+        // there
 
         let text = match &stripped[6] {
             StrippedCommandPart::Text(text) => text,
@@ -2594,7 +2599,8 @@ task test {
             StrippedCommandPart::Placeholder(p) => p,
             _ => panic!("expected placeholder"),
         };
-        // not testing anything with the placeholder, just making sure it's there
+        // not testing anything with the placeholder, just making sure it's
+        // there
 
         let text = match &stripped[2] {
             StrippedCommandPart::Text(text) => text,

--- a/crates/wdl-doc/src/docs_tree.rs
+++ b/crates/wdl-doc/src/docs_tree.rs
@@ -876,9 +876,10 @@ impl DocsTree {
         };
 
         // Local dependency module entrypoint documents are collapsed onto
-        // their module's root directory (see `WorkspaceMetadata::documentation_path`),
-        // so a node's directory (i.e. its path without a trailing
-        // `index.html`) can be looked up directly as a module root.
+        // their module's root directory (see
+        // `WorkspaceMetadata::documentation_path`), so a node's
+        // directory (i.e. its path without a trailing `index.html`) can
+        // be looked up directly as a module root.
         let node_module = |path: &Path| -> Option<&ModuleMetadata> {
             let dir = if path.file_name().expect("path should have a file name") == "index.html" {
                 path.parent().expect("path should have a parent")

--- a/crates/wdl-doc/src/lib.rs
+++ b/crates/wdl-doc/src/lib.rs
@@ -358,13 +358,15 @@ impl<T: AsRef<str>> Render for Markdown<T> {
             .clean(&unsafe_html)
             .to_string();
 
-        // Remove the outer `<p>` tag that `pulldown_cmark` wraps single lines in
+        // Remove the outer `<p>` tag that `pulldown_cmark` wraps single lines
+        // in
         let safe_html = if safe_html.starts_with("<p>") && safe_html.ends_with("</p>\n") {
             let trimmed = &safe_html[3..safe_html.len() - 5];
             if trimmed.contains("<p>") {
                 // If the trimmed string contains another `<p>` tag, it means
-                // that the original string was more complicated than a single-line paragraph,
-                // so we should keep the outer `<p>` tag.
+                // that the original string was more complicated than a
+                // single-line paragraph, so we should keep the
+                // outer `<p>` tag.
                 safe_html
             } else {
                 trimmed.to_string()
@@ -540,9 +542,11 @@ pub async fn document_workspace(config: Config) -> DocResult<()> {
                     (path.to_path_buf(), false)
                 }
                 Err(_) => {
-                    // URI was successfully converted to a file path, but it is not in the
-                    // workspace. This must be an imported WDL file and the
-                    // documentation will be generated in the `external/` directory.
+                    // URI was successfully converted to a file path, but it is
+                    // not in the workspace. This must be an
+                    // imported WDL file and the
+                    // documentation will be generated in the `external/`
+                    // directory.
                     let external = PathBuf::from("external").join(
                         path.components()
                             .skip_while(|c| !matches!(c, Component::Normal(_)))

--- a/crates/wdl-doc/src/meta.rs
+++ b/crates/wdl-doc/src/meta.rs
@@ -467,8 +467,8 @@ pub(crate) fn doc_comments(comments: impl IntoIterator<Item = Comment>) -> MetaM
     // We need to determine the minimum indentation that we can strip from each
     // paragraph line. Prior to this point, no lines have been trimmed.
     //
-    // In the most common case, we'll just be stripping a single space between the
-    // `##` and the comment text, as is convention.
+    // In the most common case, we'll just be stripping a single space between
+    // the `##` and the comment text, as is convention.
     let min_indent = paragraphs
         .iter()
         .map(|paragraph| {

--- a/crates/wdl-doc/src/parameter.rs
+++ b/crates/wdl-doc/src/parameter.rs
@@ -120,8 +120,8 @@ impl Parameter {
             .unwrap_or("None".to_string());
         if !summarize {
             // If we are not summarizing, we need to remove the first
-            // line from the leading whitespace calculation as the first line never
-            // leads with whitespace.
+            // line from the leading whitespace calculation as the first line
+            // never leads with whitespace.
             let mut lines = expr.lines();
             let first_line = lines.next().expect("expr should have at least one line");
 
@@ -287,11 +287,12 @@ where
     let params = params.collect::<Vec<_>>();
 
     let third_col = if params.iter().any(|p| p.required().is_none()) {
-        // If any parameter is an output, we use "Expression" as the third column
-        // header.
+        // If any parameter is an output, we use "Expression" as the third
+        // column header.
         "Expression"
     } else {
-        // If all parameters are inputs, we use "Default" as the third column header.
+        // If all parameters are inputs, we use "Default" as the third column
+        // header.
         "Default"
     };
 

--- a/crates/wdl-doc/src/runnable.rs
+++ b/crates/wdl-doc/src/runnable.rs
@@ -108,9 +108,9 @@ pub(crate) trait Runnable: DefinitionMeta {
             // The Unix/Windows toggle only changes the path separator in the
             // shown `sprocket run --target <path>` command, so it is only
             // meaningful when the path actually contains a separator. Detect
-            // both separators explicitly rather than via `MAIN_SEPARATOR`, which
-            // would miss the `/` in WDL import paths when the host OS is
-            // Windows.
+            // both separators explicitly rather than via `MAIN_SEPARATOR`,
+            // which would miss the `/` in WDL import paths when the
+            // host OS is Windows.
             let has_separator = raw_path.contains('/') || raw_path.contains('\\');
             html! {
                 div class="main__run-with-container" data-pagefind-ignore="all" {
@@ -322,7 +322,8 @@ fn meta_to_description(value: &MetaMapValueSource) -> Option<MetaMap> {
                 value.clone(),
             )])),
             _ => {
-                // If it's not an object or string, we don't know how to handle it.
+                // If it's not an object or string, we don't know how to handle
+                // it.
                 None
             }
         },

--- a/crates/wdl-doc/src/runnable/workflow.rs
+++ b/crates/wdl-doc/src/runnable/workflow.rs
@@ -445,8 +445,8 @@ mod tests {
         let (markup, _) = workflow.render(Path::new("assets"), &links, Path::new(""));
         let html = markup.into_string();
 
-        // Without a `meta.name` override the title is the raw WDL identifier and
-        // must be rendered as a code literal.
+        // Without a `meta.name` override the title is the raw WDL identifier
+        // and must be rendered as a code literal.
         assert!(html.contains("<code class=\"heading-code-literal\">bind_runes</code>"));
     }
 

--- a/crates/wdl-doc/tests/ui/base/code_block.rs
+++ b/crates/wdl-doc/tests/ui/base/code_block.rs
@@ -135,8 +135,8 @@ impl UiTest for CodeBlock {
 
         let code_text = info["codeText"].as_str().unwrap_or_default().to_string();
 
-        // Install a clipboard stub so we can capture the copied text, then click
-        // the copy control.
+        // Install a clipboard stub so we can capture the copied text, then
+        // click the copy control.
         driver
             .execute(
                 r#"

--- a/crates/wdl-doc/tests/ui/base/page_navigation.rs
+++ b/crates/wdl-doc/tests/ui/base/page_navigation.rs
@@ -92,8 +92,8 @@ impl UiTest for PageNavigation {
             );
         }
 
-        // The struct members section and the authored Markdown heading must both
-        // be present.
+        // The struct members section and the authored Markdown heading must
+        // both be present.
         if !link_texts.contains(&"Members") {
             bail!("expected a `Members` navigation link");
         }

--- a/crates/wdl-engine/src/backend/apptainer.rs
+++ b/crates/wdl-engine/src/backend/apptainer.rs
@@ -97,7 +97,8 @@ impl ApptainerRuntime {
                 )
             })?;
 
-        // SAFETY: the lock file is requested to be created so `Some` is always returned
+        // SAFETY: the lock file is requested to be created so `Some` is always
+        // returned
         let _lock = LockedFile::acquire_shared(&cache_dir.join(LOCK_FILE_NAME), true)
             .await?
             .unwrap();
@@ -159,13 +160,14 @@ impl ApptainerRuntime {
         image_path: &Path,
         request: &ExecuteTaskRequest<'_>,
     ) -> Result<String> {
-        // Create a temp dir for the container's execution within the attempt dir
-        // hierarchy. On many HPC systems, `/tmp` is mapped to a relatively
-        // small, local scratch disk that can fill up easily. Mapping the
-        // container's `/tmp` and `/var/tmp` paths to the filesystem we're using
-        // for other inputs and outputs prevents this from being a capacity problem,
-        // though potentially at the expense of execution speed if the
-        // non-`/tmp` filesystem is significantly slower.
+        // Create a temp dir for the container's execution within the attempt
+        // dir hierarchy. On many HPC systems, `/tmp` is mapped to a
+        // relatively small, local scratch disk that can fill up easily.
+        // Mapping the container's `/tmp` and `/var/tmp` paths to the
+        // filesystem we're using for other inputs and outputs prevents
+        // this from being a capacity problem, though potentially at the
+        // expense of execution speed if the non-`/tmp` filesystem is
+        // significantly slower.
         let container_tmp_path = request.temp_dir.join("container_tmp");
         tokio::fs::DirBuilder::new()
             .recursive(true)
@@ -472,8 +474,9 @@ impl ApptainerRuntime {
         if !output.status.success() {
             let permanent = if let Ok(stderr) = str::from_utf8(&output.stderr) {
                 let mut permanent = false;
-                // A collection of strings observed in `apptainer pull` stderr in unrecoverable
-                // conditions. Finding one of these in the output marks the attempt as a
+                // A collection of strings observed in `apptainer pull` stderr
+                // in unrecoverable conditions. Finding one of
+                // these in the output marks the attempt as a
                 // permanent failure.
                 let needles = ["manifest unknown", "403 (Forbidden)"];
                 for needle in needles {
@@ -577,9 +580,9 @@ mod tests {
             .expect("example task script should generate");
     }
 
-    // `shellcheck` works quite differently on Windows, and since we're not going to
-    // run Apptainer on Windows anytime soon, we limit this test to Unixy
-    // systems
+    // `shellcheck` works quite differently on Windows, and since we're not
+    // going to run Apptainer on Windows anytime soon, we limit this test to
+    // Unixy systems
     #[cfg(unix)]
     #[tokio::test]
     async fn example_task_shellchecks() {

--- a/crates/wdl-engine/src/backend/docker.rs
+++ b/crates/wdl-engine/src/backend/docker.rs
@@ -161,9 +161,10 @@ impl ManagedTask for DockerTask<'_> {
             )
         })?;
 
-        // On Unix, the work directory must be group writable in case the container uses
-        // a different user/group; the Crankshaft docker backend will automatically add
-        // the current user's egid to the container
+        // On Unix, the work directory must be group writable in case the
+        // container uses a different user/group; the Crankshaft docker
+        // backend will automatically add the current user's egid to the
+        // container
         #[cfg(unix)]
         {
             use std::fs::Permissions;
@@ -187,8 +188,8 @@ impl ManagedTask for DockerTask<'_> {
             )
         })?;
 
-        // Allocate the inputs, which will always be, at most, the number of inputs plus
-        // the working directory and command
+        // Allocate the inputs, which will always be, at most, the number of
+        // inputs plus the working directory and command
         let mut inputs = Vec::with_capacity(self.request.backend_inputs.len() + 2);
         for input in self.request.backend_inputs.iter() {
             let guest_path = input.guest_path().expect("input should have guest path");
@@ -255,8 +256,8 @@ impl ManagedTask for DockerTask<'_> {
             .keys()
             .filter_map(|mp| {
                 // NOTE: the root mount point is already handled by the work
-                // directory mount, so we filter it here to avoid duplicate volume
-                // mapping.
+                // directory mount, so we filter it here to avoid duplicate
+                // volume mapping.
                 if mp == DEFAULT_DISK_MOUNT_POINT {
                     None
                 } else {
@@ -389,14 +390,15 @@ async fn chown_work_dir(backend: &docker::Backend, name: &str, work_dir: &Path) 
         path = work_dir.display(),
     );
 
-    // The cleanup runs on a token of its own that nothing cancels: it matters most
-    // for a task that was canceled, and by then the evaluation's tokens are
-    // canceled and Docker would refuse to start the container. Dropping this
-    // future is the only way to stop waiting for the cleanup.
+    // The cleanup runs on a token of its own that nothing cancels: it matters
+    // most for a task that was canceled, and by then the evaluation's
+    // tokens are canceled and Docker would refuse to start the container.
+    // Dropping this future is the only way to stop waiting for the cleanup.
     //
-    // Passing no event sender keeps the cleanup off the event stream entirely, so
-    // no consumer can observe it, and none can cancel the token Crankshaft
-    // publishes with `TaskCreated` after the user has canceled evaluation.
+    // Passing no event sender keeps the cleanup off the event stream entirely,
+    // so no consumer can observe it, and none can cancel the token
+    // Crankshaft publishes with `TaskCreated` after the user has canceled
+    // evaluation.
     match backend
         .run(task, None, CancellationToken::new())
         .context("failed to submit cleanup task")?
@@ -508,9 +510,9 @@ impl DockerBackend {
         let memory = resources.memory();
         let max_memory = resources.max_memory();
 
-        // If a service is being used, then we're going to be spawning into a cluster
-        // For the purposes of resource tracking, treat it as unlimited resources and
-        // let Docker handle resource allocation
+        // If a service is being used, then we're going to be spawning into a
+        // cluster For the purposes of resource tracking, treat it as
+        // unlimited resources and let Docker handle resource allocation
         let manager = if resources.use_service() {
             TaskManager::new_unlimited(max_cpu, max_memory)
         } else {
@@ -598,10 +600,11 @@ impl TaskExecutionBackend for DockerBackend {
             }
         }
 
-        // Generate GPU specification strings in the format "<type>-gpu-<index>".
-        // Each string represents one allocated GPU, indexed from 0. The type prefix
-        // (e.g., "nvidia", "amd", "intel") identifies the GPU vendor/driver.
-        // This is the first backend to populate the gpu field; other backends should
+        // Generate GPU specification strings in the format
+        // "<type>-gpu-<index>". Each string represents one allocated
+        // GPU, indexed from 0. The type prefix (e.g., "nvidia", "amd",
+        // "intel") identifies the GPU vendor/driver. This is the first
+        // backend to populate the gpu field; other backends should
         // follow this format for consistency.
         let gpu = requirements::gpu(inputs, requirements, hints)
             .map(|count| (0..count).map(|i| format!("nvidia-gpu-{i}")).collect())
@@ -649,15 +652,16 @@ impl TaskExecutionBackend for DockerBackend {
 
             let result = self.manager.run(cpu, memory, task).await;
 
-            // A container ordinarily runs as `root`, so on Unix the files it leaves in
-            // the work directory are owned by another user and cannot be removed by the
-            // user performing evaluation. Hand ownership back whatever the outcome of
-            // the task was: a task that was canceled or that failed leaves the same
-            // files behind as one that completed.
+            // A container ordinarily runs as `root`, so on Unix the files it
+            // leaves in the work directory are owned by another
+            // user and cannot be removed by the user performing
+            // evaluation. Hand ownership back whatever the outcome of
+            // the task was: a task that was canceled or that failed leaves the
+            // same files behind as one that completed.
             //
-            // This is awaited here rather than submitted to the task manager, which
-            // abandons a task that has to wait for resources once evaluation has been
-            // canceled.
+            // This is awaited here rather than submitted to the task manager,
+            // which abandons a task that has to wait for resources
+            // once evaluation has been canceled.
             #[cfg(unix)]
             {
                 let work_dir = request.work_dir();
@@ -727,8 +731,9 @@ mod tests {
 
     #[test]
     fn a_present_source_is_explained() {
-        // SAFETY: creating a temporary directory only fails if the system has no
-        // usable temporary directory, which would fail the test suite as a whole.
+        // SAFETY: creating a temporary directory only fails if the system has
+        // no usable temporary directory, which would fail the test
+        // suite as a whole.
         let dir = TempDir::new().unwrap();
         let path = dir.path().to_str().expect("path should be UTF-8");
 
@@ -820,8 +825,8 @@ mod tests {
         };
 
         let work_dir = request.work_dir();
-        // The container creates this before it sleeps, so its presence means there is
-        // something for the cleanup to hand back
+        // The container creates this before it sleeps, so its presence means
+        // there is something for the cleanup to hand back
         let marker = work_dir.join("testdir").join("hello.txt");
 
         let mut execute = std::pin::pin!(backend.execute(&request));
@@ -847,7 +852,8 @@ mod tests {
             "the container should have created its file before the cancellation"
         );
 
-        // SAFETY: `geteuid` and `getegid` are always safe to call and cannot fail.
+        // SAFETY: `geteuid` and `getegid` are always safe to call and cannot
+        // fail.
         let (uid, gid) = unsafe { (libc::geteuid(), libc::getegid()) };
         let mut dirs = vec![work_dir];
         while let Some(dir) = dirs.pop() {
@@ -870,9 +876,10 @@ mod tests {
             }
         }
 
-        // The cleanup is the backend's own bookkeeping, so it emits no events at all:
-        // every event on the stream belongs to the task itself. Requiring the task's
-        // own events keeps this from passing on a stream that carried nothing.
+        // The cleanup is the backend's own bookkeeping, so it emits no events
+        // at all: every event on the stream belongs to the task itself.
+        // Requiring the task's own events keeps this from passing on a
+        // stream that carried nothing.
         let mut task_id = None;
         while let Ok(event) = receiver.try_recv() {
             let id = match &event {

--- a/crates/wdl-engine/src/backend/local.rs
+++ b/crates/wdl-engine/src/backend/local.rs
@@ -113,8 +113,8 @@ impl ManagedTask for LocalTask<'_> {
                 )
                 .kill_on_drop(true);
 
-            // Set the PATH variable for the child on Windows to get consistent PATH
-            // searching. See: https://github.com/rust-lang/rust/issues/122660
+            // Set the PATH variable for the child on Windows to get consistent
+            // PATH searching. See: https://github.com/rust-lang/rust/issues/122660
             #[cfg(windows)]
             if let Ok(path) = std::env::var("PATH") {
                 command.env("PATH", path);

--- a/crates/wdl-engine/src/backend/lsf_apptainer.rs
+++ b/crates/wdl-engine/src/backend/lsf_apptainer.rs
@@ -316,7 +316,8 @@ impl MonitorState {
             match record.state.parse::<JobState>() {
                 Ok(job_state) => {
                     if job.state != job_state {
-                        // If the job state is now running, send the started event
+                        // If the job state is now running, send the started
+                        // event
                         if job_state == JobState::Running {
                             send_event!(
                                 job.events.crankshaft(),
@@ -327,7 +328,8 @@ impl MonitorState {
                         }
 
                         if job_state.terminated() {
-                            // If the job was not already in a running state, send the
+                            // If the job was not already in a running state,
+                            // send the
                             // started event now
                             if job.state != JobState::Running {
                                 send_event!(
@@ -460,8 +462,8 @@ impl Monitor {
             }
         }
 
-        // Format a name for the LSF job; job names do not have to be unique, but we
-        // should not truncate the prefix or tag
+        // Format a name for the LSF job; job names do not have to be unique,
+        // but we should not truncate the prefix or tag
         let job_name = format!(
             "{prefix}{sep}{tag}-{task_name}",
             prefix = config.job_name_prefix.as_deref().unwrap_or(""),
@@ -531,7 +533,8 @@ impl Monitor {
         let stdout =
             str::from_utf8(&output.stdout).map_err(|_| anyhow!("`bsub` output was not UTF-8"))?;
 
-        // Parse out the job id from the output, which is surrounded by `<` and `>`
+        // Parse out the job id from the output, which is surrounded by `<` and
+        // `>`
         let job_id: u64 = stdout
             .split(' ')
             .nth(1)
@@ -780,8 +783,8 @@ impl TaskExecutionBackend for LsfApptainerBackend {
             .as_lsf_apptainer()
             .expect("configured backend is not LSF Apptainer");
 
-        // Determine whether CPU or memory limits are set for this queue, and clamp or
-        // deny them as appropriate if the limits are exceeded
+        // Determine whether CPU or memory limits are set for this queue, and
+        // clamp or deny them as appropriate if the limits are exceeded
         if let Some(queue) = backend_config.lsf_queue_for_task(requirements, hints) {
             if let Some(max_cpu) = queue.max_cpu_per_task
                 && required_cpu > max_cpu as f64

--- a/crates/wdl-engine/src/backend/manager.rs
+++ b/crates/wdl-engine/src/backend/manager.rs
@@ -82,11 +82,11 @@ impl LimitsState {
 
         // This algorithm is intended to unpark the greatest number of tasks.
         //
-        // It first finds the greatest subset of tasks that are constrained by CPU and
-        // then by memory.
+        // It first finds the greatest subset of tasks that are constrained by
+        // CPU and then by memory.
         //
-        // Next it finds the greatest subset of tasks that are constrained by memory and
-        // then by CPU.
+        // Next it finds the greatest subset of tasks that are constrained by
+        // memory and then by CPU.
         //
         // It then unparks whichever subset is greater.
         //
@@ -95,21 +95,21 @@ impl LimitsState {
             let parked = self.parked.make_contiguous();
 
             let cpu_by_memory_len = {
-                // Start by finding the longest range in the parked set that could run based on
-                // CPU reservation
+                // Start by finding the longest range in the parked set that
+                // could run based on CPU reservation
                 let range = fit_longest_range(parked, self.cpu, |task| OrderedFloat(task.cpu));
 
-                // Next, find the longest subset of that subset that could run based on memory
-                // reservation
+                // Next, find the longest subset of that subset that could run
+                // based on memory reservation
                 fit_longest_range(&mut parked[range], self.memory, |task| task.memory).len()
             };
 
-            // Next, find the longest range in the parked set that could run based on memory
-            // reservation
+            // Next, find the longest range in the parked set that could run
+            // based on memory reservation
             let memory_by_cpu = fit_longest_range(parked, self.memory, |task| task.memory);
 
-            // Next, find the longest subset of that subset that could run based on CPU
-            // reservation
+            // Next, find the longest subset of that subset that could run based
+            // on CPU reservation
             let memory_by_cpu = fit_longest_range(&mut parked[memory_by_cpu], self.cpu, |task| {
                 OrderedFloat(task.cpu)
             });
@@ -119,13 +119,13 @@ impl LimitsState {
                 break;
             }
 
-            // Check to see which subset is greater (for equivalence, use the one we don't
-            // need to refit for)
+            // Check to see which subset is greater (for equivalence, use the
+            // one we don't need to refit for)
             let range = if memory_by_cpu.len() >= cpu_by_memory_len {
                 memory_by_cpu
             } else {
-                // We need to refit because the above calculation of `memory_by_cpu` mutated the
-                // parked list
+                // We need to refit because the above calculation of
+                // `memory_by_cpu` mutated the parked list
                 let range = fit_longest_range(parked, self.cpu, |task| OrderedFloat(task.cpu));
                 fit_longest_range(&mut parked[range], self.memory, |task| task.memory)
             };
@@ -224,8 +224,9 @@ impl TaskManager {
                 let mut parked = {
                     let mut state = limits.0.lock().expect("failed to lock state");
 
-                    // If the task can't run due to unavailable resources, park the task until
-                    // resources are available
+                    // If the task can't run due to unavailable resources, park
+                    // the task until resources are
+                    // available
                     if cpu > state.cpu.into() || memory > state.memory {
                         debug!(
                             "parking task due to insufficient resources: task requests {cpu} \
@@ -250,7 +251,8 @@ impl TaskManager {
 
                         Some((notify_rx, id))
                     } else {
-                        // Decrement the resource counts now and continue on to run the task
+                        // Decrement the resource counts now and continue on to
+                        // run the task
                         state.cpu -= cpu;
                         state.memory -= memory;
 
@@ -296,14 +298,14 @@ impl TaskManager {
                     Some((_, id))
                         if let Some(index) = state.parked.iter().position(|t| t.id == id) =>
                     {
-                        // Task is still parked; remove it from set and do not increment the
-                        // resource counts
+                        // Task is still parked; remove it from set and do not
+                        // increment the resource counts
                         assert!(matches!(res, Ok(None)), "task should be canceled");
                         state.parked.swap_remove_back(index);
                     }
                     _ => {
-                        // Task was either not parked or previously unparked, increment the resource
-                        // counts
+                        // Task was either not parked or previously unparked,
+                        // increment the resource counts
                         state.cpu += cpu;
                         state.memory += memory;
                     }
@@ -380,7 +382,8 @@ where
     {
         assert!(low < high);
 
-        // Swap a random element (the pivot) in the remaining range with the high
+        // Swap a random element (the pivot) in the remaining range with the
+        // high
         slice.swap(high, rand::random_range(low..high));
 
         let pivot_weight = weight_fn(&slice[high]);
@@ -436,8 +439,8 @@ where
                 // Recurse on the right side
                 recurse_fit_maximal_range(slice, remaining_weight, weight_fn, pivot + 1, high, end);
             } else if pivot > 0 {
-                // Otherwise, we can completely disregard the right side (including the pivot)
-                // and recurse on the left
+                // Otherwise, we can completely disregard the right side
+                // (including the pivot) and recurse on the left
                 recurse_fit_maximal_range(slice, remaining_weight, weight_fn, low, pivot - 1, end);
             }
         }

--- a/crates/wdl-engine/src/backend/slurm_apptainer.rs
+++ b/crates/wdl-engine/src/backend/slurm_apptainer.rs
@@ -179,8 +179,8 @@ impl FromStr for JobState {
         // See https://slurm.schedmd.com/job_state_codes.html for base states
         // See https://slurm.schedmd.com/sacct.html for state flags recognized by `sacct`
 
-        // Job states may have extraneous information that follows them, so match by
-        // prefix
+        // Job states may have extraneous information that follows them, so
+        // match by prefix
         for (prefix, state) in [
             ("BOOT_FAIL", Self::BootFail),
             ("CANCELLED", Self::Canceled),
@@ -558,16 +558,16 @@ impl Monitor {
 
         let mut command = Command::new("sbatch");
 
-        // If a Slurm partition has been configured, specify it. Otherwise, the job will
-        // end up on the cluster's default partition.
+        // If a Slurm partition has been configured, specify it. Otherwise, the
+        // job will end up on the cluster's default partition.
         if let Some(partition) =
             config.slurm_partition_for_task(request.requirements, request.hints)
         {
             command.arg("--partition").arg(&partition.name);
         }
 
-        // If GPUs are required, use the gpu helper to determine the count and pass it
-        // to `sbatch` via `--gpus-per-task`.
+        // If GPUs are required, use the gpu helper to determine the count and
+        // pass it to `sbatch` via `--gpus-per-task`.
         if let Some(gpu_count) =
             requirements::gpu(request.inputs, request.requirements, request.hints)
         {
@@ -597,8 +597,9 @@ impl Monitor {
             }
         );
 
-        // The path for the Slurm-level stdout and stderr. This primarily contains the
-        // job report, as we redirect Apptainer and WDL output separately.
+        // The path for the Slurm-level stdout and stderr. This primarily
+        // contains the job report, as we redirect Apptainer and WDL
+        // output separately.
         let slurm_stdout_path = request.attempt_dir.join("slurm.stdout");
         let slurm_stderr_path = request.attempt_dir.join("slurm.stderr");
 
@@ -872,12 +873,13 @@ impl TaskExecutionBackend for SlurmApptainerBackend {
             .as_slurm_apptainer()
             .expect("configured backend is not Slurm Apptainer");
 
-        // Determine whether CPU or memory limits are set for this partition, and clamp
-        // or deny them as appropriate if the limits are exceeded
+        // Determine whether CPU or memory limits are set for this partition,
+        // and clamp or deny them as appropriate if the limits are
+        // exceeded
         //
-        // TODO ACF 2025-10-16: refactor so that we're not duplicating logic here (for
-        // the in-WDL `task` values) and below in `spawn` (for the actual
-        // resource request)
+        // TODO ACF 2025-10-16: refactor so that we're not duplicating logic
+        // here (for the in-WDL `task` values) and below in `spawn` (for
+        // the actual resource request)
         if let Some(partition) = backend_config.slurm_partition_for_task(requirements, hints) {
             if let Some(max_cpu) = partition.max_cpu_per_task
                 && required_cpu > max_cpu as f64

--- a/crates/wdl-engine/src/backend/tes.rs
+++ b/crates/wdl-engine/src/backend/tes.rs
@@ -197,7 +197,8 @@ impl TaskExecutionBackend for TesBackend {
                 hints::max_memory(request.inputs, request.hints)?.map(|m| m as f64 / ONE_GIBIBYTE);
 
             // Write the evaluated command to disk
-            // This is done even for remote execution so that a copy exists locally
+            // This is done even for remote execution so that a copy exists
+            // locally
             let command_path = request.command_path();
             if let Some(parent) = command_path.parent() {
                 fs::create_dir_all(parent).with_context(|| {
@@ -215,8 +216,8 @@ impl TaskExecutionBackend for TesBackend {
                 )
             })?;
 
-            // SAFETY: currently `inputs` is required by configuration validation, so it
-            // should always unwrap
+            // SAFETY: currently `inputs` is required by configuration
+            // validation, so it should always unwrap
             let inputs_url = Arc::new(
                 backend_config
                     .inputs
@@ -234,8 +235,8 @@ impl TaskExecutionBackend for TesBackend {
                     .build(),
             ];
 
-            // Spawn upload tasks for inputs available locally, and apply authentication to
-            // the URLs for remote inputs.
+            // Spawn upload tasks for inputs available locally, and apply
+            // authentication to the URLs for remote inputs.
             let mut uploads = JoinSet::new();
             for (i, input) in request.backend_inputs.iter().enumerate() {
                 match input.path().kind() {
@@ -273,7 +274,8 @@ impl TaskExecutionBackend for TesBackend {
                         });
                     }
                     EvaluationPathKind::Remote(url) => {
-                        // Input is already remote, add it to the Crankshaft inputs list
+                        // Input is already remote, add it to the Crankshaft
+                        // inputs list
                         backend_inputs.push(
                             Input::builder()
                                 .path(
@@ -291,9 +293,10 @@ impl TaskExecutionBackend for TesBackend {
                 }
             }
 
-            // Notify that the task is transferring inputs; for TES this covers both
-            // digesting each local input and uploading it to remote storage, which
-            // dominates the runtime of large inputs
+            // Notify that the task is transferring inputs; for TES this covers
+            // both digesting each local input and uploading it to
+            // remote storage, which dominates the runtime of large
+            // inputs
             if !uploads.is_empty()
                 && let Some(sender) = request.events.engine()
             {
@@ -327,8 +330,8 @@ impl TaskExecutionBackend for TesBackend {
                 timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S")
             );
 
-            // SAFETY: currently `outputs` is required by configuration validation, so it
-            // should always unwrap
+            // SAFETY: currently `outputs` is required by configuration
+            // validation, so it should always unwrap
             let outputs_url = backend_config
                 .outputs
                 .as_ref()
@@ -340,8 +343,8 @@ impl TaskExecutionBackend for TesBackend {
             let stdout_url = outputs_url.join(STDOUT_FILE_NAME).expect("should join");
             let stderr_url = outputs_url.join(STDERR_FILE_NAME).expect("should join");
 
-            // The TES backend will output three things: the working directory contents,
-            // stdout, and stderr.
+            // The TES backend will output three things: the working directory
+            // contents, stdout, and stderr.
             let outputs = vec![
                 Output::builder()
                     .path(GUEST_WORK_DIR)
@@ -360,8 +363,9 @@ impl TaskExecutionBackend for TesBackend {
                     .build(),
             ];
 
-            // Calculate the total size required for all disks as TES does not have a way of
-            // specifying volume sizes; a single disk will be created from which all volumes
+            // Calculate the total size required for all disks as TES does not
+            // have a way of specifying volume sizes; a single disk
+            // will be created from which all volumes
             // will be mounted
             let disks = &request.constraints.disks;
             let disk: f64 = if disks.is_empty() {
@@ -381,8 +385,8 @@ impl TaskExecutionBackend for TesBackend {
                 .keys()
                 .filter_map(|mp| {
                     // NOTE: the root mount point is already handled by the work
-                    // directory mount, so we filter it here to avoid duplicate volume
-                    // mapping.
+                    // directory mount, so we filter it here to avoid duplicate
+                    // volume mapping.
                     if mp == DEFAULT_DISK_MOUNT_POINT {
                         None
                     } else {
@@ -453,8 +457,8 @@ impl TaskExecutionBackend for TesBackend {
                 assert_eq!(results.len(), 1, "there should only be one output");
                 let result = results.into_iter().next().unwrap();
 
-                // Push an empty path segment so that future joins of the work directory URL
-                // treat it as a directory
+                // Push an empty path segment so that future joins of the work
+                // directory URL treat it as a directory
                 work_dir_url.path_segments_mut().unwrap().push("");
 
                 return Ok(Some(TaskExecutionResult {

--- a/crates/wdl-engine/src/cache.rs
+++ b/crates/wdl-engine/src/cache.rs
@@ -79,13 +79,15 @@ fn hash_command(request: &KeyRequest<'_>, input_digests: &[ArrayString<64>]) -> 
                     Some((index, len)) => {
                         let end = start + len;
 
-                        // If the backend input is cacheable, hash the input kind, content digest,
+                        // If the backend input is cacheable, hash the input
+                        // kind, content digest,
                         // and file name (non-temporary only)
                         let input = &request.backend_inputs[index];
                         if input.cacheable() {
                             input.kind().hash(&mut hasher);
 
-                            // Count the number of preceding non-cacheable inputs to offset by
+                            // Count the number of preceding non-cacheable
+                            // inputs to offset by
                             let offset = (0..index)
                                 .filter(|i| !request.backend_inputs[*i].cacheable())
                                 .count();
@@ -93,7 +95,8 @@ fn hash_command(request: &KeyRequest<'_>, input_digests: &[ArrayString<64>]) -> 
                             match input.kind() {
                                 ContentKind::File | ContentKind::Directory => {
                                     // Hash the file name
-                                    // SAFETY: guest paths are always Unix style and have a slash
+                                    // SAFETY: guest paths are always Unix style
+                                    // and have a slash
                                     let slash = start + current[start..end].rfind('/').unwrap();
                                     (&current[slash + 1..end]).hash(&mut hasher);
                                 }
@@ -526,7 +529,8 @@ impl CallCache {
         // Calculate the command digest
         let command_digest = hash_command(request, &inputs);
 
-        // Sort the input digests so that they can be easily compared with an entry
+        // Sort the input digests so that they can be easily compared with an
+        // entry
         inputs.sort();
 
         // Calculate the task's cache key
@@ -622,8 +626,8 @@ impl CallCache {
         let file = LockedFile::acquire_exclusive(&path).await?;
 
         // Truncate the file before attempting to serialize it
-        // If further operations fail, this guarantees that the cache entry will be
-        // invalidated
+        // If further operations fail, this guarantees that the cache entry will
+        // be invalidated
         file.set_len(0).with_context(|| {
             format!(
                 "failed to truncate call cache entry file `{path}`",
@@ -881,8 +885,8 @@ mod tests {
         cache.populate(&transferer, &request).await;
 
         // Change the input's guest path, but keep the file name the same
-        // The entry should be valid as the input's contents and file name remained the
-        // same
+        // The entry should be valid as the input's contents and file name
+        // remained the same
         let key = cache
             .inner
             .key(
@@ -963,8 +967,9 @@ mod tests {
         let transferer = DigestTransferer::default();
         cache.populate(&transferer, &request).await;
 
-        // Change the input's file name doesn't invalidate the entry because the file
-        // contents remained the same and file names are ignored for temporary files
+        // Change the input's file name doesn't invalidate the entry because the
+        // file contents remained the same and file names are ignored
+        // for temporary files
         let key = cache
             .inner
             .key(
@@ -1963,7 +1968,8 @@ mod tests {
         let transferer = DigestTransferer::default();
         cache.populate(&transferer, &request).await;
 
-        // Modify the `localization_optional` hint; this should not affect the entry
+        // Modify the `localization_optional` hint; this should not affect the
+        // entry
         let key = cache
             .inner
             .key(
@@ -2076,12 +2082,13 @@ mod tests {
         fs::write(&input_file_path, "changed!").await.unwrap();
         clear_digest_cache();
 
-        // Modify the `foo` input; this should not affect the entry as the backend input
-        // was excluded
+        // Modify the `foo` input; this should not affect the entry as the
+        // backend input was excluded
         let key = cache.inner.key(&transferer, &request).await.unwrap();
         cache.inner.get(&transferer, &key).await.unwrap().unwrap();
 
-        // Modify the `bar` input; the key should change and the entry should not exist
+        // Modify the `bar` input; the key should change and the entry should
+        // not exist
         let key = cache
             .inner
             .key(

--- a/crates/wdl-engine/src/cache/hash.rs
+++ b/crates/wdl-engine/src/cache/hash.rs
@@ -207,8 +207,9 @@ impl Hashable for Option<PrimitiveValue> {
         match self {
             Some(v) => v.hash(hasher),
             None => {
-                // A `None` for an optional primitive value (used in map keys) represents a WDL
-                // `None` value, so hash it as one
+                // A `None` for an optional primitive value (used in map keys)
+                // represents a WDL `None` value, so hash it as
+                // one
                 Value::None(NoneValue::untyped()).hash(hasher)
             }
         }

--- a/crates/wdl-engine/src/config.rs
+++ b/crates/wdl-engine/src/config.rs
@@ -1991,14 +1991,15 @@ impl Condition {
             }
 
             fn object_access(&self, object: &Object, name: &str) -> Option<Value> {
-                // If the object being accessed is not the hint object, let the access proceed
-                // normally
+                // If the object being accessed is not the hint object, let the
+                // access proceed normally
                 if !Arc::ptr_eq(&object.members, &self.0.hints.members) {
                     return None;
                 }
 
-                // Access to the hints object first checks for a hint override in the inputs and
-                // then falls back to the task's hints; if the name is not present in either, a
+                // Access to the hints object first checks for a hint override
+                // in the inputs and then falls back to the
+                // task's hints; if the name is not present in either, a
                 // `None` value is returned instead of an error
                 Some(
                     self.0
@@ -2073,12 +2074,13 @@ impl<'de> FromToml<'de> for Condition {
                     mapping[i].1
                 }
                 Err(i) => {
-                    // Not in the map, need to potentially offset the unescaped position
-                    // based on a preceding map entry
+                    // Not in the map, need to potentially offset the unescaped
+                    // position based on a preceding map
+                    // entry
                     unescaped
                         + if i == 0 {
-                            // No need to offset as this position comes before any
-                            // escape sequences
+                            // No need to offset as this position comes before
+                            // any escape sequences
                             0
                         } else {
                             // Offset by the last delta
@@ -2360,7 +2362,8 @@ impl LsfApptainerBackendConfig {
         // environment. These are a bit fraught, particularly if the behavior of
         // the external tools changes based on where a job gets dispatched, but
         // querying from the perspective of the current node allows
-        // us to get better error messages in circumstances typical to a cluster.
+        // us to get better error messages in circumstances typical to a
+        // cluster.
         if let Some(queue) = &self.default_lsf_queue {
             queue.validate("default").await?;
         }
@@ -2430,8 +2433,8 @@ impl LsfApptainerBackendConfig {
             return Some(queue);
         }
 
-        // Finally the default queue. If this is `None`, `bsub` gets run without a queue
-        // argument and the cluster's default is used.
+        // Finally the default queue. If this is `None`, `bsub` gets run without
+        // a queue argument and the cluster's default is used.
         self.default_lsf_queue.as_ref()
     }
 }
@@ -2590,7 +2593,8 @@ impl SlurmApptainerBackendConfig {
         // environment. These are a bit fraught, particularly if the behavior of
         // the external tools changes based on where a job gets dispatched, but
         // querying from the perspective of the current node allows
-        // us to get better error messages in circumstances typical to a cluster.
+        // us to get better error messages in circumstances typical to a
+        // cluster.
         if let Some(partition) = &self.default_slurm_partition {
             partition.validate("default").await?;
         }
@@ -2623,8 +2627,9 @@ impl SlurmApptainerBackendConfig {
         hints: &Object,
     ) -> Option<&SlurmPartitionConfig> {
         // TODO ACF 2025-09-26: what's the relationship between this code and
-        // `TaskExecutionConstraints`? Should this be there instead, or be pulling
-        // values from that instead of directly from `requirements` and `hints`?
+        // `TaskExecutionConstraints`? Should this be there instead, or be
+        // pulling values from that instead of directly from
+        // `requirements` and `hints`?
 
         // Specialized hardware gets priority.
         if let Some(partition) = self.fpga_slurm_partition.as_ref()
@@ -2652,8 +2657,9 @@ impl SlurmApptainerBackendConfig {
             return Some(partition);
         }
 
-        // Finally the default partition. If this is `None`, `sbatch` gets run without a
-        // partition argument and the cluster's default is used.
+        // Finally the default partition. If this is `None`, `sbatch` gets run
+        // without a partition argument and the cluster's default is
+        // used.
         self.default_slurm_partition.as_ref()
     }
 }
@@ -2936,8 +2942,8 @@ impl<T> ConfigBuilder<T> {
         // Merge the documents as TOML tables
         let mut merged_table: Table<'_> = Table::new();
         for (index, mut document) in documents.into_iter().enumerate() {
-            // Start by deserializing the document to ensure it is a valid standalone
-            // configuration
+            // Start by deserializing the document to ensure it is a valid
+            // standalone configuration
             document.to::<T>().map_err(|e| {
                 let (path, source) = &sources[index];
                 BuilderError::Deserialize {
@@ -3644,8 +3650,8 @@ type = 'lsf_apptainer'
         // Check a string with no escape sequences
         assert!(escape_mapping("hello world!").is_empty());
 
-        // Check for a string containing only an escape sequences (should contain an
-        // exclusive-end mapping)
+        // Check for a string containing only an escape sequences (should
+        // contain an exclusive-end mapping)
         assert_eq!(escape_mapping(r#"\"\""#), &[(1, 2), (2, 4)]);
         assert_eq!(escape_mapping(r#"\u0022\u0022"#), &[(1, 6), (2, 12)]);
         assert_eq!(

--- a/crates/wdl-engine/src/digest.rs
+++ b/crates/wdl-engine/src/digest.rs
@@ -156,8 +156,9 @@ async fn calculate_file_digest(path: &Path, mode: ContentDigestMode) -> Result<D
             .context("file digest task panicked")?
         }
         ContentDigestMode::Strongish => {
-            // Calculate a digest off of file metadata and a hash of only the first
-            // `STRONGISH_DIGEST_PREFIX_LEN` bytes of the file's contents
+            // Calculate a digest off of file metadata and a hash of only the
+            // first `STRONGISH_DIGEST_PREFIX_LEN` bytes of the
+            // file's contents
             let path = path.to_path_buf();
             spawn_blocking(move || {
                 let mut hasher = Hasher::new();
@@ -255,8 +256,9 @@ fn calculate_directory_digest(
                 )
             })?;
 
-            // For symlink entries, ensure the link isn't broken by retrieving the target's
-            // metadata; if it is broken, ignore it by not including it
+            // For symlink entries, ensure the link isn't broken by retrieving
+            // the target's metadata; if it is broken, ignore it by
+            // not including it
             if metadata.is_symlink() {
                 match fs::metadata(&entry_path) {
                     Ok(m) => metadata = m,
@@ -339,7 +341,8 @@ pub async fn calculate_local_digest(
                     }
 
                     // Always use a strong digest mode for temporary files
-                    // This will ensure that the file metadata is _not_ considered for the digest
+                    // This will ensure that the file metadata is _not_
+                    // considered for the digest
                     calculate_file_digest(
                         path,
                         if kind == ContentKind::TempFile {
@@ -418,8 +421,9 @@ pub async fn calculate_remote_digest(
                 let mut url = url.clone();
 
                 {
-                    // Append the entry to the url; we must pop the last segment if it is empty as
-                    // otherwise `push` will append another empty segment
+                    // Append the entry to the url; we must pop the last segment
+                    // if it is empty as otherwise `push`
+                    // will append another empty segment
                     let mut segments = url.path_segments_mut().expect("URL should have a path");
                     segments.pop_if_empty();
                     for segment in entry.split('/') {
@@ -694,7 +698,8 @@ pub(crate) mod test {
             "expected digests to match since they differ only past the strongish prefix length"
         );
 
-        // A strong digest, on the other hand, should be able to tell the difference
+        // A strong digest, on the other hand, should be able to tell the
+        // difference
         let digest_a = calculate_file_digest(a.path(), ContentDigestMode::Strong)
             .await
             .unwrap();
@@ -716,8 +721,8 @@ pub(crate) mod test {
         a.flush().unwrap();
         b.flush().unwrap();
 
-        // Regardless of the content digest mode, temporary files should _always_ use a
-        // strong digest
+        // Regardless of the content digest mode, temporary files should
+        // _always_ use a strong digest
         let digest_a =
             calculate_local_digest(a.path(), ContentKind::TempFile, ContentDigestMode::Weak)
                 .await
@@ -982,7 +987,8 @@ pub(crate) mod test {
         assert_eq!(digest, trailing_digest);
 
         // Digest of a remote "directory" that is "empty"
-        // We can't distinguish between a non-existent directory and an empty one
+        // We can't distinguish between a non-existent directory and an empty
+        // one
         let digest = calculate_remote_digest(
             &transferer,
             &"http://example.com/empty".parse().unwrap(),
@@ -995,8 +1001,8 @@ pub(crate) mod test {
         hasher.update(&0u32.to_le_bytes()); // Number of entries
         assert_eq!(digest.to_hex(), hasher.finalize().to_hex());
 
-        // Digest of a remote "directory" containing a file with a missing content
-        // digest
+        // Digest of a remote "directory" containing a file with a missing
+        // content digest
         assert_eq!(
             format!(
                 "{:#}",

--- a/crates/wdl-engine/src/eval.rs
+++ b/crates/wdl-engine/src/eval.rs
@@ -93,7 +93,8 @@ impl CancellationContextState {
         // Update the provided state with the new state
         let previous_state = state
             .try_update(Ordering::SeqCst, Ordering::SeqCst, |state| {
-                // If updating for an error and there has been a cancellation, bail out
+                // If updating for an error and there has been a cancellation,
+                // bail out
                 if error && state != CANCELLATION_STATE_NOT_CANCELED {
                     return None;
                 }

--- a/crates/wdl-engine/src/eval/trie.rs
+++ b/crates/wdl-engine/src/eval/trie.rs
@@ -123,7 +123,8 @@ impl InputTrie {
     ) -> Result<Option<usize>> {
         match base_dir.join(path)?.into_kind() {
             EvaluationPathKind::Local(path) => {
-                // Check to see if the path being inserted is already a guest path
+                // Check to see if the path being inserted is already a guest
+                // path
                 if let Some(dir) = self.guest_inputs_dir
                     && path.starts_with(dir)
                 {

--- a/crates/wdl-engine/src/eval/v1/expr.rs
+++ b/crates/wdl-engine/src/eval/v1/expr.rs
@@ -435,7 +435,8 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
         }
 
         async {
-            // Keep track of the start in case there is a `None` evaluated and an error
+            // Keep track of the start in case there is a `None` evaluated and
+            // an error
             let start = buffer.len();
 
             // Bump the placeholder count while evaluating the placeholder
@@ -443,12 +444,13 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
             let result = imp(self, placeholder, buffer).await;
             self.placeholders -= 1;
 
-            // Reset the evaluated none flag when we're done evaluating placeholders
+            // Reset the evaluated none flag when we're done evaluating
+            // placeholders
             if self.placeholders == 0 {
                 let evaluated_none = std::mem::replace(&mut self.evaluated_none, false);
 
-                // If a `None` was evaluated and an error occurred, truncate to the start of the
-                // placeholder evaluation
+                // If a `None` was evaluated and an error occurred, truncate to
+                // the start of the placeholder evaluation
                 if evaluated_none && result.is_err() {
                     buffer.truncate(start);
                     return Ok(());
@@ -860,8 +862,8 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
         let mut name = String::new();
         let value = self.evaluate_expr(&expr).await?;
 
-        // The first name should be an input/output and then the remainder should be a
-        // struct member
+        // The first name should be an input/output and then the remainder
+        // should be a struct member
         let mut span = None;
         let mut struct_ty: Option<&StructType> = None;
         while let Some((i, segment)) = segments.next() {
@@ -987,16 +989,17 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
 
         let (cond_expr, true_expr, false_expr) = expr.exprs();
 
-        // Evaluate the conditional expression and the true expression or the false
-        // expression, depending on the result of the conditional expression
+        // Evaluate the conditional expression and the true expression or the
+        // false expression, depending on the result of the conditional
+        // expression
         let cond = self.evaluate_expr(&cond_expr).await?;
         let (value, true_ty, false_ty) = if cond
             .coerce(Some(&self.context), &PrimitiveType::Boolean.into())
             .map_err(|_| if_conditional_mismatch(&cond.ty(), cond_expr.span()))?
             .unwrap_boolean()
         {
-            // Evaluate the `true` expression and calculate the type of the `false`
-            // expression
+            // Evaluate the `true` expression and calculate the type of the
+            // `false` expression
             let value = self.evaluate_expr(&true_expr).await?;
             let mut context = TypeContext {
                 context: &self.context,
@@ -1014,8 +1017,8 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
             let true_ty = value.ty();
             (value, true_ty, false_ty)
         } else {
-            // Evaluate the `false` expression and calculate the type of the `true`
-            // expression
+            // Evaluate the `false` expression and calculate the type of the
+            // `true` expression
             let value = self.evaluate_expr(&false_expr).await?;
             let mut context = TypeContext {
                 context: &self.context,
@@ -1312,8 +1315,8 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
             | (Value::None(_), Value::Primitive(PrimitiveValue::String(_)))
                 if op == NumericOperator::Addition && self.placeholders > 0 =>
             {
-                // Allow string concatenation with `None` in placeholders, which evaluates to
-                // `None`
+                // Allow string concatenation with `None` in placeholders, which
+                // evaluates to `None`
                 Some(Value::new_none(Type::None))
             }
             _ => None,
@@ -1344,7 +1347,8 @@ impl<C: EvaluationContext> ExprEvaluator<C> {
                     count += 1;
                 }
 
-                // First bind the function based on the argument types, then dispatch the call
+                // First bind the function based on the argument types, then
+                // dispatch the call
                 let types = &types[..count.min(MAX_PARAMETERS)];
                 let arguments = &arguments[..count.min(MAX_PARAMETERS)];
                 if count <= MAX_PARAMETERS {
@@ -1660,7 +1664,8 @@ fn parse_constant_value(target_ty: &Type, expr: &Expr) -> Option<Value> {
                     let (name, val_expr) = item.name_value();
                     let name_str = name.text().to_string();
 
-                    // Infer the type from the literal expression and recursively extract value
+                    // Infer the type from the literal expression and
+                    // recursively extract value
                     let inferred_ty = infer_type_from_literal(&val_expr)?;
                     let val = parse_constant_value(&inferred_ty, &val_expr)?;
                     Some((name_str, val))
@@ -1809,7 +1814,8 @@ pub(crate) mod test {
             _: &'a CancellationContext,
         ) -> BoxFuture<'a, Result<Location>> {
             async {
-                // For tests, redirect requests to example.com to files relative to the work dir
+                // For tests, redirect requests to example.com to files relative
+                // to the work dir
                 if source.authority() == "example.com" {
                     return Ok(Location::Path(
                         self.test_dir
@@ -1914,7 +1920,8 @@ pub(crate) mod test {
                 .into());
             }
 
-            // If the name is a reference to an enum, return it as a [`Value::TypeNameRef`].
+            // If the name is a reference to an enum, return it as a
+            // [`Value::TypeNameRef`].
             if let Some(ty) = self.env.enums.get(name) {
                 return Ok(TypeNameRefValue::new(
                     name,
@@ -2009,7 +2016,8 @@ pub(crate) mod test {
         let marker = parser.start();
         match v1::expr(&mut parser, marker) {
             Ok(()) => {
-                // This call to `next` is important as `next` adds any remaining buffered events
+                // This call to `next` is important as `next` adds any remaining
+                // buffered events
                 assert!(
                     parser.next().is_none(),
                     "parser is not finished; expected a single expression with no remaining tokens"
@@ -3599,8 +3607,8 @@ pub(crate) mod test {
 
     #[tokio::test]
     async fn call_expr() {
-        // This test will just check for errors; testing of the function implementations
-        // is in `stdlib.rs`
+        // This test will just check for errors; testing of the function
+        // implementations is in `stdlib.rs`
         let env = TestEnv::default();
         let diagnostic = eval_v1_expr(&env, V1::Zero, "min(1, 2)").await.unwrap_err();
         assert_eq!(

--- a/crates/wdl-engine/src/eval/v1/task.rs
+++ b/crates/wdl-engine/src/eval/v1/task.rs
@@ -453,14 +453,15 @@ impl<'a> State<'a> {
         temp_dir: &'a Path,
         task_name: String,
     ) -> Result<Self> {
-        // Tasks have a root scope (index 0), an output scope (index 1), and a `task`
-        // variable scope (index 2). The output scope inherits from the root scope and
-        // the task scope inherits from the output scope. Inputs and private
-        // declarations are evaluated into the root scope. Outputs are evaluated into
-        // the output scope. The task scope is used for evaluating expressions in both
-        // the command and output sections. Only the `task` variable in WDL 1.2 is
-        // introduced into the task scope; in previous WDL versions, the task scope will
-        // not have any local names.
+        // Tasks have a root scope (index 0), an output scope (index 1), and a
+        // `task` variable scope (index 2). The output scope inherits
+        // from the root scope and the task scope inherits from the
+        // output scope. Inputs and private declarations are evaluated
+        // into the root scope. Outputs are evaluated into the output
+        // scope. The task scope is used for evaluating expressions in both
+        // the command and output sections. Only the `task` variable in WDL 1.2
+        // is introduced into the task scope; in previous WDL versions,
+        // the task scope will not have any local names.
         let scopes = [
             Scope::default(),
             Scope::new(ROOT_SCOPE_INDEX),
@@ -545,8 +546,9 @@ impl<'a> State<'a> {
                 path,
                 cacheable,
             )? {
-                // Check to see if there's no guest path for a remote URL that needs to be
-                // localized; if so, we must localize it now
+                // Check to see if there's no guest path for a remote URL that
+                // needs to be localized; if so, we must
+                // localize it now
                 if self.evaluator.engine.backend().needs_local_inputs()
                     && self.backend_inputs.as_slice()[index].guest_path().is_none()
                     && is_supported_url(path.as_str())
@@ -585,9 +587,9 @@ impl<'a> State<'a> {
             });
         }
 
-        // Notify that the task is transferring inputs; this path localizes eagerly
-        // during input and declaration evaluation, before the task's sections are
-        // evaluated.
+        // Notify that the task is transferring inputs; this path localizes
+        // eagerly during input and declaration evaluation, before the
+        // task's sections are evaluated.
         self.evaluator.notify_task_localizing(&self.task_name);
 
         // Wait for the downloads to complete
@@ -645,16 +647,19 @@ impl<'a> State<'a> {
     /// path.
     fn host_path(&self, path: &GuestPath) -> Option<HostPath> {
         self.path_map.get_by_right(path).cloned().or_else(|| {
-            // A direct mapping between the guest and host wasn't found, so scan for a
-            // matching guest prefix
+            // A direct mapping between the guest and host wasn't found, so scan
+            // for a matching guest prefix
             for (host, guest) in self.path_map.iter() {
-                // Check to see if the provided guest path is prefixed by this entry
+                // Check to see if the provided guest path is prefixed by this
+                // entry
                 if let Some(remainder) = strip_path_prefix(path, guest) {
-                    // If the host is a URL, parse it and join it with the remainder
+                    // If the host is a URL, parse it and join it with the
+                    // remainder
                     if is_supported_url(host.as_str()) {
                         let mut host: Url = host.as_str().parse().ok()?;
 
-                        // Push a separator to force join to treat the path as a "directory"
+                        // Push a separator to force join to treat the path as a
+                        // "directory"
                         if let Ok(mut segments) = host.path_segments_mut() {
                             segments.pop_if_empty();
                             segments.push("");
@@ -688,8 +693,8 @@ impl<'a> State<'a> {
         };
 
         self.path_map.get_by_left(path).cloned().or_else(|| {
-            // A direct mapping between the guest and host wasn't found, so scan for a
-            // matching host prefix
+            // A direct mapping between the guest and host wasn't found, so scan
+            // for a matching host prefix
             for (host, guest) in self.path_map.iter() {
                 // Check to see if this host path entry is a URL
                 let host_url = if is_supported_url(host.as_str()) {
@@ -1036,7 +1041,8 @@ impl<'a> State<'a> {
             .version()
             .expect("document should have version");
 
-        // In WDL 1.3+, use `TASK_SCOPE_INDEX` to access task.attempt and task.previous
+        // In WDL 1.3+, use `TASK_SCOPE_INDEX` to access task.attempt and
+        // task.previous
         let scope_index = if version >= SupportedVersion::V1(V1::Three) {
             TASK_SCOPE_INDEX
         } else {
@@ -1153,8 +1159,8 @@ impl<'a> State<'a> {
             .parameter_metadata()
             .map(|s| Object::from_v1_metadata(s.items()))
             .unwrap_or_else(Object::empty);
-        // Note: Sprocket does not currently support workflow-level extension metadata,
-        // so `ext` is always an empty object.
+        // Note: Sprocket does not currently support workflow-level extension
+        // metadata, so `ext` is always an empty object.
         let task_ext = Object::empty();
 
         // In WDL 1.3+, insert a [`TaskPreEvaluation`] before evaluating the
@@ -1315,11 +1321,13 @@ impl<'a> State<'a> {
                 self.base_dir.as_local(),
                 Some(self.evaluator.engine.transferer()),
                 &|path| {
-                    // To be a valid output, the output must be one of the following:
+                    // To be a valid output, the output must be one of the
+                    // following:
                     // * the path to the `stdout` file
                     // * the path to the `stderr` file
                     // * a known input path
-                    // * prefixed with the work directory (when the backend uses containers)
+                    // * prefixed with the work directory (when the backend uses
+                    //   containers)
 
                     // Check for a reference to the stdout/stderr files
                     if path.as_str() == evaluated.stdout().as_file().unwrap().as_str()
@@ -1333,7 +1341,8 @@ impl<'a> State<'a> {
                         return Ok(host);
                     }
 
-                    // Otherwise, if this is already a host path to a known input, return it
+                    // Otherwise, if this is already a host path to a known
+                    // input, return it
                     if self.guest_path(path).is_some() {
                         return Ok(path.clone());
                     }
@@ -1415,8 +1424,8 @@ impl<'a> State<'a> {
                 }
             }
 
-            // Notify that the task is transferring inputs, but only when there is
-            // something to transfer
+            // Notify that the task is transferring inputs, but only when there
+            // is something to transfer
             if !downloads.is_empty() {
                 self.evaluator.notify_task_localizing(&self.task_name);
             }
@@ -1608,9 +1617,9 @@ impl Evaluator {
         // Write the inputs to the task's root directory
         write_json_file(task_eval_root.join(INPUTS_FILE), &inputs)?;
 
-        // Mint the name for the first attempt before any of the task's work begins,
-        // so that even localization performed while evaluating inputs and
-        // declarations is attributable to the task.
+        // Mint the name for the first attempt before any of the task's work
+        // begins, so that even localization performed while evaluating
+        // inputs and declarations is attributable to the task.
         let mut state = State::new(self, document, task, &temp_dir, self.generate_task_name(id))?;
         self.notify_task_initializing(id, &state.task_name);
         let nodes = toposort(&graph, None).expect("graph should be acyclic");
@@ -1675,8 +1684,8 @@ impl Evaluator {
                 )
                 .await?;
 
-            // Get the maximum number of retries, either from the task's requirements or
-            // from configuration
+            // Get the maximum number of retries, either from the task's
+            // requirements or from configuration
             let max_retries =
                 requirements::max_retries(&inputs, &requirements, self.engine.config())?;
 
@@ -1695,11 +1704,13 @@ impl Evaluator {
                 && let Some(cache) = self.engine.call_cache()
             {
                 if hints::cacheable(&inputs, &hints, self.engine.config()) {
-                    // The configured default container is only part of the cache key
-                    // when the task has no `container` requirement of its own. When
-                    // the task does specify `container`, the requirement is already
-                    // covered by the `requirements` digest, so including the default
-                    // here would be redundant; when it doesn't, a change to the
+                    // The configured default container is only part of the
+                    // cache key when the task has no
+                    // `container` requirement of its own. When
+                    // the task does specify `container`, the requirement is
+                    // already covered by the `requirements`
+                    // digest, so including the default here
+                    // would be redundant; when it doesn't, a change to the
                     // configured default must invalidate the cache entry.
                     let default_container =
                         if requirements::has_container_requirement(&inputs, &requirements) {
@@ -1796,7 +1807,8 @@ impl Evaluator {
                             });
                         }
 
-                        // We're serving the results from the call cache; no need to update, so set
+                        // We're serving the results from the call cache; no
+                        // need to update, so set
                         // the key to `None`
                         key = None;
                         Some(results)
@@ -1895,7 +1907,8 @@ impl Evaluator {
                 attempt += 1;
 
                 if let Some(task) = state.scopes[TASK_SCOPE_INDEX.0].names.get(TASK_VAR_NAME) {
-                    // SAFETY: task variable should always be TaskPostEvaluation at this point
+                    // SAFETY: task variable should always be TaskPostEvaluation
+                    // at this point
                     let task = task.as_task_post_evaluation().unwrap();
                     previous_task_data = Some(task.data().clone());
                 }
@@ -1908,8 +1921,8 @@ impl Evaluator {
             }
 
             // Remap any guest symbolic links to the corresponding host paths
-            // This must occur *before* we put the result in the cache to ensure consistent
-            // work directory digesting
+            // This must occur *before* we put the result in the cache to ensure
+            // consistent work directory digesting
             if !cached && let Err(e) = self.remap_links(&state, &result.work_dir) {
                 return Err(EvaluationError::new(
                     state.document.clone(),
@@ -1948,8 +1961,8 @@ impl Evaluator {
             break EvaluatedTask::new(cached, result, None);
         };
 
-        // Evaluate the remaining inputs (unused), private decls, and outputs if the
-        // task executed successfully
+        // Evaluate the remaining inputs (unused), private decls, and outputs if
+        // the task executed successfully
         if !evaluated.failed() {
             for index in &nodes[current..] {
                 match &graph[*index] {
@@ -2074,7 +2087,8 @@ impl Evaluator {
             // Get the corresponding host path (lookup can't fail)
             let host = state.path_map.get_by_right(guest).unwrap();
 
-            // Check for a host path that is a URL and use the localized path instead
+            // Check for a host path that is a URL and use the localized path
+            // instead
             let base_host_path =
                 if self.engine.backend().needs_local_inputs() && is_supported_url(host.as_str()) {
                     state
@@ -2801,7 +2815,8 @@ task test {
             "expected second run to skip execution"
         );
 
-        // Now evaluate the swapped source; it should be treated as a modified command
+        // Now evaluate the swapped source; it should be treated as a modified
+        // command
         let evaluated = evaluate_task(config, root_dir.path(), SWAPPED_SOURCE).await;
         assert!(!evaluated.cached());
         assert_eq!(evaluated.exit_code(), 0);
@@ -2914,10 +2929,10 @@ task test {
             "expected second run to skip execution"
         );
 
-        // Evaluate the modified source; it should still be cached despite the different
-        // input value and file contents.
-        // Note: that the contents of `foo.txt` is returned because the modified input
-        // was excluded
+        // Evaluate the modified source; it should still be cached despite the
+        // different input value and file contents.
+        // Note: that the contents of `foo.txt` is returned because the modified
+        // input was excluded
         let evaluated = evaluate_task(config.clone(), root_dir.path(), MODIFIED_SOURCE).await;
         assert!(evaluated.cached());
         assert_eq!(evaluated.exit_code(), 0);
@@ -2932,8 +2947,8 @@ task test {
             ""
         );
 
-        // Change the not excluded file; this should invalidate the entry and rerun the
-        // task with the previously modified excluded input
+        // Change the not excluded file; this should invalidate the entry and
+        // rerun the task with the previously modified excluded input
         fs::write(root_dir.path().join("not.txt"), "modified!").unwrap();
         clear_digest_cache();
         let evaluated = evaluate_task(config, root_dir.path(), MODIFIED_SOURCE).await;
@@ -3031,8 +3046,8 @@ task test {
         fs::write(root_dir.path().join("foo.txt"), "modified!").unwrap();
         clear_digest_cache();
 
-        // The cache entry should be invalidated because `not_excluded` was ultimately
-        // modified
+        // The cache entry should be invalidated because `not_excluded` was
+        // ultimately modified
         let evaluated = evaluate_task(config.clone(), root_dir.path(), SOURCE).await;
         assert!(!evaluated.cached());
         assert_eq!(evaluated.exit_code(), 0);

--- a/crates/wdl-engine/src/eval/v1/task/requirements.rs
+++ b/crates/wdl-engine/src/eval/v1/task/requirements.rs
@@ -283,7 +283,8 @@ pub(crate) fn gpu(inputs: &TaskInputs, requirements: &Object, hints: &Object) ->
         return Some(DEFAULT_GPU_COUNT);
     };
 
-    // A string `gpu` hint is allowed by the spec, but we do not support them yet.
+    // A string `gpu` hint is allowed by the spec, but we do not support them
+    // yet.
     //
     // TODO(clay): support string hints for GPU specifications.
     if let Some(hint) = hint.as_string() {
@@ -307,8 +308,8 @@ pub(crate) fn gpu(inputs: &TaskInputs, requirements: &Object, hints: &Object) ->
             None
         }
         None => {
-            // Typechecking should have already validated that the hint is an integer or
-            // a string.
+            // Typechecking should have already validated that the hint is an
+            // integer or a string.
             unreachable!("`{TASK_HINT_GPU}` hint must be an integer or string")
         }
     }
@@ -373,8 +374,8 @@ pub(crate) fn disks<'a>(
             }
 
             if let Some(map) = v.as_map() {
-                // Find the corresponding key; we have to scan the keys because the map is
-                // storing primitive values
+                // Find the corresponding key; we have to scan the keys because
+                // the map is storing primitive values
                 if let Some((_, v)) = map.iter().find(|(k, _)| match (k, mount_point) {
                     (_, None) => false,
                     (k, Some(mount_point)) => k
@@ -424,15 +425,17 @@ pub(crate) fn disks<'a>(
                 Some((size.parse().ok()?, None))
             }
             (Some(first), Some(second), None) => {
-                // Check for `<size> <unit>`; convert from the specified unit to GiB
+                // Check for `<size> <unit>`; convert from the specified unit to
+                // GiB
                 if let Ok(size) = first.parse() {
                     let unit: StorageUnit = second.parse().ok()?;
                     let size = unit.bytes(size)? / (ONE_GIBIBYTE as u64);
                     return Some((size.try_into().ok()?, None));
                 }
 
-                // Specification is `<mount-point> <size>` (where size is already in GiB)
-                // The mount point must be absolute, i.e. start with `/`
+                // Specification is `<mount-point> <size>` (where size is
+                // already in GiB) The mount point must be
+                // absolute, i.e. start with `/`
                 if !first.starts_with('/') {
                     return None;
                 }

--- a/crates/wdl-engine/src/eval/v1/workflow.rs
+++ b/crates/wdl-engine/src/eval/v1/workflow.rs
@@ -516,8 +516,8 @@ impl Subgraph {
                 assert!(prev.is_none());
             }
 
-            // Decrement the indegree the nodes connected to the entry as we're not
-            // including it in the subgraph
+            // Decrement the indegree the nodes connected to the entry as we're
+            // not including it in the subgraph
             for edge in graph.edges_directed(entry, Direction::Outgoing) {
                 if edge.target() != exit {
                     *nodes
@@ -526,7 +526,8 @@ impl Subgraph {
                 }
             }
 
-            // Set the exit node to an indegree of 1 (incoming from the entry node)
+            // Set the exit node to an indegree of 1 (incoming from the entry
+            // node)
             *parent.get_mut(&exit).expect("should have exit node") = 1;
             nodes
         }
@@ -693,8 +694,9 @@ impl Evaluator {
         // Build an evaluation graph for the workflow
         let mut diagnostics = Diagnostics::default();
 
-        // We need to provide inputs to the workflow graph builder to avoid adding
-        // dependency edges from the default expressions if a value was provided
+        // We need to provide inputs to the workflow graph builder to avoid
+        // adding dependency edges from the default expressions if a
+        // value was provided
         let graph = WorkflowGraphBuilder::default().build(
             &definition,
             &mut diagnostics,
@@ -710,7 +712,8 @@ impl Evaluator {
         let mut subgraph = Subgraph::new(&graph);
         let subgraphs = subgraph.split(&graph);
 
-        // Create the temp directory now as it may be needed for workflow evaluation
+        // Create the temp directory now as it may be needed for workflow
+        // evaluation
         let temp_dir = eval_root_dir.join("tmp");
         fs::create_dir_all(&temp_dir).with_context(|| {
             format!(
@@ -799,7 +802,8 @@ impl State {
                     Ok(())
                 }
                 Err(e) => {
-                    // Perform a cancellation and wait for the futures to complete
+                    // Perform a cancellation and wait for the futures to
+                    // complete
                     cancellation.error(&e);
                     futures.join_all().await;
                     Err(e)
@@ -888,8 +892,8 @@ impl State {
                 awaiting.remove(&node);
                 subgraph.remove_node(&self.graph, node);
 
-                // Continue to see if we can progress further in the subgraph; if not we'll
-                // await more futures
+                // Continue to see if we can progress further in the subgraph;
+                // if not we'll await more futures
                 continue;
             }
 
@@ -942,7 +946,8 @@ impl State {
                                     Ok(node)
                                 }
                                 Err(e) => {
-                                    // Perform a cancellation and wait for the futures to complete
+                                    // Perform a cancellation and wait for the
+                                    // futures to complete
                                     cancellation.error(&e);
                                     futures.join_all().await;
                                     Err(e)
@@ -964,7 +969,8 @@ impl State {
                     WorkflowGraphNode::ConditionalClause(..)
                     | WorkflowGraphNode::ExitConditional(_)
                     | WorkflowGraphNode::ExitScatter(_) => {
-                        // Handled directly in `evaluate_conditional` and `evaluate_scatter`
+                        // Handled directly in `evaluate_conditional` and
+                        // `evaluate_scatter`
                         continue;
                     }
                 }
@@ -1360,8 +1366,8 @@ impl State {
             "no conditional statement branch was taken"
         );
 
-        // All conditionals evaluated to false; set the expected names to `None` in the
-        // parent scope.
+        // All conditionals evaluated to false; set the expected names to `None`
+        // in the parent scope.
         let mut scopes = self.scopes.write().await;
         let parent = scopes.get_mut(parent);
 
@@ -1411,8 +1417,8 @@ impl State {
                 .expect("should have a future to wait on")
                 .expect("failed to join future")?;
 
-            // Append the result to the gather (the first two variables in scope are always
-            // the scatter index and variable)
+            // Append the result to the gather (the first two variables in scope
+            // are always the scatter index and variable)
             let mut scopes = scopes.write().await;
             for (name, value) in scopes.get_mut(scope).local().skip(2) {
                 match gathers.get_mut(name) {
@@ -1458,7 +1464,8 @@ impl State {
             })?
             .as_slice();
 
-        // If the array is empty, evaluate it specially to promote empty arrays/calls
+        // If the array is empty, evaluate it specially to promote empty
+        // arrays/calls
         if array.is_empty() {
             return self.evaluate_empty_scatter(stmt, parent).await;
         }
@@ -1496,7 +1503,8 @@ impl State {
                 });
             }
 
-            // If we've reached the concurrency limit, await one of the futures to complete
+            // If we've reached the concurrency limit, await one of the futures
+            // to complete
             if futures.len() as u64 >= max_concurrency {
                 await_next(futures, &self.scopes, &mut gathers, array.len()).await?;
             }
@@ -1507,7 +1515,8 @@ impl State {
             await_next(futures, &self.scopes, &mut gathers, array.len()).await?;
         }
 
-        // Return an error if all the tasks completed but there was a cancellation
+        // Return an error if all the tasks completed but there was a
+        // cancellation
         if self.evaluator.cancellation.state() != CancellationContextState::NotCanceled {
             return Err(EvaluationError::Canceled);
         }
@@ -1543,11 +1552,12 @@ impl State {
         let mut scopes = self.scopes.write().await;
         let scope = scopes.get_mut(parent);
 
-        // Iterate through the names, skipping the first which is always the scatter
-        // variable
+        // Iterate through the names, skipping the first which is always the
+        // scatter variable
         for (name, local) in stmt_scope.names().skip(1) {
             let value: Value = if let Type::Call(call_ty) = local.ty() {
-                // Value is a call; promote all of the call's output as empty arrays
+                // Value is a call; promote all of the call's output as empty
+                // arrays
                 CallValue::new_unchecked(
                     call_ty.clone(),
                     Outputs::from_iter(call_ty.outputs().iter().map(|(n, o)| {
@@ -1682,7 +1692,8 @@ impl State {
             ));
         }
 
-        // Determine the inputs and evaluator to use for the task or workflow call
+        // Determine the inputs and evaluator to use for the task or workflow
+        // call
         let inputs = self.inputs.calls().get(alias.text()).cloned();
         let mut document = namespace
             .as_ref()
@@ -1947,7 +1958,8 @@ workflow test {
         let evaluator =
             engine.create_v1_evaluator(Events::disabled(), CancellationContext::default());
 
-        // Evaluate the `test` workflow in `source.wdl` using the default local backend
+        // Evaluate the `test` workflow in `source.wdl` using the default local
+        // backend
         let mut inputs = WorkflowInputs::default();
         inputs.set("a", "qux".to_string());
         inputs.set("b", 1234);
@@ -2404,8 +2416,8 @@ workflow foo {
 
     #[tokio::test]
     async fn it_reports_progress() {
-        // Create two test WDL files: one with a no-op workflow to be called and another
-        // with a no-op task to be called
+        // Create two test WDL files: one with a no-op workflow to be called and
+        // another with a no-op task to be called
         let root_dir = TempDir::new().expect("failed to create temporary directory");
         fs::write(
             root_dir.path().join("other.wdl"),
@@ -2464,7 +2476,8 @@ workflow w {
             tasks_completed: AtomicUsize,
         }
 
-        // Use a progress callback that simply increments the appropriate counter
+        // Use a progress callback that simply increments the appropriate
+        // counter
         let state = Arc::<State>::default();
         let events_state = state.clone();
         let events = Events::new(100);

--- a/crates/wdl-engine/src/http.rs
+++ b/crates/wdl-engine/src/http.rs
@@ -259,7 +259,8 @@ impl Transferer for HttpTransferer {
                             .context("failed to create temporary file")?
                             .into_temp_path();
 
-                        // Perform the download (always overwrite the local temp file)
+                        // Perform the download (always overwrite the local temp
+                        // file)
                         cloud_copy::copy(
                             self.0.config.clone(),
                             self.0.client.clone(),

--- a/crates/wdl-engine/src/inputs.rs
+++ b/crates/wdl-engine/src/inputs.rs
@@ -379,9 +379,9 @@ impl TaskInputs {
                     return Ok(true);
                 }
 
-                // Auto-wrap a non-array value in a single-element array when the
-                // expected type is an array and the value is coercible to the
-                // element type.
+                // Auto-wrap a non-array value in a single-element array when
+                // the expected type is an array and the value
+                // is coercible to the element type.
                 let value = if let Some(arr_ty) = expected.as_array()
                     && !matches!(&value, Value::Compound(CompoundValue::Array(_)))
                     && value.ty().is_coercible_to(arr_ty.element_type())
@@ -1042,8 +1042,8 @@ impl Inputs {
             return Ok(None);
         }
 
-        // Otherwise, build a set of candidate targets from the prefixes of each input
-        // key.
+        // Otherwise, build a set of candidate targets from the prefixes of each
+        // input key.
         let mut target_candidates = BTreeSet::new();
         for key in object.keys() {
             let Some((prefix, _)) = key.split_once('.') else {
@@ -1055,8 +1055,8 @@ impl Inputs {
             target_candidates.insert(prefix);
         }
 
-        // If every prefix is the same, there will be only one candidate. If not, report
-        // an error.
+        // If every prefix is the same, there will be only one candidate. If
+        // not, report an error.
         let target_name = match target_candidates
             .iter()
             .take(2)
@@ -1099,8 +1099,9 @@ impl Inputs {
                         .with_context(|| format!("invalid input key `{key}`"))?;
                 }
                 _ => {
-                    // This should be caught by the initial check of the prefixes in
-                    // `parse_json_object()`, but we retain a friendly error message in case this
+                    // This should be caught by the initial check of the
+                    // prefixes in `parse_json_object()`,
+                    // but we retain a friendly error message in case this
                     // function gets called from another context in the future.
                     bail!(
                         "invalid input key `{key}`: expected key to be prefixed with `{task}`",
@@ -1132,8 +1133,9 @@ impl Inputs {
                         .with_context(|| format!("invalid input key `{key}`"))?;
                 }
                 _ => {
-                    // This should be caught by the initial check of the prefixes in
-                    // `parse_json_object()`, but we retain a friendly error message in case this
+                    // This should be caught by the initial check of the
+                    // prefixes in `parse_json_object()`,
+                    // but we retain a friendly error message in case this
                     // function gets called from another context in the future.
                     bail!(
                         "invalid input key `{key}`: expected key to be prefixed with `{workflow}`",

--- a/crates/wdl-engine/src/lock.rs
+++ b/crates/wdl-engine/src/lock.rs
@@ -41,8 +41,8 @@ impl LockedFile {
                     format!("failed to create file `{path}`", path = path.display())
                 })?;
 
-                // Re-open the file as readable as the lock is shared and we don't want the file
-                // to be writable
+                // Re-open the file as readable as the lock is shared and we
+                // don't want the file to be writable
                 fs::File::open(path).with_context(|| {
                     format!("failed to open file `{path}`", path = path.display())
                 })?
@@ -89,8 +89,8 @@ impl LockedFile {
     /// If the file does not exist, it is created.
     pub async fn acquire_exclusive(path: impl AsRef<Path>) -> Result<Self> {
         let path = path.as_ref();
-        // Create or open the file, but do not truncate it if it exists before the lock
-        // is acquired
+        // Create or open the file, but do not truncate it if it exists before
+        // the lock is acquired
         let mut options = fs::OpenOptions::new();
         options.create(true).write(true);
         let file = options

--- a/crates/wdl-engine/src/outputs.rs
+++ b/crates/wdl-engine/src/outputs.rs
@@ -42,8 +42,8 @@ impl Outputs {
 
     /// Sorts the outputs according to a callback.
     pub(crate) fn sort_by(&mut self, mut cmp: impl FnMut(&str, &str) -> Ordering) {
-        // We can sort unstable as none of the keys are equivalent in ordering; thus the
-        // resulting sort is still considered to be stable
+        // We can sort unstable as none of the keys are equivalent in ordering;
+        // thus the resulting sort is still considered to be stable
         self.values.sort_unstable_by(move |a, _, b, _| {
             let ordering = cmp(a, b);
             assert_ne!(ordering, Ordering::Equal);

--- a/crates/wdl-engine/src/stdlib/glob.rs
+++ b/crates/wdl-engine/src/stdlib/glob.rs
@@ -95,10 +95,12 @@ fn glob_local_path(
             } else {
                 // Currently this is at odd with the 1.3 spec, specifically:
                 //
-                // `Broken symlinks (those that point to non-existent targets) are included.`
+                // `Broken symlinks (those that point to non-existent targets)
+                // are included.`
                 //
-                // However, since this function returns `Array[File]` and 1.3 also says that
-                // non-optional files should exist, including them doesn't seem appropriate.
+                // However, since this function returns `Array[File]` and 1.3
+                // also says that non-optional files should
+                // exist, including them doesn't seem appropriate.
                 //
                 // For now, we'll exclude them until that matter is resolved.
                 false

--- a/crates/wdl-engine/src/stdlib/join_paths.rs
+++ b/crates/wdl-engine/src/stdlib/join_paths.rs
@@ -80,9 +80,9 @@ fn join_paths_simple(context: CallContext<'_>) -> Result<Value, Diagnostic> {
             ));
         }
 
-        // For consistency with `PathBuf::push`, push an empty segment so that we treat
-        // the last segment as a directory; otherwise, `Url::join` will treat it as a
-        // file.
+        // For consistency with `PathBuf::push`, push an empty segment so that
+        // we treat the last segment as a directory; otherwise,
+        // `Url::join` will treat it as a file.
         if let Ok(mut segments) = url.path_segments_mut() {
             segments.pop_if_empty();
             segments.push("");
@@ -199,9 +199,9 @@ fn join_paths(context: CallContext<'_>) -> Result<Value, Diagnostic> {
                 ));
             }
 
-            // For consistency with `PathBuf::push`, push an empty segment so that we treat
-            // the last segment as a directory; otherwise, `Url::join` will treat it as a
-            // file.
+            // For consistency with `PathBuf::push`, push an empty segment so
+            // that we treat the last segment as a directory;
+            // otherwise, `Url::join` will treat it as a file.
             if let Ok(mut segments) = url.path_segments_mut() {
                 segments.pop_if_empty();
                 segments.push("");

--- a/crates/wdl-engine/src/stdlib/read_tsv.rs
+++ b/crates/wdl-engine/src/stdlib/read_tsv.rs
@@ -156,8 +156,8 @@ fn read_tsv(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>
 
         let mut lines = BufReader::new(file).lines();
 
-        // Read the file header if there is one; ignore it if the header was directly
-        // specified.
+        // Read the file header if there is one; ignore it if the header was
+        // directly specified.
         let file_has_header = context
             .coerce_argument(1, PrimitiveType::Boolean)
             .unwrap_boolean();

--- a/crates/wdl-engine/src/stdlib/size.rs
+++ b/crates/wdl-engine/src/stdlib/size.rs
@@ -69,12 +69,14 @@ fn size(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnostic>> {
         // directory and treat it as such.
         let value = match context.arguments[0].value.as_string() {
             Some(_) => {
-                // Coerce the string to a file to ensure we do any guest-to-host translation
+                // Coerce the string to a file to ensure we do any guest-to-host
+                // translation
                 let path = context
                     .coerce_argument(0, PrimitiveType::File)
                     .unwrap_file();
 
-                // If the path is a URL that isn't `file` schemed, treat as a file
+                // If the path is a URL that isn't `file` schemed, treat as a
+                // file
                 if !is_file_url(path.as_str()) && is_supported_url(path.as_str()) {
                     PrimitiveValue::File(path).into()
                 } else {

--- a/crates/wdl-engine/src/stdlib/write_lines.rs
+++ b/crates/wdl-engine/src/stdlib/write_lines.rs
@@ -47,7 +47,8 @@ fn write_lines(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagnost
             .coerce_argument(0, ANALYSIS_STDLIB.array_string_type().clone())
             .unwrap_array();
 
-        // Create a temporary file that will be persisted after writing the lines
+        // Create a temporary file that will be persisted after writing the
+        // lines
         let (file, path) = NamedTempFile::with_prefix_in("tmp", context.temp_dir())
             .map_err(|e| {
                 function_call_failed(

--- a/crates/wdl-engine/src/stdlib/write_objects.rs
+++ b/crates/wdl-engine/src/stdlib/write_objects.rs
@@ -69,8 +69,8 @@ fn write_objects(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Diagno
             .expect("expected an array type for the argument")
             .element_type();
 
-        // If it's an array of objects, we need to ensure each object has the exact same
-        // member names
+        // If it's an array of objects, we need to ensure each object has the
+        // exact same member names
         let mut empty = array.is_empty();
         if matches!(element_type, Type::Object) {
             let mut iter = array.as_slice().iter();

--- a/crates/wdl-engine/src/stdlib/write_tsv.rs
+++ b/crates/wdl-engine/src/stdlib/write_tsv.rs
@@ -269,8 +269,8 @@ fn write_tsv_struct(context: CallContext<'_>) -> BoxFuture<'_, Result<Value, Dia
 
         let mut writer = BufWriter::new(fs::File::from(file));
 
-        // Get the struct type to print the columns; we need to do this even when the
-        // array is empty
+        // Get the struct type to print the columns; we need to do this even
+        // when the array is empty
         let rows_ty = rows.ty();
         let ty = match rows_ty.as_array() {
             Some(ty) => ty

--- a/crates/wdl-engine/src/tree.rs
+++ b/crates/wdl-engine/src/tree.rs
@@ -115,9 +115,10 @@ impl SyntaxNode {
     ///
     /// Returns `None` if there is no sibling node.
     pub fn next_sibling(&self) -> Option<SyntaxNode> {
-        // This should also be a constant-time access rather than having to iterate.
-        // We need the offset relative to the start of the parent from the green node to
-        // do that; currently that information is private in `rowan`.
+        // This should also be a constant-time access rather than having to
+        // iterate. We need the offset relative to the start of the
+        // parent from the green node to do that; currently that
+        // information is private in `rowan`.
 
         let parent = self.parent()?;
         let mut children = parent.children();
@@ -135,9 +136,10 @@ impl SyntaxNode {
     ///
     /// Returns `None` if there is no sibling node or token.
     pub fn next_sibling_or_token(&self) -> Option<SyntaxElement> {
-        // This should also be a constant-time access rather than having to iterate.
-        // We need the offset relative to the start of the parent from the green node to
-        // do that; currently that information is private in `rowan`.
+        // This should also be a constant-time access rather than having to
+        // iterate. We need the offset relative to the start of the
+        // parent from the green node to do that; currently that
+        // information is private in `rowan`.
 
         let parent = self.parent()?;
         let mut children = parent.children_with_tokens();
@@ -246,9 +248,10 @@ impl TreeNode for SyntaxNode {
     }
 
     fn last_token(&self) -> Option<Self::Token> {
-        // Unfortunately `rowan` does not expose the relative offset of each green
-        // child. If it did, we could easily just look at the last child here
-        // instead of iterating to find the last child's start.
+        // Unfortunately `rowan` does not expose the relative offset of each
+        // green child. If it did, we could easily just look at the last
+        // child here instead of iterating to find the last child's
+        // start.
         let mut last: Option<(usize, NodeOrToken<&GreenNodeData, &GreenTokenData>)> = None;
         let mut start = self.0.offset;
 
@@ -343,9 +346,9 @@ impl SyntaxToken {
     ///
     /// Returns `None` if there is no next sibling node or token.
     pub fn next_sibling_or_token(&self) -> Option<SyntaxElement> {
-        // This should also be a constant-time access rather than having to iterate.
-        // We need the offset relative to the start of the parent from the green node to
-        // do that.
+        // This should also be a constant-time access rather than having to
+        // iterate. We need the offset relative to the start of the
+        // parent from the green node to do that.
 
         let parent = self.parent();
         let mut children = parent.children_with_tokens();

--- a/crates/wdl-engine/src/value.rs
+++ b/crates/wdl-engine/src/value.rs
@@ -847,14 +847,16 @@ impl Value {
         match self {
             Self::Primitive(v @ PrimitiveValue::File(path))
             | Self::Primitive(v @ PrimitiveValue::Directory(path)) => {
-                // We treat file and directory paths almost entirely the same, other than when
-                // reporting errors and choosing which variant to return in the result
+                // We treat file and directory paths almost entirely the same,
+                // other than when reporting errors and choosing
+                // which variant to return in the result
                 let is_file = v.as_file().is_some();
                 let path = translate(path)?;
 
                 if path::is_file_url(path.as_str()) {
-                    // File URLs must be absolute paths, so we just check whether it exists without
-                    // performing any joining
+                    // File URLs must be absolute paths, so we just check
+                    // whether it exists without performing
+                    // any joining
                     let exists = path
                         .as_str()
                         .parse::<Url>()
@@ -1236,7 +1238,8 @@ impl<'de> serde::Deserialize<'de> for Value {
                     elements.push(element);
                 }
 
-                // Try to find a mutually-agreeable common type for the elements of the array.
+                // Try to find a mutually-agreeable common type for the elements
+                // of the array.
                 let mut candidate_ty = None;
                 for element in elements.iter() {
                     let new_candidate_ty = element.ty();
@@ -1576,14 +1579,14 @@ impl Hash for PrimitiveValue {
                 v.hash(state);
             }
             Self::Float(v) => {
-                // Hash this with the same discriminant as integer; this allows coercion from
-                // int to float.
+                // Hash this with the same discriminant as integer; this allows
+                // coercion from int to float.
                 1.hash(state);
                 v.hash(state);
             }
             Self::String(v) | Self::File(HostPath(v)) | Self::Directory(HostPath(v)) => {
-                // Hash these with the same discriminant; this allows coercion from file and
-                // directory to string
+                // Hash these with the same discriminant; this allows coercion
+                // from file and directory to string
                 2.hash(state);
                 v.hash(state);
             }
@@ -2807,8 +2810,8 @@ impl Coercible for CompoundValue {
             match (self, target_ty) {
                 // Array[X] -> Array[Y](+) where X -> Y
                 (Self::Array(v), CompoundType::Array(target_ty)) => {
-                    // Don't allow coercion when the source is empty but the target has the
-                    // non-empty qualifier
+                    // Don't allow coercion when the source is empty but the
+                    // target has the non-empty qualifier
                     if v.is_empty() && target_ty.is_non_empty() {
                         bail!("cannot coerce empty array value to non-empty array {target:#}");
                     }

--- a/crates/wdl-engine/tests/inputs.rs
+++ b/crates/wdl-engine/tests/inputs.rs
@@ -169,10 +169,11 @@ async fn run_test(test: &Path) -> Result<()> {
     let json_path = test.join("inputs.json");
     let yaml_path = test.join("inputs.yaml");
 
-    // Special case for the "missing-file" test which intentionally tests missing
-    // input files
+    // Special case for the "missing-file" test which intentionally tests
+    // missing input files
     if test_name == "missing-file" {
-        // Always use the JSON path for consistency across platforms and pass as &Path
+        // Always use the JSON path for consistency across platforms and pass as
+        // &Path
         let result = match Inputs::parse(document, &json_path) {
             Ok(_) => String::new(),
             Err(e) => format!("{e:#}"),

--- a/crates/wdl-engine/tests/tasks.rs
+++ b/crates/wdl-engine/tests/tasks.rs
@@ -136,7 +136,8 @@ fn run_test(test: &Path, config: TestConfig) -> BoxFuture<'_, Result<()>> {
         let test_dir = absolute(test).expect("failed to get absolute directory");
         let test_dir_path = test_dir.as_path().into();
 
-        // Make any paths specified in the inputs file relative to the test directory
+        // Make any paths specified in the inputs file relative to the test
+        // directory
         let task = result
             .document()
             .task_by_name(&name)
@@ -344,8 +345,8 @@ fn compare_evaluation_results(
 }
 
 fn main() -> Result<(), anyhow::Error> {
-    // Default log level to off as some tests are designed to fail and we don't want
-    // to log errors during the test
+    // Default log level to off as some tests are designed to fail and we don't
+    // want to log errors during the test
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::builder()

--- a/crates/wdl-engine/tests/workflows.rs
+++ b/crates/wdl-engine/tests/workflows.rs
@@ -100,7 +100,8 @@ fn run_test(test: &Path, config: TestConfig) -> BoxFuture<'_, Result<()>> {
         let test_dir = absolute(test).expect("failed to get absolute directory");
         let test_dir_path = test_dir.as_path().into();
 
-        // Make any paths specified in the inputs file relative to the test directory
+        // Make any paths specified in the inputs file relative to the test
+        // directory
         let workflow = result
             .document()
             .workflow()
@@ -145,8 +146,8 @@ fn run_test(test: &Path, config: TestConfig) -> BoxFuture<'_, Result<()>> {
 }
 
 fn main() -> Result<()> {
-    // Default log level to off as some tests are designed to fail and we don't want
-    // to log errors during the test
+    // Default log level to off as some tests are designed to fail and we don't
+    // want to log errors during the test
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::builder()

--- a/crates/wdl-format/src/token/post.rs
+++ b/crates/wdl-format/src/token/post.rs
@@ -589,8 +589,9 @@ impl Postprocessor {
             let next = pre_buffer.peek().copied();
             self.step(token.clone(), next, &mut post_buffer);
 
-            // If we cached before the step and the line is now too long, revert, line
-            // break, then repeat the step we just took.
+            // If we cached before the step and the line is now too long,
+            // revert, line break, then repeat the step we just
+            // took.
             if max_length.is_some_and(|max| post_buffer.last_line_width(config) > max)
                 && let Some(cache) = cache.take()
                 && let Some(cached_self) = cached_self.take()

--- a/crates/wdl-format/src/v1/expr.rs
+++ b/crates/wdl-format/src/v1/expr.rs
@@ -189,8 +189,10 @@ pub fn format_literal_string(
                             if let Some(next_c) = chars.peek()
                                 && *next_c == '\''
                             {
-                                // Do not write this backslash as single quotes don't need
-                                // escaping in a double-quoted string (and we format all
+                                // Do not write this backslash as single quotes
+                                // don't need
+                                // escaping in a double-quoted string (and we
+                                // format all
                                 // LiteralStrings as double-quoted strings).
                                 prev_c = Some(c);
                                 continue;
@@ -199,8 +201,10 @@ pub fn format_literal_string(
                         }
                         '"' => {
                             if prev_c.is_none_or(|c| c != '\\') {
-                                // This double quote sign is not escaped, so we need to escape
-                                // it. This happens when a single quoted string is re-formatted
+                                // This double quote sign is not escaped, so we
+                                // need to escape
+                                // it. This happens when a single quoted string
+                                // is re-formatted
                                 // as a double quoted string.
                                 replacement.push('\\');
                             }
@@ -999,8 +1003,8 @@ pub fn format_if_expr(
             if cur.kind().is_trivia() {
                 continue;
             }
-            // only match on `else`; `then` could be considered for "chaining" but that
-            // makes it harder to read IMO (a-frantz).
+            // only match on `else`; `then` could be considered for "chaining"
+            // but that makes it harder to read IMO (a-frantz).
             result = matches!(cur.kind(), SyntaxKind::ElseKeyword);
             break;
         }

--- a/crates/wdl-format/src/v1/import.rs
+++ b/crates/wdl-format/src/v1/import.rs
@@ -130,9 +130,10 @@ pub fn format_symbolic_module_path(
                 (&child).write(stream, config);
             }
             SyntaxKind::Slash => {
-                // `SyntaxKind::Slash` is a "linebreakable" token, but we don't want module
-                // paths to get line broken; so we push this token as a
-                // `LiteralStringText` to prevent that.
+                // `SyntaxKind::Slash` is a "linebreakable" token, but we don't
+                // want module paths to get line broken; so we
+                // push this token as a `LiteralStringText` to
+                // prevent that.
                 stream.push_ast_token_as(
                     child.element().as_token().expect("slash should be token"),
                     SyntaxKind::LiteralStringText,

--- a/crates/wdl-format/src/v1/task.rs
+++ b/crates/wdl-format/src/v1/task.rs
@@ -171,8 +171,8 @@ pub fn format_command_section(
     match parts {
         None => {
             // The command section has mixed indentation, so we format it as is.
-            // TODO: We may want to format this differently in the future, but for now
-            // we can say "ugly input, ugly output".
+            // TODO: We may want to format this differently in the future, but
+            // for now we can say "ugly input, ugly output".
             for child in children {
                 match child.element().kind() {
                     SyntaxKind::CloseBrace => {
@@ -216,7 +216,8 @@ pub fn format_command_section(
                                 bash_indent = None;
                                 stream.end_line();
                                 if lines.peek().is_none() {
-                                    // save the leading whitespace to use as temporary indent
+                                    // save the leading whitespace to use as
+                                    // temporary indent
                                     bash_indent = Some(
                                         line.chars()
                                             .take_while(|c| matches!(c, ' ' | '\t'))

--- a/crates/wdl-format/src/v1/workflow.rs
+++ b/crates/wdl-format/src/v1/workflow.rs
@@ -65,8 +65,8 @@ pub fn format_conditional_statement_clause(
         children.next();
     }
 
-    // If the ConditionalStatementClause contains a condition, we need to process
-    // the parens and all elements inside!
+    // If the ConditionalStatementClause contains a condition, we need to
+    // process the parens and all elements inside!
     if has_condition {
         let open_paren = children.next().expect("open paren");
         assert_eq!(open_paren.element().kind(), SyntaxKind::OpenParen);

--- a/crates/wdl-format/src/v1/workflow/call.rs
+++ b/crates/wdl-format/src/v1/workflow/call.rs
@@ -69,8 +69,8 @@ pub fn format_call_input_item(
 
     let name = children.next().expect("call input item name");
     (&name).write(stream, config);
-    // Don't call end_word() here in case the name is alone in which case it should
-    // be followed by a comma.
+    // Don't call end_word() here in case the name is alone in which case it
+    // should be followed by a comma.
 
     if let Some(equals) = children.next() {
         stream.end_word();

--- a/crates/wdl-grammar/src/diagnostic.rs
+++ b/crates/wdl-grammar/src/diagnostic.rs
@@ -428,8 +428,8 @@ impl Diagnostic {
 
         if self.labels.is_empty() {
             // Codespan will treat this as a label at the end of the file
-            // We add this so that every diagnostic has at least one label with the file
-            // printed.
+            // We add this so that every diagnostic has at least one label with
+            // the file printed.
             diagnostic.labels.push(codespan::Label::new(
                 codespan::LabelStyle::Primary,
                 file_id,

--- a/crates/wdl-grammar/src/grammar.rs
+++ b/crates/wdl-grammar/src/grammar.rs
@@ -83,14 +83,15 @@ pub fn document(
 ) -> (Vec<Event>, Vec<Diagnostic>) {
     let root = parser.start();
     // Look for a starting `version` keyword token
-    // If this fails, an error is emitted and we'll skip parsing the remainder of
-    // the file.
+    // If this fails, an error is emitted and we'll skip parsing the remainder
+    // of the file.
     let (mut parser, diagnostic) = match parser.peek() {
         Some((PreambleToken::VersionKeyword, _)) => {
             match version_statement(parser, fallback_version) {
                 (parser, None) => {
-                    // A version statement was successfully parsed; continue on with parsing the
-                    // rest of the document.
+                    // A version statement was successfully parsed; continue on
+                    // with parsing the rest of the
+                    // document.
                     let mut parser = parser.morph();
                     v1::items(&mut parser);
                     root.complete(&mut parser, SyntaxKind::RootNode);
@@ -119,9 +120,9 @@ pub fn document(
         }
     };
 
-    // At this point, the parse cannot continue; but we still want the tree to cover
-    // every span of the source, so we will insert a special "unparsed" token for
-    // the remaining source.
+    // At this point, the parse cannot continue; but we still want the tree to
+    // cover every span of the source, so we will insert a special
+    // "unparsed" token for the remaining source.
     parser.diagnostic(diagnostic);
     parser.consume_remainder();
     root.complete(&mut parser, SyntaxKind::RootNode);

--- a/crates/wdl-grammar/src/grammar/v1.rs
+++ b/crates/wdl-grammar/src/grammar/v1.rs
@@ -532,7 +532,8 @@ pub fn items(parser: &mut Parser<'_>) {
 
     parser.pop_recovery_set();
 
-    // This call to `next` is important as `next` adds any remaining buffered events
+    // This call to `next` is important as `next` adds any remaining buffered
+    // events
     assert!(parser.next().is_none(), "parser is not finished");
 }
 
@@ -2206,8 +2207,9 @@ fn call_statement(
     }
 
     if let Some((Token::OpenBrace, _)) = parser.peek() {
-        // Given the optional `input:` that we need to parse after the open brace, we
-        // unfortunately can't use `Parser::matching_delimited` here
+        // Given the optional `input:` that we need to parse after the open
+        // brace, we unfortunately can't use
+        // `Parser::matching_delimited` here
         let open_span = parser.require(Token::OpenBrace);
 
         if parser.next_if(Token::InputKeyword) {
@@ -2342,7 +2344,8 @@ fn expr_with_precedence(
         // Check for either an infix or postfix operation
         match parser.peek() {
             Some((token, _)) if INFIX_OPERATOR_EXPECTED_SET.contains(token.into_raw()) => {
-                // The operation is an infix operation; check the precedence level
+                // The operation is an infix operation; check the precedence
+                // level
                 let (precedence, kind, associativity) = infix_precedence(token);
                 if precedence < min_precedence {
                     break;
@@ -2369,7 +2372,8 @@ fn expr_with_precedence(
                 lhs = infix.complete(&mut parser, kind);
             }
             Some((token, _)) if POSTFIX_OPERATOR_EXPECTED_SET.contains(token.into_raw()) => {
-                // The operation is a postfix operation; check the precedence level
+                // The operation is a postfix operation; check the precedence
+                // level
                 let precedence = postfix_precedence(token);
                 if precedence < min_precedence {
                     break;

--- a/crates/wdl-grammar/src/lexer.rs
+++ b/crates/wdl-grammar/src/lexer.rs
@@ -295,9 +295,9 @@ where
     where
         T2: Logos<'a, Source = str, Error = (), Extras = ()> + Copy,
     {
-        // If the lexer has peeked, we need to "reset" the lexer so that it is no longer
-        // peeked; this allows the morphed lexer to lex the previously peeked
-        // span
+        // If the lexer has peeked, we need to "reset" the lexer so that it is
+        // no longer peeked; this allows the morphed lexer to lex the
+        // previously peeked span
         let lexer = match self.peeked {
             Some(peeked) => {
                 let mut lexer = T2::lexer(self.lexer.source());

--- a/crates/wdl-grammar/src/parser.rs
+++ b/crates/wdl-grammar/src/parser.rs
@@ -580,9 +580,9 @@ where
     pub fn peek2(&mut self) -> Option<Peek2<T>> {
         let first = self.peek()?;
 
-        // We have to clone the lexer here since it only supports a single lookahead.
-        // The clone is cheap, but it does mean we'll re-tokenize this second lookahead
-        // eventually.
+        // We have to clone the lexer here since it only supports a single
+        // lookahead. The clone is cheap, but it does mean we'll
+        // re-tokenize this second lookahead eventually.
         let mut lexer = self
             .lexer
             .as_ref()
@@ -749,8 +749,9 @@ where
                 if let Some((Ok(token), _)) = lexer.as_mut().expect("should have a lexer").peek()
                     && !recovery.contains(token.into_raw())
                 {
-                    // Determine if the token is recoverable in the parent recovery set
-                    // If so, we'll restart where we first attempted to parse this item
+                    // Determine if the token is recoverable in the parent
+                    // recovery set If so, we'll restart
+                    // where we first attempted to parse this item
                     if let Some(parent) = &parent
                         && parent.contains(token.into_raw())
                     {
@@ -783,8 +784,9 @@ where
                 }
 
                 if let Err(mut e) = self.expect(delimiter) {
-                    // Attach a label to the diagnostic hinting at where we expected the
-                    // delimiter to be; to do this, look back at the last non-trivia token event
+                    // Attach a label to the diagnostic hinting at where we
+                    // expected the delimiter to be; to do
+                    // this, look back at the last non-trivia token event
                     // in the parser events and use its span for the label.
                     let span = self.events.iter().rev().find_map(|e| match e {
                         Event::Token { kind, span }
@@ -865,15 +867,16 @@ where
             // to move past the entire set of tokens that are part
             // of the interpolation
             if T::recover_interpolation(token, span, self) {
-                // If the diagnostic label started at this token, we need to extend its length
-                // to cover the interpolation
+                // If the diagnostic label started at this token, we need to
+                // extend its length to cover the interpolation
                 for label in diagnostic.inner.labels_mut() {
                     let label_span = label.span();
                     if label_span.start() != span.start() {
                         continue;
                     }
 
-                    // The label should include everything up to the current start
+                    // The label should include everything up to the current
+                    // start
                     label.set_span(Span::new(
                         label_span.start(),
                         self.lexer
@@ -900,8 +903,8 @@ where
 
     /// Starts a new node event.
     pub fn start(&mut self) -> Marker {
-        // Peek before starting the node so that any trivia appears as siblings to this
-        // node
+        // Peek before starting the node so that any trivia appears as siblings
+        // to this node
         if !self.events.is_empty() {
             self.peek();
 
@@ -1219,8 +1222,8 @@ where
                     lexer.next();
                 }
 
-                // Consecutive unknown tokens of the same type get condensed into a single
-                // diagnostic and event
+                // Consecutive unknown tokens of the same type get condensed
+                // into a single diagnostic and event
                 while let Some((Err(_), peeked_span)) = lexer.peek() {
                     unknown_span = Span::new(
                         unknown_span.start(),

--- a/crates/wdl-grammar/src/tree.rs
+++ b/crates/wdl-grammar/src/tree.rs
@@ -755,8 +755,9 @@ pub fn construct_tree(source: &str, mut events: Vec<Event>) -> SyntaxNode {
                     };
                 }
 
-                // As the current node was pushed first and then its ancestors, walk
-                // the list in reverse to start the "oldest" ancestor first
+                // As the current node was pushed first and then its ancestors,
+                // walk the list in reverse to start the
+                // "oldest" ancestor first
                 for kind in ancestors.drain(..).rev() {
                     if kind != SyntaxKind::Abandoned {
                         builder.start_node(kind.into());

--- a/crates/wdl-grammar/src/version.rs
+++ b/crates/wdl-grammar/src/version.rs
@@ -95,8 +95,8 @@ impl SupportedVersion {
     /// assert!(SupportedVersion::V1(V1::Zero).has_same_major_version(SupportedVersion::V1(V1::Two)));
     /// ```
     pub fn has_same_major_version(self, other: SupportedVersion) -> bool {
-        // Check only that the discriminants are equal, ignoring the value contained by
-        // each.
+        // Check only that the discriminants are equal, ignoring the value
+        // contained by each.
         mem::discriminant(&self) == mem::discriminant(&other)
     }
 

--- a/crates/wdl-lint/src/lib.rs
+++ b/crates/wdl-lint/src/lib.rs
@@ -170,8 +170,8 @@ pub fn rules(config: &Config) -> Vec<Box<dyn Rule + Send + Sync>> {
         Box::<rules::InlineInstall>::default(),
     ];
 
-    // Ensure all the rule IDs are unique and pascal case and that related rules are
-    // valid, exist and not self-referential.
+    // Ensure all the rule IDs are unique and pascal case and that related rules
+    // are valid, exist and not self-referential.
     #[cfg(debug_assertions)]
     {
         use std::collections::HashSet;

--- a/crates/wdl-lint/src/rules/bash_set_syntax.rs
+++ b/crates/wdl-lint/src/rules/bash_set_syntax.rs
@@ -213,7 +213,8 @@ impl BashSetSyntax {
                 let (matched_opt, opt_name_span, should_break, is_interactive_only) = if opt == 'o'
                 {
                     if byte_offset + opt_len < chunk.len() {
-                        // Some invalid syntax, 'o' should be at the end of the chunk
+                        // Some invalid syntax, 'o' should be at the end of the
+                        // chunk
                         return (false, last_chunk_end);
                     }
 

--- a/crates/wdl-lint/src/rules/command_section_indentation.rs
+++ b/crates/wdl-lint/src/rules/command_section_indentation.rs
@@ -186,7 +186,8 @@ impl Visitor for CommandSectionIndentationRule {
                                     let current = IndentationKind::from(*b);
                                     let kind = kind.get_or_insert(current);
                                     if current != *kind {
-                                        // Mixed indentation, store the span of the first mixed
+                                        // Mixed indentation, store the span of
+                                        // the first mixed
                                         // character
                                         mixed_span =
                                             Some(Span::new(text.span().start() + start + i, 1));
@@ -199,8 +200,8 @@ impl Visitor for CommandSectionIndentationRule {
                     }
                 }
                 CommandPart::Placeholder(_) => {
-                    // Encountered a placeholder, skip the next line of text as it's
-                    // really a part of the same line
+                    // Encountered a placeholder, skip the next line of text as
+                    // it's really a part of the same line
                     skip_next_line = true;
                 }
             }

--- a/crates/wdl-lint/src/rules/container_uri.rs
+++ b/crates/wdl-lint/src/rules/container_uri.rs
@@ -197,12 +197,13 @@ task say_goodbye {
     fn tags(&self) -> TagSet {
         // NOTE: these are the justification for these tags:
         //
-        // - Clarity because it resolves the ambiguous situations described in the
-        //   explanation above.
-        // - Portability because this resolves situations where different execution
-        //   engines might behave differently (e.g., one container engine might always
-        //   pull the latest image for a mutably tagged container whereas another may
-        //   use a older, cached version until the user prompts it to upgrade).
+        // - Clarity because it resolves the ambiguous situations described in
+        //   the explanation above.
+        // - Portability because this resolves situations where different
+        //   execution engines might behave differently (e.g., one container
+        //   engine might always pull the latest image for a mutably tagged
+        //   container whereas another may use a older, cached version until the
+        //   user prompts it to upgrade).
         TagSet::new(&[Tag::Clarity, Tag::Portability])
     }
 
@@ -283,8 +284,8 @@ fn check_container_value(
         if array.is_empty() {
             diagnostics.exceptable_add(empty_array(value.expr().span()), node, exceptable_nodes);
         } else if array.len() == 1 {
-            // SAFETY: we just checked to ensure that exactly one element exists in the
-            // vec, so this will always unwrap.
+            // SAFETY: we just checked to ensure that exactly one element exists
+            // in the vec, so this will always unwrap.
             let uri = array.iter().next().unwrap();
             diagnostics.exceptable_add(
                 array_to_string_literal(uri.literal_string().span()),

--- a/crates/wdl-lint/src/rules/doc_meta_strings.rs
+++ b/crates/wdl-lint/src/rules/doc_meta_strings.rs
@@ -200,8 +200,8 @@ impl Visitor for DocMetaStringsRule {
                 );
             }
 
-            // Recursively check any nested objects (handles "outputs" and other nested
-            // structures)
+            // Recursively check any nested objects (handles "outputs" and other
+            // nested structures)
             if let MetadataValue::Object(ref obj) = value {
                 check_object_items(obj, diagnostics, &self.exceptable_nodes());
             }

--- a/crates/wdl-lint/src/rules/expected_runtime_keys.rs
+++ b/crates/wdl-lint/src/rules/expected_runtime_keys.rs
@@ -395,8 +395,9 @@ impl Visitor for ExpectedRuntimeKeysRule {
                         );
                     }
 
-                    // Now that we've emitted the necessary diagnostics for this runtime section,
-                    // clear our tracking container of encountered keys to prepare for the next
+                    // Now that we've emitted the necessary diagnostics for this
+                    // runtime section, clear our tracking
+                    // container of encountered keys to prepare for the next
                     // runtime section.
                     self.encountered_keys.clear();
                     self.runtime_processed_for_task = true;
@@ -427,12 +428,12 @@ impl Visitor for ExpectedRuntimeKeysRule {
             // The only keys that need to be individually inspected are WDL v1.1
             // keys because,
             //
-            // - WDL v1.0 contains no deprecated keys: the only issue that can occur is when
-            //   one of the two recommended key is omitted, and that is handled at the end
-            //   of the `document()` method.
-            // - WDL v1.2 deprecates the `runtime` section, so any WDL document with a
-            //   version of 1.2 or later should ignore the keys and report the section as
-            //   deprecated (in another rule).
+            // - WDL v1.0 contains no deprecated keys: the only issue that can
+            //   occur is when one of the two recommended key is omitted, and
+            //   that is handled at the end of the `document()` method.
+            // - WDL v1.2 deprecates the `runtime` section, so any WDL document
+            //   with a version of 1.2 or later should ignore the keys and
+            //   report the section as deprecated (in another rule).
             if minor_version == V1::One {
                 match keys_v1_1().get(key_name.text()) {
                     Some(kind) => {
@@ -453,10 +454,12 @@ impl Visitor for ExpectedRuntimeKeysRule {
                         // If the key was _not_ found in the map, that means the
                         // key was not one of the permitted values for WDL v1.1.
                         //
-                        // If it's also not in the explicitly allowed configuration,
+                        // If it's also not in the explicitly allowed
+                        // configuration,
                         // add a diagnostic for it.
                         if !self.allowed_runtime_keys.contains(key_text) {
-                            // Note we don't use `item.span()` here to avoid highlighting the whole
+                            // Note we don't use `item.span()` here to avoid
+                            // highlighting the whole
                             // runtime object.
                             let text_for_key_span = item
                                 .inner()

--- a/crates/wdl-lint/src/rules/parameter_meta_matched.rs
+++ b/crates/wdl-lint/src/rules/parameter_meta_matched.rs
@@ -209,7 +209,8 @@ fn check_parameter_meta(
         .collect();
 
     // We determine the intersection of expected and actual parameter names.
-    // Using these we next check for missing and extraneous parameters separately.
+    // Using these we next check for missing and extraneous parameters
+    // separately.
     let expected_order: Vec<_> = expected
         .iter()
         .map(|decl| decl.name().text().to_string())
@@ -286,8 +287,9 @@ impl Visitor for ParameterMetaMatchedRule {
             return;
         }
 
-        // Note that only the first input and parameter_meta sections are checked as any
-        // additional sections is considered a validation error
+        // Note that only the first input and parameter_meta sections are
+        // checked as any additional sections is considered a validation
+        // error
         match task.parameter_metadata() {
             Some(param_meta) => {
                 check_parameter_meta(
@@ -315,8 +317,9 @@ impl Visitor for ParameterMetaMatchedRule {
             return;
         }
 
-        // Note that only the first input and parameter_meta sections are checked as any
-        // additional sections is considered a validation error
+        // Note that only the first input and parameter_meta sections are
+        // checked as any additional sections is considered a validation
+        // error
         match workflow.parameter_metadata() {
             Some(param_meta) => {
                 check_parameter_meta(
@@ -353,8 +356,9 @@ impl Visitor for ParameterMetaMatchedRule {
             return;
         }
 
-        // Note that only the first input and parameter_meta sections are checked as any
-        // additional sections is considered a validation error
+        // Note that only the first input and parameter_meta sections are
+        // checked as any additional sections is considered a validation
+        // error
         match def.parameter_metadata().next() {
             Some(param_meta) => {
                 check_parameter_meta(

--- a/crates/wdl-lint/src/rules/shellcheck.rs
+++ b/crates/wdl-lint/src/rules/shellcheck.rs
@@ -642,7 +642,8 @@ fn map_shellcheck_lines(
                         continue;
                     }
 
-                    // The first line is removed entirely, UNLESS there is content on it.
+                    // The first line is removed entirely, UNLESS there is
+                    // content on it.
                     if !skipped_first_line && line.is_empty() {
                         skipped_first_line = true;
                         continue;
@@ -751,7 +752,8 @@ impl Visitor for ShellCheckRule {
         let Some(scope) = doc.find_scope_by_position(section.inner().text_range().start().into())
         else {
             // This is the case where the command section has not been analyzed
-            // e.g. it is in a task that has not been analyzed because it is a duplicate.
+            // e.g. it is in a task that has not been analyzed because it is a
+            // duplicate.
             return;
         };
         let mut context = CommandContext::new(doc.clone(), scope);

--- a/crates/wdl-lint/src/rules/unused_doc_comments.rs
+++ b/crates/wdl-lint/src/rules/unused_doc_comments.rs
@@ -75,8 +75,8 @@ const VALID_SYNTAX_KINDS_FOR_DOC_COMMENTS: &[SyntaxKind] = &[
 fn valid_target_for_doc_comment(doc_comment_target: &SyntaxElement) -> bool {
     let kind = doc_comment_target.kind();
 
-    // A BoundDeclNode can only have doc comments if it is a part of an InputSection
-    // or OutputSection.
+    // A BoundDeclNode can only have doc comments if it is a part of an
+    // InputSection or OutputSection.
     if kind == SyntaxKind::BoundDeclNode {
         let Some(parent) = doc_comment_target.parent() else {
             return false;

--- a/crates/wdl-lsp/src/server.rs
+++ b/crates/wdl-lsp/src/server.rs
@@ -72,7 +72,8 @@ fn normalize_uri_path(uri: &mut Url) {
 
     // Call `to_file_path` which will automatically decode any encoded sequences
     if let Ok(path) = uri.to_file_path() {
-        // On windows we need to normalize any drive letter prefixes to uppercase
+        // On windows we need to normalize any drive letter prefixes to
+        // uppercase
         let path = if cfg!(windows) {
             let mut comps = path.components();
             match comps.next() {
@@ -493,8 +494,8 @@ impl ServerOptions {
         all_rules.sort_unstable();
         all_rules.dedup();
 
-        // TODO ACF 2025-07-07: add configurability around the fallback behavior; see
-        // https://github.com/stjude-rust-labs/wdl/issues/517
+        // TODO ACF 2025-07-07: add configurability around the fallback
+        // behavior; see https://github.com/stjude-rust-labs/wdl/issues/517
         let analyzer_config = AnalysisConfig::default()
             .with_fallback_version(Some(Default::default()))
             .with_diagnostics_config(DiagnosticsConfig::new(

--- a/crates/wdl-lsp/tests/requests/completions.rs
+++ b/crates/wdl-lsp/tests/requests/completions.rs
@@ -327,8 +327,8 @@ async fn should_complete_scope_variables() {
     assert_contains(&items, "floor");
     assert_contains(&items, "stdout");
     assert_contains(&items, "stderr");
-    // The following standard library functions are present in WDL version 1.3 and
-    // should appear as completions.
+    // The following standard library functions are present in WDL version 1.3
+    // and should appear as completions.
     assert_contains(&items, "min");
     assert_contains(&items, "find");
     assert_contains(&items, "chunk");
@@ -386,8 +386,8 @@ async fn should_complete_scope_variables_v1_0_stdlib() {
     assert_contains(&items, "floor");
     assert_contains(&items, "stdout");
     assert_contains(&items, "stderr");
-    // The following standard library functions are *not* present in WDL version 1.0
-    // and should *not* appear as completions.
+    // The following standard library functions are *not* present in WDL version
+    // 1.0 and should *not* appear as completions.
     assert_not_contains(&items, "min");
     assert_not_contains(&items, "find");
     assert_not_contains(&items, "chunk");

--- a/crates/wdl-modules/src/hash.rs
+++ b/crates/wdl-modules/src/hash.rs
@@ -632,7 +632,8 @@ mod tests {
         fs::write(dir.path().join("root.wdl"), b"workflow w {}").unwrap();
         fs::write(dir.path().join("sub").join("nested.wdl"), b"task t {}").unwrap();
 
-        // Simulate Unix-style paths (as `hash_directory` would produce on Unix).
+        // Simulate Unix-style paths (as `hash_directory` would produce on
+        // Unix).
         let mut h_unix = Hasher::new(dir.path().to_path_buf());
         for p in ["root.wdl", "sub/nested.wdl"] {
             h_unix.try_add(p).unwrap();

--- a/crates/wdl-modules/src/resolver/git/ops/checkout.rs
+++ b/crates/wdl-modules/src/resolver/git/ops/checkout.rs
@@ -311,8 +311,8 @@ where
                     }
                 }));
             }
-            // libgit2 fetch.c:144-151 rejects an exact OID when the remote does not
-            // advertise OID wants.
+            // libgit2 fetch.c:144-151 rejects an exact OID when the remote does
+            // not advertise OID wants.
             if error.class() != git2::ErrorClass::Invalid
                 || !error
                     .message()
@@ -325,8 +325,9 @@ where
                 });
             }
             drop(repo);
-            // Local fixtures do not exercise this path because local transport advertises
-            // both OID capabilities (libgit2 local.c:263-268).
+            // Local fixtures do not exercise this path because local transport
+            // advertises both OID capabilities (libgit2
+            // local.c:263-268).
             std::fs::remove_dir_all(leaf).map_err(|source| GitError::Io {
                 path: leaf.to_path_buf(),
                 source,

--- a/crates/wdl-modules/src/resolver/policy.rs
+++ b/crates/wdl-modules/src/resolver/policy.rs
@@ -276,16 +276,20 @@ impl ResolverPolicy {
                     // Resolve the hostname to IP addresses and reject if any
                     // resolved address is non-public.
                     //
-                    // Port 0 is passed only because `to_socket_addrs` requires a
-                    // port; the value is insignificant for the address lookup and
-                    // the DNS result is identical for any port. The policy does not
-                    // restrict which port the URL itself uses; that is left to the
+                    // Port 0 is passed only because `to_socket_addrs` requires
+                    // a port; the value is insignificant
+                    // for the address lookup and
+                    // the DNS result is identical for any port. The policy does
+                    // not restrict which port the URL
+                    // itself uses; that is left to the
                     // caller's URL.
                     //
-                    // Both DNS failure and empty results are treated as rejection
-                    // (fail-closed). This preflight check cannot bind libgit2's
-                    // later connection to the validated addresses, so preventing
-                    // DNS rebinding requires peer-IP validation in a custom
+                    // Both DNS failure and empty results are treated as
+                    // rejection (fail-closed). This
+                    // preflight check cannot bind libgit2's
+                    // later connection to the validated addresses, so
+                    // preventing DNS rebinding requires
+                    // peer-IP validation in a custom
                     // transport.
                     if url.scheme() != "file" {
                         let addrs: Vec<std::net::SocketAddr> =

--- a/crates/wdl-modules/src/resolver/trust.rs
+++ b/crates/wdl-modules/src/resolver/trust.rs
@@ -443,7 +443,8 @@ mod tests {
             }),
         ));
         assert!(!store.trust_signer(key, None));
-        // SAFETY: `trust_signer` inserted the key and structured identity above.
+        // SAFETY: `trust_signer` inserted the key and structured identity
+        // above.
         let identity = store.identity(&key).unwrap();
         assert_eq!(identity.name.as_deref(), Some("Ada"));
         assert_eq!(identity.email.as_deref(), Some("ada@example.com"));

--- a/crates/wdl-modules/src/signing.rs
+++ b/crates/wdl-modules/src/signing.rs
@@ -575,7 +575,8 @@ mod tests {
         let module_sig = ModuleSignature::new(&signer, &digest, None).unwrap();
 
         let mut buf = Vec::new();
-        // SAFETY: writing valid signature data to an in-memory buffer cannot fail.
+        // SAFETY: writing valid signature data to an in-memory buffer cannot
+        // fail.
         module_sig.write(&mut buf).unwrap();
         // SAFETY: `write` emitted a valid module signature document.
         let parsed = ModuleSignature::parse(&buf).unwrap();

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -218,8 +218,9 @@ impl Analysis {
         let validator = move || {
             let mut validator = Validator::default();
 
-            // So the validator is always *aware* of all `wdl-lint` rules, even when the
-            // linter isn't. Keeps `KnownRules` from firing unnecessarily.
+            // So the validator is always *aware* of all `wdl-lint` rules, even
+            // when the linter isn't. Keeps `KnownRules` from firing
+            // unnecessarily.
             validator.extend_rules(wdl::lint::RULE_MAP.clone());
             if self.enabled_lint_tags.count() > 0 {
                 let visitor =
@@ -415,7 +416,8 @@ pub(crate) fn resolution_context_from_paths(
     for start in starts {
         // Skip a start whose directory was already walked; many source paths
         // commonly share the same parent directory, and the upward walk from a
-        // directory is deterministic, so re-walking it cannot find anything new.
+        // directory is deterministic, so re-walking it cannot find anything
+        // new.
         if !walked.insert(start.clone()) {
             continue;
         }

--- a/src/commands/inputs.rs
+++ b/src/commands/inputs.rs
@@ -443,7 +443,8 @@ impl InputProcessor {
                             &workflow,
                         )?;
 
-                        // Any inputs specified by the workflow itself cannot be overridden.
+                        // Any inputs specified by the workflow itself cannot be
+                        // overridden.
                         specified.iter().for_each(|s| {
                             let key = namespace.clone().push(s).join().expect("key to join");
                             self.results.remove(&key);

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1011,7 +1011,8 @@ pub async fn run(
         setup_run_context(handle, &args, &config, &source, &target, &inputs).await?;
 
     let cancellation = CancellationContext::new(config.run.engine.failure_mode);
-    // Determined here as the engine configuration is moved into evaluation below.
+    // Determined here as the engine configuration is moved into evaluation
+    // below.
     let uses_docker = uses_docker_backend(&config.run.engine);
     let events = Events::new(
         config

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -749,7 +749,8 @@ impl Runner {
                     {
                         Ok(res) => res,
                         Err(e) => {
-                            // TODO(serial): Spanned diagnostics would be nice here too
+                            // TODO(serial): Spanned diagnostics would be nice
+                            // here too
                             errors.push(Arc::new(e.context(format!(
                                 "converting to WDL inputs for test `{}` for WDL document `{}`",
                                 test.name,
@@ -1037,9 +1038,9 @@ pub async fn test(
         .map_err(CommandError::from)?;
 
     // Find and parse all YAML before beginning any executions.
-    // This is so that any totally invalid YAML is caught up-front before we start
-    // testing. Smaller issues with test definitions will later be collected and
-    // reported on after all tests execute.
+    // This is so that any totally invalid YAML is caught up-front before we
+    // start testing. Smaller issues with test definitions will later be
+    // collected and reported on after all tests execute.
     let mut documents = Vec::new();
     let mut counts = DiagnosticCounts::default();
     for analysis in analysis_results.filter(&[&source]) {
@@ -1138,7 +1139,8 @@ pub async fn test(
     config.run.engine.task.memory_limit_behavior = TaskResourceLimitBehavior::TryWithMax;
     config.validate()?;
 
-    // Determined here as the engine configuration is moved into the engine below.
+    // Determined here as the engine configuration is moved into the engine
+    // below.
     let uses_docker = uses_docker_backend(&config.run.engine);
     let engine = Engine::new(config.run.engine)
         .await

--- a/src/config.rs
+++ b/src/config.rs
@@ -1309,11 +1309,13 @@ impl Config {
             Ok(())
         }
 
-        // Expand paths in the configuration for both the `run` and `server` sections
+        // Expand paths in the configuration for both the `run` and `server`
+        // sections
         self.run.output_dir = expand(&self.run.output_dir)?;
         self.server.output_dir = expand(&self.server.output_dir)?;
 
-        // Expand the paths in the engine configuration for both `run` and `server`
+        // Expand the paths in the engine configuration for both `run` and
+        // `server`
         expand_paths(&mut self.run.engine)?;
         expand_paths(&mut self.server.engine)?;
 

--- a/src/inputs/file.rs
+++ b/src/inputs/file.rs
@@ -234,7 +234,8 @@ mod tests {
     #[tokio::test]
     async fn read_remote() {
         // The URL is a gist of `fixtures/inputs_one.json`
-        // Create a new gist and substitute it here if the file contents need to change
+        // Create a new gist and substitute it here if the file contents need to
+        // change
         let inputs = read_input_file(&"https://gist.githubusercontent.com/peterhuene/9990b86bf0c419e144326b0276bf6f14/raw/d4116ef8888ccd78e2967d7ad32e1aeb3e4ab734/inputs.json".parse().unwrap())
             .await
             .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,8 @@ async fn real_main() -> CommandResult<()> {
                     config
                 }
                 Err(e) => {
-                    // If there is source associated with the error, emit a diagnostic
+                    // If there is source associated with the error, emit a
+                    // diagnostic
                     if let Some(source) = e.source() {
                         emit_diagnostics(
                             &e.path().to_string(),
@@ -133,7 +134,8 @@ async fn real_main() -> CommandResult<()> {
                         )
                         .context("failed to emit diagnostics")?;
 
-                        // Bail out without returning to caller as the diagnostic was displayed
+                        // Bail out without returning to caller as the
+                        // diagnostic was displayed
                         std::process::exit(1);
                     }
 
@@ -251,14 +253,14 @@ fn initialize_logging(
     {
         Ok(filter) => filter,
         Err(e) => {
-            // If there was an error and the variable was set, then the error was due to
-            // parsing an invalid directive
+            // If there was an error and the variable was set, then the error
+            // was due to parsing an invalid directive
             if std::env::var("RUST_LOG").is_ok() {
                 return Err(e);
             }
 
-            // Otherwise, use a default directive env filter that disables noisy hyper
-            // output
+            // Otherwise, use a default directive env filter that disables noisy
+            // hyper output
             EnvFilter::builder()
                 .with_default_directive(LevelFilter::from(verbosity).into())
                 .from_env_lossy()
@@ -270,8 +272,8 @@ fn initialize_logging(
     // This layer should always come first in the subscriber
     let (filter_layer, filter_reload_handle) = reload::Layer::new(env_filter);
 
-    // Set up an indicatif layer so that progress bars don't interfere with logging
-    // output
+    // Set up an indicatif layer so that progress bars don't interfere with
+    // logging output
     let indicatif_layer = IndicatifLayer::new()
         .with_span_child_prefix_indent("    ")
         .with_span_child_prefix_symbol("↳ ");

--- a/src/memory_stats.rs
+++ b/src/memory_stats.rs
@@ -43,9 +43,9 @@ fn peak_memory_bytes() -> Option<u64> {
 
     // `ru_maxrss` is reported in bytes on macOS but in kibibytes on Linux and
     // the BSDs. The macOS man page still says kibibytes, but the Darwin kernel
-    // assigns `ru_maxrss` from `resident_size_max` in bytes without dividing, so
-    // the man page is inaccurate here (verified against `/usr/bin/time -l`).
-    // Ref (Linux, KiB): https://man7.org/linux/man-pages/man2/getrusage.2.html
+    // assigns `ru_maxrss` from `resident_size_max` in bytes without dividing,
+    // so the man page is inaccurate here (verified against `/usr/bin/time
+    // -l`). Ref (Linux, KiB): https://man7.org/linux/man-pages/man2/getrusage.2.html
     // Ref (macOS, bytes): https://github.com/apple-oss-distributions/xnu/blob/main/bsd/kern/kern_resource.c
     #[cfg(target_os = "macos")]
     {

--- a/src/system/v1/db/sqlite.rs
+++ b/src/system/v1/db/sqlite.rs
@@ -874,7 +874,8 @@ mod tests {
             .await
             .expect("failed to insert version");
 
-        // Now connect using `from_pool()` — should fail with `InvalidVersion` error
+        // Now connect using `from_pool()` — should fail with `InvalidVersion`
+        // error
         let result = SqliteDatabase::from_pool(pool).await;
 
         assert!(
@@ -1351,8 +1352,8 @@ mod tests {
                 .expect("failed to update task")
         );
 
-        // The first terminal status wins; reconciliation of a finished task is a
-        // no-op.
+        // The first terminal status wins; reconciliation of a finished task is
+        // a no-op.
         assert!(
             db.update_task_completed("t", Some(0), Utc::now())
                 .await

--- a/src/system/v1/exec.rs
+++ b/src/system/v1/exec.rs
@@ -616,9 +616,10 @@ impl RunnableExecutor {
             );
         }
 
-        // Evaluation is over, so no further events can be emitted. Let the monitor
-        // consume what is left and reconcile any task that never reached a
-        // terminal status before the run is considered finished.
+        // Evaluation is over, so no further events can be emitted. Let the
+        // monitor consume what is left and reconcile any task that
+        // never reached a terminal status before the run is considered
+        // finished.
         monitor_shutdown.cancel();
         if let Err(e) = task_monitor.await {
             tracing::error!("task monitor for run {} failed: {e:#}", self.run_id);
@@ -982,10 +983,11 @@ pub async fn execute_target(
             Ok(())
         }
         Err(e) => {
-            // Cancelling a run aborts whatever it is doing, and work that is not a
-            // task execution reports that abort as an ordinary evaluation error.
-            // Localizing a large input is the common case: the transfer is torn
-            // down by the cancellation token and fails. The run was canceled, not
+            // Cancelling a run aborts whatever it is doing, and work that is
+            // not a task execution reports that abort as an
+            // ordinary evaluation error. Localizing a large input
+            // is the common case: the transfer is torn down by the
+            // cancellation token and fails. The run was canceled, not
             // failed, and only the user's own cancellation counts here — a
             // cancellation triggered by an error must still be recorded as a
             // failure.

--- a/src/system/v1/exec/svc/run_manager.rs
+++ b/src/system/v1/exec/svc/run_manager.rs
@@ -445,8 +445,9 @@ impl RunManagerSvc {
         let semaphore = self.semaphore.clone();
         let handle = tokio::spawn(async move {
             let _permit = if let Some(ref sem) = semaphore {
-                // SAFETY: the semaphore is Arc-wrapped and held by the manager for its
-                // entire lifetime. It is never explicitly closed. If this fails, it
+                // SAFETY: the semaphore is Arc-wrapped and held by the manager
+                // for its entire lifetime. It is never
+                // explicitly closed. If this fails, it
                 // indicates a catastrophic programming error.
                 Some(sem.acquire().await.unwrap())
             } else {
@@ -595,8 +596,9 @@ async fn cancel_run(
             // `Canceled` in the database.
             CancellationContextState::Canceling => {
                 db.cancel_run(id, Utc::now()).await?;
-                // NOTE: when a run is actually canceled, remove it from the runs
-                // map, as it won't remove itself at the end of execution.
+                // NOTE: when a run is actually canceled, remove it from the
+                // runs map, as it won't remove itself at the
+                // end of execution.
                 runs_guard.remove(&id);
             }
         }

--- a/src/system/v1/exec/svc/task_monitor.rs
+++ b/src/system/v1/exec/svc/task_monitor.rs
@@ -105,8 +105,9 @@ impl TaskMonitorSvc {
         let mut engine_open = true;
 
         while crankshaft_open || engine_open {
-            // The receivers are only borrowed for the duration of the select, so
-            // that handling an event can take the monitor mutably.
+            // The receivers are only borrowed for the duration of the select,
+            // so that handling an event can take the monitor
+            // mutably.
             let incoming = select! {
                 biased;
                 _ = self.shutdown.cancelled() => Incoming::Shutdown,
@@ -145,9 +146,9 @@ impl TaskMonitorSvc {
             }
         }
 
-        // A shutdown can arrive while events are still buffered. Those events are
-        // the record of what actually happened, so they are consumed before any
-        // task is written off as unfinished.
+        // A shutdown can arrive while events are still buffered. Those events
+        // are the record of what actually happened, so they are
+        // consumed before any task is written off as unfinished.
         self.drain().await;
         self.reconcile().await;
     }
@@ -208,8 +209,9 @@ impl TaskMonitorSvc {
                 let _ = self.db.update_task_localizing(&name).await?;
             }
             EngineEvent::ReusedCachedExecutionResult { id: _, name } => {
-                // The task may never have been announced as initializing if that
-                // event is still in flight on the other channel.
+                // The task may never have been announced as initializing if
+                // that event is still in flight on the other
+                // channel.
                 self.db
                     .create_task(&name, self.run_id, TaskStatus::Initializing)
                     .await?;
@@ -235,12 +237,14 @@ impl TaskMonitorSvc {
                 tes_id: _,
                 token: _,
             } => {
-                // A backend may run a task on its own behalf rather than on behalf
-                // of a WDL task, such as the Docker backend's `chown` of a work
-                // directory. Crankshaft reports it like any other task, but it is
-                // an implementation detail of running a task rather than something
-                // a user submitted, so it is left out of the run's tasks entirely.
-                // Dropping its id here is enough: every later event is resolved
+                // A backend may run a task on its own behalf rather than on
+                // behalf of a WDL task, such as the Docker
+                // backend's `chown` of a work directory.
+                // Crankshaft reports it like any other task, but it is
+                // an implementation detail of running a task rather than
+                // something a user submitted, so it is left out
+                // of the run's tasks entirely. Dropping its id
+                // here is enough: every later event is resolved
                 // through `task_names`.
                 if name.starts_with(CLEANUP_TASK_NAME_PREFIX) {
                     return Ok(());

--- a/tests/api/runs.rs
+++ b/tests/api/runs.rs
@@ -777,7 +777,8 @@ task final_task {
         .await
         .expect("workflow should start running");
 
-    // Wait for `slow_task` to actually be running inside Docker before canceling
+    // Wait for `slow_task` to actually be running inside Docker before
+    // canceling
     poll_for_task_running(&db, run_uuid, "slow_task-", 60)
         .await
         .expect("slow_task should be running");
@@ -860,9 +861,9 @@ task final_task {
     assert!(slow_task.completed_at.is_some());
 
     // Whether `final_task` is recorded at all depends on how far the workflow
-    // got before the cancel landed: the engine creates the task's record when it
-    // starts evaluating it, which is before it decides not to run it. Either way
-    // it must never have executed.
+    // got before the cancel landed: the engine creates the task's record when
+    // it starts evaluating it, which is before it decides not to run it.
+    // Either way it must never have executed.
     if let Some(final_task) = wdl_tasks.iter().find(|t| t.name.starts_with("final_task-")) {
         assert_eq!(final_task.status, TaskStatus::Canceled);
         assert!(
@@ -942,7 +943,8 @@ task sleep_task {
         .await
         .expect("sleep_task should be running");
 
-    // With fast failure mode, single cancel request should go straight to Cancelled
+    // With fast failure mode, single cancel request should go straight to
+    // Cancelled
     let cancel_response = app
         .clone()
         .oneshot(
@@ -2312,8 +2314,9 @@ async fn cancel_run_during_input_transfer(pool: sqlx::SqlitePool) {
     /// The advertised size of the input the origin never finishes sending.
     const INPUT_SIZE: usize = 1024 * 1024;
 
-    // An origin that answers the existence probe but stalls part way through the
-    // body, so the run is stuck transferring the input until it is canceled.
+    // An origin that answers the existence probe but stalls part way through
+    // the body, so the run is stuck transferring the input until it is
+    // canceled.
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
     let origin = tokio::spawn(async move {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -72,7 +72,8 @@ fn find_tests(starting_dir: &Path) -> Vec<PathBuf> {
             continue;
         }
         if path.is_dir() {
-            // The following tests require Docker, so skip if the Docker tests are disabled
+            // The following tests require Docker, so skip if the Docker tests
+            // are disabled
             #[cfg(docker_tests_disabled)]
             match path.file_name().and_then(|n| n.to_str()) {
                 Some("run") | Some("test") => continue,
@@ -243,10 +244,10 @@ fn run_sprocket(test_path: &Path, working_test_directory: &Path) -> Result<Comma
 fn resolve_env_config(test_path: &Path) -> Result<Option<NamedTempFile>> {
     let mut config_overridden = false;
     let mut sprocket_config = sprocket::Config::default();
-    // For `run` tests, allow overriding the engine config. We restrict the override
-    // to this subset of tests in order to avoid messing with the expected output
-    // for commands that format the config and therefore expect the config to be
-    // exactly the default.
+    // For `run` tests, allow overriding the engine config. We restrict the
+    // override to this subset of tests in order to avoid messing with the
+    // expected output for commands that format the config and therefore
+    // expect the config to be exactly the default.
     if test_path.starts_with("tests/cli/run")
         && let Some(env_config) = env::var_os("SPROCKET_TEST_ENGINE_CONFIG")
     {
@@ -640,9 +641,10 @@ fn compare_test_results(
             )?;
             normalize_expected_outputs(&expected_output_dir)
                 .context("failed to normalize expected outputs")?;
-            // Normalize temp dir paths inside any text files copied into outputs/
-            // during BLESS. `recursive_copy` preserves file contents verbatim, so
-            // any file that captured the temp path will embed a one-run absolute
+            // Normalize temp dir paths inside any text files copied into
+            // outputs/ during BLESS. `recursive_copy` preserves
+            // file contents verbatim, so any file that captured the
+            // temp path will embed a one-run absolute
             // path that future comparisons will never match.
             normalize_output_files(&expected_output_dir, working_test_directory)
                 .context("failed to normalize output file contents")?;

--- a/tests/system/v1/exec/config.rs
+++ b/tests/system/v1/exec/config.rs
@@ -237,7 +237,8 @@ fn validate_preserves_url_case_sensitivity() {
 
     config.validate().unwrap();
 
-    // Both should be kept (URLs are case-sensitive in host part for deduplication)
+    // Both should be kept (URLs are case-sensitive in host part for
+    // deduplication)
     assert_eq!(config.allowed_urls.len(), 2);
 }
 

--- a/tests/system/v1/exec/sources.rs
+++ b/tests/system/v1/exec/sources.rs
@@ -79,7 +79,8 @@ fn validate_file_with_path_traversal() -> Result<()> {
     let traversal_path = allowed_dir.join("..").join("secret.wdl");
     let result = validate_source(traversal_path.to_str().unwrap(), &config);
 
-    // Should be rejected as forbidden (canonicalization resolves `..` and checks)
+    // Should be rejected as forbidden (canonicalization resolves `..` and
+    // checks)
     assert!(matches!(result, Err(ConfigError::FilePathForbidden(_))));
 
     Ok(())

--- a/tests/system/v1/fs/index.rs
+++ b/tests/system/v1/fs/index.rs
@@ -375,8 +375,8 @@ async fn create_index_with_partial_db_failure(pool: SqlitePool) -> Result<()> {
     let run_dir = output_dir.ensure_workflow_run("test-workflow")?;
     fs::write(run_dir.root().join("outputs.json"), "{}")?;
 
-    // Create one file that exists and one that doesn't (`styling_metrics.json` is
-    // missing)
+    // Create one file that exists and one that doesn't (`styling_metrics.json`
+    // is missing)
     let outputs: Outputs = [
         make_file_output(
             run_dir.root(),
@@ -397,7 +397,8 @@ async fn create_index_with_partial_db_failure(pool: SqlitePool) -> Result<()> {
 
     assert!(result.is_err());
 
-    // Verify that the successful symlinks were created even though operation failed
+    // Verify that the successful symlinks were created even though operation
+    // failed
     let index_dir = output_dir.index_dir(&index_path("yak"));
     assert!(index_dir.join("outputs.json").exists());
     assert!(index_dir.join("satisfaction_survey.tsv").exists());
@@ -786,8 +787,8 @@ async fn create_index_skips_outputs_outside_of_output_directory(pool: SqlitePool
     let run_dir = output_dir.ensure_workflow_run("test-workflow")?;
     fs::write(run_dir.outputs_file(), "{}")?;
 
-    // An input that a task passes straight through to an output lives outside of
-    // the output directory.
+    // An input that a task passes straight through to an output lives outside
+    // of the output directory.
     let inputs = TempDir::new()?;
     let input_file = inputs.path().join("reads.bam");
     fs::write(&input_file, "reads")?;

--- a/tests/system/v1/fs/index/rebuild.rs
+++ b/tests/system/v1/fs/index/rebuild.rs
@@ -301,8 +301,8 @@ async fn rebuild_index_skips_entries_outside_of_output_directory(pool: SqlitePoo
     let run_dir = output_dir.ensure_workflow_run("test-workflow")?;
     fs::write(run_dir.root().join("result.txt"), "result")?;
 
-    // A database written before index paths were validated can hold entries that
-    // escape the index directory and even the output directory itself.
+    // A database written before index paths were validated can hold entries
+    // that escape the index directory and even the output directory itself.
     db.create_index_log_entry(
         run_id,
         "./index/../../escape/result.txt",


### PR DESCRIPTION
CI is failing since the latest nightly changed the behavior of `wrap_comments`. There's a lot here, unfortunately

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
