### PR TITLE
fix: make standard library LSP prose version-aware

### DIFF
--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* Standard-library hover, completion, and signature help now use documentation
+  appropriate for the document's WDL version, and signature help no longer
+  shows overloads introduced in later versions
+  ([#1006](https://github.com/stjude-rust-labs/sprocket/issues/1006)).
+
 ## 0.25.0 - 2026-08-26
 
 #### Added

--- a/crates/wdl-analysis/src/handlers/completions.rs
+++ b/crates/wdl-analysis/src/handlers/completions.rs
@@ -792,16 +792,16 @@ fn add_stdlib_completions(version: Option<SupportedVersion>, items: &mut Vec<Com
                 })
             }
             Function::Polymorphic(p) => {
+                let docs = p.definition(v).and_then(|d| make_md_docs(d.to_string()));
                 for sig in p.signatures().iter().filter(|s| s.minimum_version() <= v) {
                     let params = TypeParameters::new(sig.type_parameters());
                     let detail = Some(format!("{name}{}", sig.display(&params)));
-                    let docs = sig.definition().and_then(|d| make_md_docs(d.to_string()));
                     let snippet = build_function_snippet(name, sig);
                     items.push(CompletionItem {
                         label: name.to_string(),
                         kind: Some(CompletionItemKind::FUNCTION),
                         detail,
-                        documentation: docs,
+                        documentation: docs.clone(),
                         insert_text_format: Some(InsertTextFormat::SNIPPET),
                         insert_text: Some(snippet),
                         ..Default::default()

--- a/crates/wdl-analysis/src/handlers/hover.rs
+++ b/crates/wdl-analysis/src/handlers/hover.rs
@@ -568,12 +568,7 @@ fn get_function_hover_content(
                 .collect::<Vec<_>>()
                 .join("\n---\n");
 
-            let docs = p
-                .signatures()
-                .iter()
-                .find(|s| s.minimum_version() <= v)
-                .and_then(|s| s.definition())
-                .unwrap_or("");
+            let docs = p.definition(v).unwrap_or("");
             (detail, docs)
         }
     };

--- a/crates/wdl-analysis/src/handlers/signature_help.rs
+++ b/crates/wdl-analysis/src/handlers/signature_help.rs
@@ -45,11 +45,25 @@ pub fn signature_help(
         bail!("document `{uri}` not found in graph")
     };
     let node = graph.get(index);
-    let (root, lines) = match node.parse_state() {
-        ParseState::Parsed { root, lines, .. } => {
-            (SyntaxNode::new_root(root.clone()), lines.clone())
-        }
+    let (root, lines, parsed_version) = match node.parse_state() {
+        ParseState::Parsed {
+            root,
+            lines,
+            wdl_version,
+            ..
+        } => (
+            SyntaxNode::new_root(root.clone()),
+            lines.clone(),
+            *wdl_version,
+        ),
         _ => bail!("document `{uri} has not been parsed",),
+    };
+    let version = node
+        .document()
+        .and_then(|document| document.version())
+        .or(parsed_version);
+    let Some(version) = version else {
+        return Ok(None);
     };
     let offset = position_to_offset(&lines, position, encoding)?;
     let Some(token) = root.token_at_offset(offset).left_biased() else {
@@ -99,9 +113,18 @@ pub fn signature_help(
         }
     };
 
-    let signatures = match func {
-        Function::Monomorphic(m) => vec![m.signature()],
-        Function::Polymorphic(p) => p.signatures().iter().collect(),
+    let (signatures, definition) = match func {
+        Function::Monomorphic(m) if m.minimum_version() <= version => {
+            (vec![m.signature()], m.signature().definition())
+        }
+        Function::Monomorphic(_) => return Ok(None),
+        Function::Polymorphic(p) => (
+            p.signatures()
+                .iter()
+                .filter(|s| s.minimum_version() <= version)
+                .collect(),
+            p.definition(version),
+        ),
     };
 
     let sig_info: Vec<_> = signatures
@@ -146,7 +169,7 @@ pub fn signature_help(
 
             SignatureInformation {
                 label,
-                documentation: s.definition().map(|def| {
+                documentation: definition.map(|def| {
                     Documentation::MarkupContent(MarkupContent {
                         kind: MarkupKind::Markdown,
                         value: def.to_string(),

--- a/crates/wdl-analysis/src/stdlib.rs
+++ b/crates/wdl-analysis/src/stdlib.rs
@@ -1520,6 +1520,19 @@ impl PolymorphicFunction {
         &self.signatures
     }
 
+    /// Gets the function definition for the given WDL version.
+    pub fn definition(&self, version: SupportedVersion) -> Option<&'static str> {
+        self.signatures
+            .iter()
+            .filter(|s| s.minimum_version() <= version)
+            .filter_map(|s| {
+                s.definition()
+                    .map(|definition| (s.minimum_version(), definition))
+            })
+            .max_by_key(|(version, _)| *version)
+            .map(|(_, definition)| definition)
+    }
+
     /// Binds the function to the given arguments.
     ///
     /// This performs overload resolution for the polymorphic function.
@@ -2261,7 +2274,38 @@ workflow test_split {
             .is_none()
     );
 
-    const BASENAME_DEFINITION: &str = r#"
+    // https://github.com/openwdl/wdl/blob/wdl-1.0/SPEC.md#string-basenamestring
+    const BASENAME_DEFINITION_V1_0: &str = r#"
+Returns the "basename" of a file - the name after the last directory separator in the file's path.
+
+The optional second parameter specifies a literal suffix to remove from the file name. If the file name does not end with the specified suffix then it is ignored.
+
+**Parameters**
+
+1. `File`: Path of the file to read.
+2. `String`: (Optional) Suffix to remove from the file name.
+
+**Returns**: The file's basename as a `String`.
+
+Example: test_basename.wdl
+
+```wdl
+version 1.0
+
+workflow test_basename {
+  input {
+    File file
+  }
+
+  output {
+    Boolean unchanged = basename(file, ".txt") == basename(file)
+  }
+}
+```
+"#;
+
+    // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#basename
+    const BASENAME_DEFINITION_V1_2: &str = r#"
 Returns the "basename" of a file or directory - the name after the last directory separator in the path.
 
 The optional second parameter specifies a literal suffix to remove from the file name. If the file name does not end with the specified suffix then it is ignored.
@@ -2288,7 +2332,6 @@ workflow test_basename {
 ```
 "#;
 
-    // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#basename
     assert!(
         functions
             .insert(
@@ -2296,20 +2339,14 @@ workflow test_basename {
                 PolymorphicFunction::new(vec![
                     FunctionSignature::builder()
                         .required(1)
-                        .parameter(
-                            "path",
-                            PrimitiveType::File,
-                            "Path of the file or directory to read. If the argument is a \
-                             `String`, it is assumed to be a local file path relative to the \
-                             current working directory of the task.",
-                        )
+                        .parameter("path", PrimitiveType::File, "Path of the file to read.",)
                         .parameter(
                             "suffix",
                             PrimitiveType::String,
                             "(Optional) Suffix to remove from the file name.",
                         )
                         .ret(PrimitiveType::String)
-                        .definition(BASENAME_DEFINITION)
+                        .definition(BASENAME_DEFINITION_V1_0)
                         .build(),
                     // This overload isn't explicitly specified in the spec, but the spec
                     // allows for `String` where file/directory are accepted; an explicit
@@ -2321,9 +2358,7 @@ workflow test_basename {
                         .parameter(
                             "path",
                             PrimitiveType::String,
-                            "Path of the file or directory to read. If the argument is a \
-                             `String`, it is assumed to be a local file path relative to the \
-                             current working directory of the task."
+                            "Path of the file or directory to read."
                         )
                         .parameter(
                             "suffix",
@@ -2331,7 +2366,7 @@ workflow test_basename {
                             "(Optional) Suffix to remove from the file name."
                         )
                         .ret(PrimitiveType::String)
-                        .definition(BASENAME_DEFINITION)
+                        .definition(BASENAME_DEFINITION_V1_2)
                         .build(),
                     FunctionSignature::builder()
                         .min_version(SupportedVersion::V1(V1::Two))
@@ -2339,9 +2374,7 @@ workflow test_basename {
                         .parameter(
                             "path",
                             PrimitiveType::Directory,
-                            "Path of the file or directory to read. If the argument is a \
-                             `String`, it is assumed to be a local file path relative to the \
-                             current working directory of the task.",
+                            "Path of the directory to read.",
                         )
                         .parameter(
                             "suffix",
@@ -2349,7 +2382,7 @@ workflow test_basename {
                             "(Optional) Suffix to remove from the file name.",
                         )
                         .ret(PrimitiveType::String)
-                        .definition(BASENAME_DEFINITION)
+                        .definition(BASENAME_DEFINITION_V1_2)
                         .build(),
                 ])
                 .into(),
@@ -2521,7 +2554,42 @@ task gen_files {
             .is_none()
     );
 
-    const SIZE_DEFINITION: &str = r#"
+    // https://github.com/openwdl/wdl/blob/wdl-1.0/SPEC.md#float-sizefile-string
+    const SIZE_DEFINITION_V1_0: &str = r#"
+Determines the size of a file or the sum of the file sizes contained within a compound value. Files may be optional; `None` values have a size of `0.0`. By default, the size is returned in bytes unless the optional second argument specifies a [unit](#units-of-storage).
+
+If the size cannot be represented in the specified unit because the resulting value is too large to fit in a `Float`, an error is raised.
+
+**Parameters**
+
+1. `File|File?|X`: A file or compound value containing files for which to determine the size.
+2. `String`: (Optional) The unit of storage; defaults to `B`.
+
+**Returns**: The size of the files as a `Float`.
+
+Example: file_sizes_task.wdl
+
+```wdl
+version 1.0
+
+task file_sizes {
+  input {
+    Array[File?] files
+  }
+
+  command <<<
+    true
+  >>>
+
+  output {
+    Float total_bytes = size(files)
+  }
+}
+```
+"#;
+
+    // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#size
+    const SIZE_DEFINITION_V1_2: &str = r#"
 Determines the size of a file, directory, or the sum total sizes of the files/directories contained within a compound value. The files may be optional values; `None` values have a size of `0.0`. By default, the size is returned in bytes unless the optional second argument is specified with a [unit](#units-of-storage)
 
 In the second variant of the `size` function, the parameter type `X` represents any compound type that contains `File` or `File?` nested at any depth.
@@ -2567,7 +2635,6 @@ task file_sizes {
 ```
 "#;
 
-    // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#size
     assert!(
         functions
             .insert(
@@ -2581,8 +2648,7 @@ task file_sizes {
                         .parameter(
                             "value",
                             Type::None,
-                            "A file, directory, or a compound value containing files/directories, \
-                             for which to determine the size."
+                            "An absent file system path, which has a size of `0.0`."
                         )
                         .parameter(
                             "unit",
@@ -2590,15 +2656,14 @@ task file_sizes {
                             "(Optional) The unit of storage; defaults to 'B'."
                         )
                         .ret(PrimitiveType::Float)
-                        .definition(SIZE_DEFINITION)
+                        .definition(SIZE_DEFINITION_V1_2)
                         .build(),
                     FunctionSignature::builder()
                         .required(1)
                         .parameter(
                             "value",
                             Type::from(PrimitiveType::File).optional(),
-                            "A file, directory, or a compound value containing files/directories, \
-                             for which to determine the size."
+                            "A file or optional file for which to determine the size."
                         )
                         .parameter(
                             "unit",
@@ -2606,7 +2671,7 @@ task file_sizes {
                             "(Optional) The unit of storage; defaults to 'B'."
                         )
                         .ret(PrimitiveType::Float)
-                        .definition(SIZE_DEFINITION)
+                        .definition(SIZE_DEFINITION_V1_0)
                         .build(),
                     // This overload isn't explicitly specified in the spec, but the spec
                     // allows for `String` where file/directory are accepted; an explicit
@@ -2618,8 +2683,8 @@ task file_sizes {
                         .parameter(
                             "value",
                             Type::from(PrimitiveType::String).optional(),
-                            "A file, directory, or a compound value containing files/directories, \
-                             for which to determine the size.",
+                            "A string path or optional string path for which to determine the \
+                             size.",
                         )
                         .parameter(
                             "unit",
@@ -2627,7 +2692,7 @@ task file_sizes {
                             "(Optional) The unit of storage; defaults to 'B'.",
                         )
                         .ret(PrimitiveType::Float)
-                        .definition(SIZE_DEFINITION)
+                        .definition(SIZE_DEFINITION_V1_2)
                         .build(),
                     FunctionSignature::builder()
                         .min_version(SupportedVersion::V1(V1::Two))
@@ -2635,8 +2700,7 @@ task file_sizes {
                         .parameter(
                             "value",
                             Type::from(PrimitiveType::Directory).optional(),
-                            "A file, directory, or a compound value containing files/directories, \
-                             for which to determine the size."
+                            "A directory or optional directory for which to determine the size."
                         )
                         .parameter(
                             "unit",
@@ -2644,7 +2708,7 @@ task file_sizes {
                             "(Optional) The unit of storage; defaults to 'B'."
                         )
                         .ret(PrimitiveType::Float)
-                        .definition(SIZE_DEFINITION)
+                        .definition(SIZE_DEFINITION_V1_2)
                         .build(),
                     FunctionSignature::builder()
                         .required(1)
@@ -2652,8 +2716,8 @@ task file_sizes {
                         .parameter(
                             "value",
                             GenericType::Parameter("X"),
-                            "A file, directory, or a compound value containing files/directories, \
-                             for which to determine the size."
+                            "A compound value containing file system paths for which to determine \
+                             the total size."
                         )
                         .parameter(
                             "unit",
@@ -2661,7 +2725,7 @@ task file_sizes {
                             "(Optional) The unit of storage; defaults to 'B'."
                         )
                         .ret(PrimitiveType::Float)
-                        .definition(SIZE_DEFINITION)
+                        .definition(SIZE_DEFINITION_V1_0)
                         .build(),
                 ])
                 .into(),
@@ -3038,8 +3102,42 @@ task write_lines {
             .is_none()
     );
 
-    const READ_TSV_DEFINITION: &str = r#"
-Reads a tab-separated value (TSV) file as an `Array[Array[String]]` representing a table of values. Trailing end-of-line characters (`` and `\n`) are removed from each line.
+    // https://github.com/openwdl/wdl/blob/wdl-1.0/SPEC.md#arrayarraystring-read_tsvstringfile
+    const READ_TSV_DEFINITION_V1_0: &str = r#"
+Reads a tab-separated value (TSV) file as an `Array[Array[String]]` representing a table of values. Trailing end-of-line characters (`\r` and `\n`) are removed from each line. There is no requirement that all rows have the same length.
+
+If the file is empty, an empty array is returned.
+
+**Parameters**
+
+1. `File`: The TSV file to read.
+
+**Returns**: An `Array` of rows in the TSV file, where each row is an `Array[String]` of fields.
+
+Example: read_tsv_task.wdl
+
+```wdl
+version 1.0
+
+task read_tsv {
+  input {
+    File data
+  }
+
+  command <<<
+    true
+  >>>
+
+  output {
+    Array[Array[String]] table = read_tsv(data)
+  }
+}
+```
+"#;
+
+    // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_tsv
+    const READ_TSV_DEFINITION_V1_2: &str = r#"
+Reads a tab-separated value (TSV) file as an `Array[Array[String]]` representing a table of values. Trailing end-of-line characters (`\r` and `\n`) are removed from each line.
 
 This function has three variants:
 
@@ -3090,7 +3188,6 @@ task read_tsv {
 ```
 "#;
 
-    // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_tsv
     assert!(
         functions
             .insert(
@@ -3099,7 +3196,7 @@ task read_tsv {
                     FunctionSignature::builder()
                         .parameter("file", PrimitiveType::File, "The TSV file to read.")
                         .ret(array_array_string.clone())
-                        .definition(READ_TSV_DEFINITION)
+                        .definition(READ_TSV_DEFINITION_V1_0)
                         .build(),
                     FunctionSignature::builder()
                         .min_version(SupportedVersion::V1(V1::Two))
@@ -3110,7 +3207,7 @@ task read_tsv {
                             "(Optional) Whether to treat the file's first line as a header.",
                         )
                         .ret(array_object.clone())
-                        .definition(READ_TSV_DEFINITION)
+                        .definition(READ_TSV_DEFINITION_V1_2)
                         .build(),
                     FunctionSignature::builder()
                         .min_version(SupportedVersion::V1(V1::Two))
@@ -3127,7 +3224,7 @@ task read_tsv {
                              parameter is also required.",
                         )
                         .ret(array_object.clone())
-                        .definition(READ_TSV_DEFINITION)
+                        .definition(READ_TSV_DEFINITION_V1_2)
                         .build(),
                 ])
                 .into(),
@@ -3135,7 +3232,35 @@ task read_tsv {
             .is_none()
     );
 
-    const WRITE_TSV_DEFINITION: &str = r#"
+    // https://github.com/openwdl/wdl/blob/wdl-1.0/SPEC.md#file-write_tsvarrayarraystring
+    const WRITE_TSV_DEFINITION_V1_0: &str = r#"
+Writes a tab-separated value (TSV) file with one line for each element in an `Array[Array[String]]`. Each row is joined with tab characters and terminated by a newline (`\n`). If the array is empty, an empty file is written.
+
+**Parameters**
+
+1. `Array[Array[String]]`: An array of rows, where each row is an array of column values.
+
+**Returns**: A `File`.
+
+Example: write_tsv_task.wdl
+
+```wdl
+version 1.0
+
+task write_tsv {
+  input {
+    Array[Array[String]] rows
+  }
+
+  command <<<
+    cat ~{write_tsv(rows)}
+  >>>
+}
+```
+"#;
+
+    // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_tsv
+    const WRITE_TSV_DEFINITION_V1_2: &str = r#"
 Given an `Array` of elements, writes a tab-separated value (TSV) file with one line for each element.
 
 There are three variants of this function:
@@ -3210,7 +3335,6 @@ task write_tsv {
 ```
 "#;
 
-    // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_tsv
     assert!(
         functions
             .insert(
@@ -3220,19 +3344,17 @@ task write_tsv {
                         .parameter(
                             "data",
                             array_array_string.clone(),
-                            "An array of rows, where each row is either an `Array` of column \
-                             values or a struct whose values are the column values.",
+                            "An array of rows, where each row is an array of column values.",
                         )
                         .ret(PrimitiveType::File)
-                        .definition(WRITE_TSV_DEFINITION)
+                        .definition(WRITE_TSV_DEFINITION_V1_0)
                         .build(),
                     FunctionSignature::builder()
                         .min_version(SupportedVersion::V1(V1::Two))
                         .parameter(
                             "data",
                             array_array_string.clone(),
-                            "An array of rows, where each row is either an `Array` of column \
-                             values or a struct whose values are the column values.",
+                            "An array of rows, where each row is an array of column values.",
                         )
                         .parameter(
                             "header",
@@ -3248,7 +3370,7 @@ task write_tsv {
                              is false."
                         )
                         .ret(PrimitiveType::File)
-                        .definition(WRITE_TSV_DEFINITION)
+                        .definition(WRITE_TSV_DEFINITION_V1_2)
                         .build(),
                     FunctionSignature::builder()
                         .min_version(SupportedVersion::V1(V1::Two))
@@ -3257,8 +3379,7 @@ task write_tsv {
                         .parameter(
                             "data",
                             GenericArrayType::new(GenericType::Parameter("S")),
-                            "An array of rows, where each row is either an `Array` of column \
-                             values or a struct whose values are the column values.",
+                            "An array of structures whose primitive member values form the rows.",
                         )
                         .parameter(
                             "header",
@@ -3274,7 +3395,7 @@ task write_tsv {
                              is false."
                         )
                         .ret(PrimitiveType::File)
-                        .definition(WRITE_TSV_DEFINITION)
+                        .definition(WRITE_TSV_DEFINITION_V1_2)
                         .build(),
                 ])
                 .into(),
@@ -3625,7 +3746,8 @@ task read_objects {
             .is_none()
     );
 
-    const WRITE_OBJECT_DEFINITION: &str = r#"
+    // https://github.com/openwdl/wdl/blob/wdl-1.0/SPEC.md#file-write_objectobject
+    const WRITE_OBJECT_DEFINITION_V1_0: &str = r#"
 Writes a tab-separated value (TSV) file representing the names and values of the members of an `Object`. The file will contain exactly two rows. The first row specifies the object member names. The second row specifies the object member values corresponding to the names in the first row.
 
 Each line is terminated by the newline (`\n`) character.
@@ -3643,7 +3765,7 @@ If the entire contents of the file can not be written for any reason, the callin
 Example: write_object_task.wdl
 
 ```wdl
-version 1.2
+version 1.0
 
 task write_object {
   input {
@@ -3661,7 +3783,40 @@ task write_object {
 ```
 "#;
 
-    // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_object
+    // https://github.com/openwdl/wdl/blob/wdl-1.1/SPEC.md#write_object
+    const WRITE_OBJECT_DEFINITION_V1_1: &str = r#"
+Writes a tab-separated value (TSV) file with the contents of an `Object` or `Struct`. The file contains two tab-delimited lines. The first line contains the member names, and the second line contains the corresponding values.
+
+Member values must be primitive types that can be serialized to strings. Attempting to write an `Object` or `Struct` with a compound member value results in an error.
+
+**Parameters**
+
+1. `Object|Struct`: An object or structure to write.
+
+**Returns**: A `File`.
+
+Example: write_object_task.wdl
+
+```wdl
+version 1.1
+
+struct Row {
+  String name
+  Int value
+}
+
+task write_object {
+  input {
+    Row row
+  }
+
+  command <<<
+    cat ~{write_object(row)}
+  >>>
+}
+```
+"#;
+
     assert!(
         functions
             .insert(
@@ -3670,14 +3825,18 @@ task write_object {
                     FunctionSignature::builder()
                         .parameter("object", Type::Object, "An object to write.")
                         .ret(PrimitiveType::File)
-                        .definition(WRITE_OBJECT_DEFINITION)
+                        .definition(WRITE_OBJECT_DEFINITION_V1_0)
                         .build(),
                     FunctionSignature::builder()
                         .min_version(SupportedVersion::V1(V1::One))
                         .type_parameter("S", PrimitiveStructConstraint)
-                        .parameter("object", GenericType::Parameter("S"), "An object to write.")
+                        .parameter(
+                            "object",
+                            GenericType::Parameter("S"),
+                            "A structure to write.",
+                        )
                         .ret(PrimitiveType::File)
-                        .definition(WRITE_OBJECT_DEFINITION)
+                        .definition(WRITE_OBJECT_DEFINITION_V1_1)
                         .build(),
                 ])
                 .into(),
@@ -3685,7 +3844,8 @@ task write_object {
             .is_none()
     );
 
-    const WRITE_OBJECTS_DEFINITION: &str = r#"
+    // https://github.com/openwdl/wdl/blob/wdl-1.0/SPEC.md#file-write_objectsarrayobject
+    const WRITE_OBJECTS_DEFINITION_V1_0: &str = r#"
 Writes a tab-separated value (TSV) file representing the names and values of the members of any number of `Object`s. The first line of the file will be a header row with the names of the object members. There will be one additional row for each element in the input array, where each additional row contains the values of an object corresponding to the member names.
 
 Each line is terminated by the newline (`\n`) character.
@@ -3703,7 +3863,7 @@ If the entire contents of the file can not be written for any reason, the callin
 Example: write_objects_task.wdl
 
 ```wdl
-version 1.2
+version 1.0
 
 task write_objects {
   input {
@@ -3725,7 +3885,40 @@ task write_objects {
 ```
 "#;
 
-    // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#write_objects
+    // https://github.com/openwdl/wdl/blob/wdl-1.1/SPEC.md#write_objects
+    const WRITE_OBJECTS_DEFINITION_V1_1: &str = r#"
+Writes a tab-separated value (TSV) file with the contents of an `Array[Object]` or `Array[Struct]`. The first line contains the member names, and each subsequent line contains the corresponding values for one array element.
+
+All array elements must have the same member names. Member values must be primitive types that can be serialized to strings. If the array is empty, an empty file is written.
+
+**Parameters**
+
+1. `Array[Object]|Array[Struct]`: An array of objects or structures to write.
+
+**Returns**: A `File`.
+
+Example: write_objects_task.wdl
+
+```wdl
+version 1.1
+
+struct Row {
+  String name
+  Int value
+}
+
+task write_objects {
+  input {
+    Array[Row] rows
+  }
+
+  command <<<
+    cat ~{write_objects(rows)}
+  >>>
+}
+```
+"#;
+
     assert!(
         functions
             .insert(
@@ -3734,7 +3927,7 @@ task write_objects {
                     FunctionSignature::builder()
                         .parameter("objects", array_object.clone(), "The objects to write.")
                         .ret(PrimitiveType::File)
-                        .definition(WRITE_OBJECTS_DEFINITION)
+                        .definition(WRITE_OBJECTS_DEFINITION_V1_0)
                         .build(),
                     FunctionSignature::builder()
                         .min_version(SupportedVersion::V1(V1::One))
@@ -3742,10 +3935,10 @@ task write_objects {
                         .parameter(
                             "objects",
                             GenericArrayType::new(GenericType::Parameter("S")),
-                            "The objects to write."
+                            "The structures to write."
                         )
                         .ret(PrimitiveType::File)
-                        .definition(WRITE_OBJECTS_DEFINITION)
+                        .definition(WRITE_OBJECTS_DEFINITION_V1_1)
                         .build(),
                 ])
                 .into(),
@@ -4647,7 +4840,8 @@ task as_map {
             .is_none()
     );
 
-    const KEYS_DEFINITION: &str = r#"
+    // https://github.com/openwdl/wdl/blob/wdl-1.1/SPEC.md#-keys
+    const KEYS_DEFINITION_V1_1: &str = r#"
 Given a `Map[K, V]` `m`, returns a new `Array[K]` containing all the keys in `m`. The order of the keys in the returned array is the same as the order in which the elements were added to the `Map`.
 
 If `m` is empty, an empty array is returned.
@@ -4661,7 +4855,7 @@ If `m` is empty, an empty array is returned.
 Example: keys_map_task.wdl
 
 ```wdl
-version 1.2
+version 1.1
 
 task keys_map {
   input {
@@ -4676,6 +4870,39 @@ task keys_map {
 "#;
 
     // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#keys
+    const KEYS_DEFINITION_V1_2: &str = r#"
+Given a key-value collection (`Map`, `Struct`, or `Object`), returns an `Array` containing its keys.
+
+Map keys retain their insertion order. Struct keys retain their definition order. Object key order is unspecified. If a `Map` or `Object` is empty, an empty array is returned.
+
+**Parameters**
+
+1. `Map[K, V]|Struct|Object`: Collection from which to extract keys.
+
+**Returns**: An `Array[K]` for a `Map`, or an `Array[String]` for a `Struct` or `Object`.
+
+Example: keys_task.wdl
+
+```wdl
+version 1.2
+
+struct Name {
+  String first
+  String last
+}
+
+workflow keys_task {
+  input {
+    Name name
+  }
+
+  output {
+    Array[String] fields = keys(name)
+  }
+}
+```
+"#;
+
     assert!(
         functions
             .insert(
@@ -4694,7 +4921,7 @@ task keys_map {
                             "Collection from which to extract keys.",
                         )
                         .ret(GenericArrayType::new(GenericType::Parameter("K")))
-                        .definition(KEYS_DEFINITION)
+                        .definition(KEYS_DEFINITION_V1_1)
                         .build(),
                     FunctionSignature::builder()
                         .min_version(SupportedVersion::V1(V1::Two))
@@ -4705,7 +4932,7 @@ task keys_map {
                             "Collection from which to extract keys.",
                         )
                         .ret(array_string.clone())
-                        .definition(KEYS_DEFINITION)
+                        .definition(KEYS_DEFINITION_V1_2)
                         .build(),
                     FunctionSignature::builder()
                         .min_version(SupportedVersion::V1(V1::Two))
@@ -4715,7 +4942,7 @@ task keys_map {
                             "Collection from which to extract keys.",
                         )
                         .ret(array_string.clone())
-                        .definition(KEYS_DEFINITION)
+                        .definition(KEYS_DEFINITION_V1_2)
                         .build(),
                 ])
                 .into(),
@@ -5190,6 +5417,8 @@ task length_array {
 
 #[cfg(test)]
 mod test {
+    use std::collections::BTreeMap;
+
     use pretty_assertions::assert_eq;
 
     use super::*;
@@ -5242,7 +5471,7 @@ mod test {
                 "size(value: String?, <unit: String>) -> Float",
                 "size(value: Directory?, <unit: String>) -> Float",
                 "size(value: X, <unit: String>) -> Float where `X`: any compound type that \
-                 recursively contains a `File` or `Directory`",
+                 recursively contains a file system path",
                 "stdout() -> File",
                 "stderr() -> File",
                 "read_string(file: File) -> String",
@@ -5312,6 +5541,107 @@ mod test {
                 "length(string: String) -> Int",
             ]
         );
+    }
+
+    #[test_log::test]
+    fn verify_versioned_polymorphic_definitions() {
+        fn definition(name: &str, version: V1) -> &'static str {
+            let Function::Polymorphic(function) =
+                STDLIB.function(name).expect("function should exist")
+            else {
+                panic!("function should be polymorphic");
+            };
+
+            function
+                .definition(SupportedVersion::V1(version))
+                .expect("function should have a definition")
+        }
+
+        let v1_0 = V1::Zero;
+        let v1_1 = V1::One;
+        let v1_2 = V1::Two;
+        let v1_3 = V1::Three;
+
+        assert!(definition("basename", v1_0).contains("basename\" of a file -"));
+        assert!(!definition("basename", v1_0).contains("file or directory"));
+        assert_eq!(definition("basename", v1_0), definition("basename", v1_1));
+        assert!(definition("basename", v1_2).contains("file or directory"));
+
+        assert!(definition("size", v1_0).contains("sum of the file sizes"));
+        assert!(!definition("size", v1_0).contains("files/directories"));
+        assert_eq!(definition("size", v1_0), definition("size", v1_1));
+        assert!(definition("size", v1_2).contains("file, directory"));
+
+        for name in ["read_tsv", "write_tsv"] {
+            assert!(!definition(name, v1_0).contains("three variants"));
+            assert_eq!(definition(name, v1_0), definition(name, v1_1));
+            assert!(definition(name, v1_2).contains("three variants"));
+        }
+
+        for name in ["write_object", "write_objects"] {
+            assert!(!definition(name, v1_0).contains("Struct"));
+            assert!(definition(name, v1_1).contains("Struct"));
+            assert_eq!(definition(name, v1_1), definition(name, v1_2));
+        }
+
+        assert!(definition("keys", v1_1).contains("Given a `Map"));
+        assert!(!definition("keys", v1_1).contains("`Struct`"));
+        assert!(definition("keys", v1_2).contains("`Struct`"));
+
+        for name in [
+            "basename",
+            "size",
+            "read_tsv",
+            "write_tsv",
+            "write_object",
+            "write_objects",
+            "keys",
+        ] {
+            assert_eq!(definition(name, v1_2), definition(name, v1_3));
+        }
+    }
+
+    #[test_log::test]
+    fn verify_polymorphic_definition_tiers() {
+        const MIXED_VERSION_FUNCTIONS: [&str; 7] = [
+            "basename",
+            "size",
+            "read_tsv",
+            "write_tsv",
+            "write_object",
+            "write_objects",
+            "keys",
+        ];
+
+        for (name, function) in STDLIB.functions() {
+            let Function::Polymorphic(function) = function else {
+                continue;
+            };
+
+            let mut tiers = BTreeMap::new();
+            for signature in function.signatures() {
+                let definition = signature
+                    .definition()
+                    .expect("every polymorphic signature should have a definition");
+                if let Some(existing) = tiers.get(&signature.minimum_version()) {
+                    assert_eq!(
+                        *existing, definition,
+                        "`{name}` signatures in the same version tier should share prose"
+                    );
+                } else {
+                    tiers.insert(signature.minimum_version(), definition);
+                }
+            }
+
+            if MIXED_VERSION_FUNCTIONS.contains(&name) {
+                let definitions = tiers.values().copied().collect::<IndexSet<_>>();
+                assert_eq!(
+                    definitions.len(),
+                    tiers.len(),
+                    "`{name}` should have distinct prose for each version tier"
+                );
+            }
+        }
     }
 
     #[test_log::test]

--- a/crates/wdl-analysis/src/stdlib.rs
+++ b/crates/wdl-analysis/src/stdlib.rs
@@ -2276,32 +2276,8 @@ workflow test_split {
 
     // https://github.com/openwdl/wdl/blob/wdl-1.0/SPEC.md#string-basenamestring
     const BASENAME_DEFINITION_V1_0: &str = r#"
-Returns the "basename" of a file - the name after the last directory separator in the file's path.
-
-The optional second parameter specifies a literal suffix to remove from the file name. If the file name does not end with the specified suffix then it is ignored.
-
-**Parameters**
-
-1. `File`: Path of the file to read.
-2. `String`: (Optional) Suffix to remove from the file name.
-
-**Returns**: The file's basename as a `String`.
-
-Example: test_basename.wdl
-
-```wdl
-version 1.0
-
-workflow test_basename {
-  input {
-    File file
-  }
-
-  output {
-    Boolean unchanged = basename(file, ".txt") == basename(file)
-  }
-}
-```
+- This function returns the basename of a file path passed to it: `basename("/path/to/file.txt")` returns `"file.txt"`.
+- Also supports an optional parameter, suffix to remove: `basename("/path/to/file.txt", ".txt")` returns `"file"`.
 "#;
 
     // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#basename
@@ -2556,36 +2532,38 @@ task gen_files {
 
     // https://github.com/openwdl/wdl/blob/wdl-1.0/SPEC.md#float-sizefile-string
     const SIZE_DEFINITION_V1_0: &str = r#"
-Determines the size of a file or the sum of the file sizes contained within a compound value. Files may be optional; `None` values have a size of `0.0`. By default, the size is returned in bytes unless the optional second argument specifies a [unit](#units-of-storage).
-
-If the size cannot be represented in the specified unit because the resulting value is too large to fit in a `Float`, an error is raised.
-
-**Parameters**
-
-1. `File|File?|X`: A file or compound value containing files for which to determine the size.
-2. `String`: (Optional) The unit of storage; defaults to `B`.
-
-**Returns**: The size of the files as a `Float`.
-
-Example: file_sizes_task.wdl
+Given a `File` and a `String` (optional), returns the size of the file in Bytes or in the unit specified by the second argument.
 
 ```wdl
 version 1.0
 
-task file_sizes {
+task example {
   input {
-    Array[File?] files
+    File input_file
   }
 
-  command <<<
-    true
-  >>>
+  command {
+    echo "this file is 22 bytes" > created_file
+  }
 
   output {
-    Float total_bytes = size(files)
+    Float input_file_size = size(input_file)
+    Float created_file_size = size("created_file") # 22.0
+    Float created_file_size_in_KB = size("created_file", "K") # 0.022
   }
 }
 ```
+
+Supported units are KiloByte ("K", "KB"), MegaByte ("M", "MB"), GigaByte ("G", "GB"), TeraByte ("T", "TB") as well as their [binary version](https://en.wikipedia.org/wiki/Binary_prefix) "Ki" ("KiB"), "Mi" ("MiB"), "Gi" ("GiB"), "Ti" ("TiB").
+Default unit is Bytes ("B").
+
+### Acceptable compound input types
+
+Varieties of the `size` function also exist for the following compound types. The `String` unit is always treated the same as above. Note that to avoid numerical overflow, very long arrays of files should probably favor larger units.
+
+- `Float size(File?, [String])`: Returns the size of the file, if specified, or 0.0 otherwise.
+- `Float size(Array[File], [String])`: Returns the sum of sizes of the files in the array.
+- `Float size(Array[File?], [String])`: Returns the sum of sizes of all specified files in the array.
 "#;
 
     // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#size
@@ -3104,35 +3082,31 @@ task write_lines {
 
     // https://github.com/openwdl/wdl/blob/wdl-1.0/SPEC.md#arrayarraystring-read_tsvstringfile
     const READ_TSV_DEFINITION_V1_0: &str = r#"
-Reads a tab-separated value (TSV) file as an `Array[Array[String]]` representing a table of values. Trailing end-of-line characters (`\r` and `\n`) are removed from each line. There is no requirement that all rows have the same length.
+The `read_tsv()` function takes one parameter, which is a file-like object (`String`, `File`) and returns an `Array[Array[String]]` representing the table from the TSV file.
 
-If the file is empty, an empty array is returned.
+If the parameter is a `String`, this is assumed to be a local file path relative to the current working directory of the task.
 
-**Parameters**
-
-1. `File`: The TSV file to read.
-
-**Returns**: An `Array` of rows in the TSV file, where each row is an `Array[String]` of fields.
-
-Example: read_tsv_task.wdl
+For example, if I write a task that outputs a file to `./results/file_list.tsv`, and my task is defined as:
 
 ```wdl
 version 1.0
 
-task read_tsv {
+task do_stuff {
   input {
-    File data
+    File file
   }
-
-  command <<<
-    true
-  >>>
-
+  command {
+    python do_stuff.py ${file}
+  }
   output {
-    Array[Array[String]] table = read_tsv(data)
+    Array[Array[String]] output_table = read_tsv("./results/file_list.tsv")
   }
 }
 ```
+
+Then when the task finishes, to fulfill the `outputs_table` variable, `./results/file_list.tsv` must be a valid TSV file or an error will be reported.
+
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. Examples of failure include but are not limited to not having access to the file, resource limitations (e.g. memory) when reading the file, and implementation-imposed file size limits.
 "#;
 
     // https://github.com/openwdl/wdl/blob/wdl-1.2/SPEC.md#read_tsv
@@ -3234,28 +3208,30 @@ task read_tsv {
 
     // https://github.com/openwdl/wdl/blob/wdl-1.0/SPEC.md#file-write_tsvarrayarraystring
     const WRITE_TSV_DEFINITION_V1_0: &str = r#"
-Writes a tab-separated value (TSV) file with one line for each element in an `Array[Array[String]]`. Each row is joined with tab characters and terminated by a newline (`\n`). If the array is empty, an empty file is written.
-
-**Parameters**
-
-1. `Array[Array[String]]`: An array of rows, where each row is an array of column values.
-
-**Returns**: A `File`.
-
-Example: write_tsv_task.wdl
+Given something that's compatible with `Array[Array[String]]`, this writes a TSV file of the data structure.
 
 ```wdl
 version 1.0
 
-task write_tsv {
-  input {
-    Array[Array[String]] rows
+task example {
+  Array[String] array = [["one", "two", "three"], ["un", "deux", "trois"]]
+  command {
+    ./script --tsv=${write_tsv(array)}
   }
-
-  command <<<
-    cat ~{write_tsv(rows)}
-  >>>
 }
+```
+
+If this task were run, the command might look like:
+
+```
+./script --tsv=/local/fs/tmp/array.tsv
+```
+
+And `/local/fs/tmp/array.tsv` would contain:
+
+```
+one\ttwo\tthree
+un\tdeux\ttrois
 ```
 "#;
 
@@ -3748,38 +3724,41 @@ task read_objects {
 
     // https://github.com/openwdl/wdl/blob/wdl-1.0/SPEC.md#file-write_objectobject
     const WRITE_OBJECT_DEFINITION_V1_0: &str = r#"
-Writes a tab-separated value (TSV) file representing the names and values of the members of an `Object`. The file will contain exactly two rows. The first row specifies the object member names. The second row specifies the object member values corresponding to the names in the first row.
-
-Each line is terminated by the newline (`\n`) character.
-
-The generated file should be given a random name and written in a temporary directory, so as not to conflict with any other task output files.
-
-If the entire contents of the file can not be written for any reason, the calling task or workflow fails with an error. Examples of failure include, but are not limited to, insufficient disk space to write the file.
-
-**Parameters**
-
-1. `Object`: An `Object` whose members will be written to the file.
-
-**Returns**: A `File`.
-
-Example: write_object_task.wdl
+Given any `Object`, this will write out a 2-row, n-column TSV file with the object's attributes and values.
 
 ```wdl
 version 1.0
 
-task write_object {
-  input {
-    Object my_obj = {"key_0": "value_A0", "key_1": "value_A1", "key_2": "value_A2"}
-  }
-
+task test {
+  Object input
   command <<<
-    cat ~{write_object(my_obj)}
+    /bin/do_work --obj=~{write_object(input)}
   >>>
-
   output {
-    Object new_obj = read_object(stdout())
+    File results = stdout()
   }
 }
+```
+
+If `input` were to have the value:
+
+|Attribute|Value|
+|---------|-----|
+|key_1    |"value_1"|
+|key_2    |"value_2"|
+|key_3    |"value_3"|
+
+The command would instantiate to:
+
+```
+/bin/do_work --obj=/path/to/input.tsv
+```
+
+Where `/path/to/input.tsv` would contain:
+
+```
+key_1\tkey_2\tkey_3
+value_1\tvalue_2\tvalue_3
 ```
 "#;
 
@@ -3846,42 +3825,51 @@ task write_object {
 
     // https://github.com/openwdl/wdl/blob/wdl-1.0/SPEC.md#file-write_objectsarrayobject
     const WRITE_OBJECTS_DEFINITION_V1_0: &str = r#"
-Writes a tab-separated value (TSV) file representing the names and values of the members of any number of `Object`s. The first line of the file will be a header row with the names of the object members. There will be one additional row for each element in the input array, where each additional row contains the values of an object corresponding to the member names.
-
-Each line is terminated by the newline (`\n`) character.
-
-The generated file should be given a random name and written in a temporary directory, so as not to conflict with any other task output files.
-
-If the entire contents of the file can not be written for any reason, the calling task or workflow fails with an error. Examples of failure include, but are not limited to, insufficient disk space to write the file.
-
-**Parameters**
-
-1. `Array[Object]`: An `Array[Object]` whose elements will be written to the file.
-
-**Returns**: A `File`.
-
-Example: write_objects_task.wdl
+Given any `Array[Object]`, this will write out a 2+ row, n-column TSV file with each object's attributes and values.
 
 ```wdl
 version 1.0
 
-task write_objects {
+task test {
   input {
-    Array[Object] my_objs = [
-      {"key_0": "value_A0", "key_1": "value_A1", "key_2": "value_A2"},
-      {"key_0": "value_B0", "key_1": "value_B1", "key_2": "value_B2"},
-      {"key_0": "value_C0", "key_1": "value_C1", "key_2": "value_C2"}
-    ]
+    Array[Object] in
   }
-
   command <<<
-    cat ~{write_objects(my_objs)}
+    /bin/do_work --obj=~{write_objects(in)}
   >>>
-
   output {
-    Array[Object] new_objs = read_objects(stdout())
+    File results = stdout()
   }
 }
+```
+
+If `in` were to have the value:
+
+|Index|Attribute|Value|
+|-----|---------|-----|
+|0    |key_1    |"value_1"|
+|     |key_2    |"value_2"|
+|     |key_3    |"value_3"|
+|1    |key_1    |"value_4"|
+|     |key_2    |"value_5"|
+|     |key_3    |"value_6"|
+|2    |key_1    |"value_7"|
+|     |key_2    |"value_8"|
+|     |key_3    |"value_9"|
+
+The command would instantiate to:
+
+```
+/bin/do_work --obj=/path/to/input.tsv
+```
+
+Where `/path/to/input.tsv` would contain:
+
+```
+key_1\tkey_2\tkey_3
+value_1\tvalue_2\tvalue_3
+value_4\tvalue_5\tvalue_6
+value_7\tvalue_8\tvalue_9
 ```
 "#;
 
@@ -5562,12 +5550,12 @@ mod test {
         let v1_2 = V1::Two;
         let v1_3 = V1::Three;
 
-        assert!(definition("basename", v1_0).contains("basename\" of a file -"));
+        assert!(definition("basename", v1_0).contains("basename of a file path passed to it"));
         assert!(!definition("basename", v1_0).contains("file or directory"));
         assert_eq!(definition("basename", v1_0), definition("basename", v1_1));
         assert!(definition("basename", v1_2).contains("file or directory"));
 
-        assert!(definition("size", v1_0).contains("sum of the file sizes"));
+        assert!(definition("size", v1_0).contains("Given a `File` and a `String`"));
         assert!(!definition("size", v1_0).contains("files/directories"));
         assert_eq!(definition("size", v1_0), definition("size", v1_1));
         assert!(definition("size", v1_2).contains("file, directory"));

--- a/crates/wdl-analysis/src/stdlib/constraints.rs
+++ b/crates/wdl-analysis/src/stdlib/constraints.rs
@@ -29,7 +29,7 @@ pub struct SizeableConstraint;
 
 impl Constraint for SizeableConstraint {
     fn description(&self) -> &'static str {
-        "any compound type that recursively contains a `File` or `Directory`"
+        "any compound type that recursively contains a file system path"
     }
 
     fn satisfied(&self, ty: &Type) -> bool {

--- a/crates/wdl-engine/src/stdlib/size.rs
+++ b/crates/wdl-engine/src/stdlib/size.rs
@@ -359,7 +359,7 @@ pub const fn descriptor() -> Function {
                 ),
                 Signature::new(
                     "(value: X, <unit: String>) -> Float where `X`: any compound type that \
-                     recursively contains a `File` or `Directory`",
+                     recursively contains a file system path",
                     Callback::Async(size),
                 ),
             ]

--- a/crates/wdl-lsp/tests/requests/completions.rs
+++ b/crates/wdl-lsp/tests/requests/completions.rs
@@ -6,6 +6,7 @@ use async_lsp::lsp_types::CompletionItemKind;
 use async_lsp::lsp_types::CompletionParams;
 use async_lsp::lsp_types::CompletionResponse;
 use async_lsp::lsp_types::CompletionTriggerKind;
+use async_lsp::lsp_types::Documentation;
 use async_lsp::lsp_types::Position;
 use async_lsp::lsp_types::TextDocumentIdentifier;
 use async_lsp::lsp_types::TextDocumentPositionParams;
@@ -392,6 +393,19 @@ async fn should_complete_scope_variables_v1_0_stdlib() {
     assert_not_contains(&items, "find");
     assert_not_contains(&items, "chunk");
     assert_not_contains(&items, "matches");
+
+    let basename_items = items
+        .iter()
+        .filter(|item| item.label == "basename")
+        .collect::<Vec<_>>();
+    assert!(!basename_items.is_empty());
+    for item in basename_items {
+        let Some(Documentation::MarkupContent(documentation)) = &item.documentation else {
+            panic!("basename completion should have markdown documentation");
+        };
+        assert!(documentation.value.contains("version 1.0"));
+        assert!(!documentation.value.contains("file or directory"));
+    }
 }
 
 #[tokio::test]

--- a/crates/wdl-lsp/tests/requests/completions.rs
+++ b/crates/wdl-lsp/tests/requests/completions.rs
@@ -403,7 +403,11 @@ async fn should_complete_scope_variables_v1_0_stdlib() {
         let Some(Documentation::MarkupContent(documentation)) = &item.documentation else {
             panic!("basename completion should have markdown documentation");
         };
-        assert!(documentation.value.contains("version 1.0"));
+        assert!(
+            documentation
+                .value
+                .contains("basename of a file path passed to it")
+        );
         assert!(!documentation.value.contains("file or directory"));
     }
 }

--- a/crates/wdl-lsp/tests/requests/hover.rs
+++ b/crates/wdl-lsp/tests/requests/hover.rs
@@ -206,8 +206,7 @@ async fn should_hover_version_filtering_v1_0() {
         &response,
         "basename(path: Directory, <suffix: String>) -> String",
     );
-    assert_hover_content(&response, "Returns the \"basename\" of a file -");
-    assert_hover_content(&response, "version 1.0");
+    assert_hover_content(&response, "basename of a file path passed to it");
     assert_hover_not_content(&response, "file or directory");
     // Position of `split`
     let response = hover_request(&mut ctx, wdl, Position::new(12, 23))

--- a/crates/wdl-lsp/tests/requests/hover.rs
+++ b/crates/wdl-lsp/tests/requests/hover.rs
@@ -169,6 +169,8 @@ async fn should_hover_version_filtering() {
         &response,
         "basename(path: Directory, <suffix: String>) -> String",
     );
+    assert_hover_content(&response, "Returns the \"basename\" of a file or directory");
+    assert_hover_content(&response, "version 1.2");
     // Position of `split`
     let response = hover_request(&mut ctx, wdl, Position::new(12, 23))
         .await
@@ -204,6 +206,9 @@ async fn should_hover_version_filtering_v1_0() {
         &response,
         "basename(path: Directory, <suffix: String>) -> String",
     );
+    assert_hover_content(&response, "Returns the \"basename\" of a file -");
+    assert_hover_content(&response, "version 1.0");
+    assert_hover_not_content(&response, "file or directory");
     // Position of `split`
     let response = hover_request(&mut ctx, wdl, Position::new(12, 23))
         .await

--- a/crates/wdl-lsp/tests/requests/signature_help.rs
+++ b/crates/wdl-lsp/tests/requests/signature_help.rs
@@ -1,12 +1,16 @@
 //! Integration tests for the `textDocument/signatureHelp` request.
 
+use async_lsp::lsp_types::DidChangeTextDocumentParams;
 use async_lsp::lsp_types::ParameterLabel;
 use async_lsp::lsp_types::Position;
 use async_lsp::lsp_types::SignatureHelp;
 use async_lsp::lsp_types::SignatureHelpParams;
 use async_lsp::lsp_types::SignatureHelpTriggerKind;
+use async_lsp::lsp_types::TextDocumentContentChangeEvent;
 use async_lsp::lsp_types::TextDocumentIdentifier;
 use async_lsp::lsp_types::TextDocumentPositionParams;
+use async_lsp::lsp_types::VersionedTextDocumentIdentifier;
+use async_lsp::lsp_types::notification::DidChangeTextDocument;
 use async_lsp::lsp_types::request::SignatureHelpRequest;
 use pretty_assertions::assert_eq;
 
@@ -116,4 +120,61 @@ async fn should_provide_signature_help_for_polymorphic_function() {
     let param_info = &sig_info.parameters.as_ref().unwrap();
     assert_eq!(param_info[0].label, ParameterLabel::LabelOffsets([5, 17]));
     assert_eq!(param_info[1].label, ParameterLabel::LabelOffsets([20, 32]));
+}
+
+#[tokio::test]
+async fn should_filter_signature_help_by_version() {
+    let mut ctx = setup().await;
+
+    let response = signature_help_request(&mut ctx, "source_v1_0.wdl", Position::new(7, 24))
+        .await
+        .expect("request should succeed");
+    let help = response.expect("should have a signature help response");
+
+    assert_eq!(help.signatures.len(), 2);
+    assert!(
+        help.signatures
+            .iter()
+            .all(|signature| !signature.label.contains("Directory"))
+    );
+    assert!(help.signatures.iter().all(|signature| {
+        let Some(async_lsp::lsp_types::Documentation::MarkupContent(documentation)) =
+            &signature.documentation
+        else {
+            return false;
+        };
+        documentation.value.contains("version 1.0")
+            && !documentation.value.contains("files/directories")
+    }));
+
+    let response = signature_help_request(&mut ctx, "source_v1_0.wdl", Position::new(8, 36))
+        .await
+        .expect("request should succeed");
+    assert!(response.is_none());
+}
+
+#[tokio::test]
+async fn should_provide_signature_help_during_incremental_change() {
+    let mut ctx = setup().await;
+    let path = "source.wdl";
+    let mut text = std::fs::read_to_string(ctx.doc_path(path)).expect("source should be readable");
+    text.push('\n');
+
+    ctx.notify::<DidChangeTextDocument>(DidChangeTextDocumentParams {
+        text_document: VersionedTextDocumentIdentifier {
+            uri: ctx.doc_uri(path),
+            version: 1,
+        },
+        content_changes: vec![TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text,
+        }],
+    })
+    .expect("notification should succeed");
+
+    let response = signature_help_request(&mut ctx, path, Position::new(7, 24))
+        .await
+        .expect("request should succeed");
+    assert!(response.is_some());
 }

--- a/crates/wdl-lsp/tests/workspace/signature_help/source_v1_0.wdl
+++ b/crates/wdl-lsp/tests/workspace/signature_help/source_v1_0.wdl
@@ -1,0 +1,11 @@
+version 1.0
+
+workflow main {
+
+    output {
+        String s = read_string()
+        String sub = sub("a", "b", )
+        Float sz = size()
+        Array[String] parts = split("a,b", ",")
+    }
+}


### PR DESCRIPTION
Standard-library hover filtered overloads by the document's WDL version but still described newer behavior. Signature help also exposed overloads introduced after the declared version.

I added documentation tiers for the seven affected polymorphic functions and selected the newest eligible tier consistently across hover, completion, and signature help. Signature help now filters overloads without disappearing during incremental edits, and the shared `size` overload description now says "a file system path" so it reads correctly in every version instead of naming the WDL 1.2-only `Directory` type.

Closes #1006.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
