### PR TITLE
docs: define Sprocket 1.x compatibility policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,7 @@ For all contributors:
 - [ ] You have added tests (when appropriate).
 - [ ] You have added an entry in the CHANGELOG (when appropriate).
 - [ ] You have updated the README or other documentation to account for these changes (when appropriate).
+- [ ] You have classified changes to stable interfaces under the [compatibility policy](https://github.com/stjude-rust-labs/sprocket/blob/main/COMPATIBILITY.md) (when appropriate).
 - [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).
 
 For PRs containing lint rule changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+The `wdl` and `wdl-*` Rust crates and any separately released Python bindings
+follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). The
+`sprocket` executable and its root Rust library do not; executable compatibility
+is defined by the [Sprocket compatibility policy](COMPATIBILITY.md).
 
 ## Unreleased
 
+### Added
+
+* Added the Sprocket 1.x compatibility and deprecation policy
+  ([#1071](https://github.com/stjude-rust-labs/sprocket/issues/1071)).
+
 ### Changed
 
+* `sprocket config init` now references the `sprocket.toml` schema from its
+  release tag instead of the changing `main` branch
+  ([#1071](https://github.com/stjude-rust-labs/sprocket/issues/1071)).
 * `sprocket run` and `sprocket dev test` now warn on a second Ctrl-C that
   terminating Sprocket leaves Docker containers running
   ([#1020](https://github.com/stjude-rust-labs/sprocket/issues/1020)).

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,225 @@
+# Sprocket Compatibility Policy
+
+This document defines the compatibility guarantees for the `sprocket` command
+line tool beginning with Sprocket 1.0. It applies to every Sprocket 1.x release.
+Before 1.0, any interface may change without the notice required by this
+policy.
+
+## Versioning
+
+The `sprocket` executable uses `MAJOR.MINOR.PATCH` version numbers, but it does
+not use Semantic Versioning to communicate compatibility.
+
+- Patch releases contain bug fixes and compatible behavioral corrections.
+- Minor releases may add compatible features and remove features whose full
+  deprecation period has elapsed.
+- Major versions identify broader changes in Sprocket's functionality or
+  purpose. A major version does not necessarily contain a breaking change.
+
+This policy governs the 1.x release line. A later major release may publish a
+successor policy, but changing the major version does not by itself waive the
+review and notice requirements in this document.
+
+The `wdl` and `wdl-*` Rust crates and any separately released Python bindings
+follow [Semantic Versioning](https://semver.org/) according to their own package
+versions. Sprocket 1.0 does not stabilize those APIs. In particular, a pre-1.0
+package may make a SemVer-permitted breaking change in a minor release.
+
+The Rust library in the root `sprocket` package is an experimental
+implementation interface. It shares the executable's version and does not have
+a separate SemVer compatibility guarantee. Users should not depend on the
+`sprocket` crate as a library; the project neither recommends nor supports that
+use.
+
+## Stable Interfaces
+
+Beginning with Sprocket 1.0, the following interfaces are stable unless their
+documentation explicitly marks them experimental:
+
+| Interface | Stable contract | Documentation of record |
+| --- | --- | --- |
+| Command line | Non-`dev` commands, options, arguments, and documented behavior | `sprocket --help`, subcommand help, and [Sprocket documentation](https://sprocket.bio/) |
+| Process behavior | Documented exit statuses and placement of output on standard output or standard error | This policy, command help, and [Sprocket documentation](https://sprocket.bio/) |
+| Configuration | Documented `sprocket.toml` keys, value types, defaults, and meanings | The version of `jsonschemas/sprocket.toml.json` shipped with the release for structure and types, and [configuration documentation](https://sprocket.bio/configuration/overview.html) for behavior |
+| HTTP API | `/api/v1` paths, methods, parameters, request and response bodies, status codes, and documented meanings | The server's `/api/v1/openapi.json` document and [server documentation](https://sprocket.bio/subcommands/server.html) |
+| Machine-readable output | Documented JSON fields, types, meanings, exit status, and output stream, including documented generated JSON files | Command help and [Sprocket documentation](https://sprocket.bio/) |
+| Run artifacts | Documented `inputs.json` and `outputs.json` formats and documented `--index-on` behavior | [Provenance documentation](https://sprocket.bio/concepts/provenance.html) |
+
+An interface that is not documented is outside this contract until its
+documentation explicitly adds it. Internal Rust types and implementation
+details are not made stable merely because they are public in generated API
+documentation.
+
+### Exit Status and Stream Conventions
+
+Sprocket uses these command-wide exit statuses:
+
+| Status | Meaning |
+| --- | --- |
+| `0` | The command completed successfully. |
+| `1` | The command could not complete successfully, including configuration, validation, analysis, execution, or operational failures. |
+| `2` | The command line could not be parsed, or an argument value failed argument-level validation, such as when a source path does not exist. |
+
+Unless a command documents a different contract, its requested result or
+machine-readable payload goes to standard output. Diagnostics, warnings,
+progress, prompts, and logs go to standard error. Moving documented output to
+the other stream is a breaking change.
+
+Human-readable wording, whitespace, layout, color, progress displays,
+diagnostic prose, and log messages are not stable. Scripts must not parse
+human-readable output. A machine-readable format is stable only when the
+documentation identifies its format and stream.
+
+## Experimental Interfaces
+
+Experimental interfaces may change or be removed without the stable
+deprecation period. User-visible experimental changes must still appear in the
+release notes.
+
+The following interfaces are experimental or otherwise outside the executable
+compatibility contract:
+
+- Commands, options, formats, and behavior under `sprocket dev`.
+- `module.json`, `module-lock.json`, module signatures, and related module
+  formats while module commands remain under `sprocket dev module`.
+- WDL test definitions and their schema while testing remains under
+  `sprocket dev test`.
+- WDL 1.4 support.
+- Configuration keys and features explicitly marked experimental.
+- Configuration keys that exclusively configure `sprocket dev` commands until
+  those commands graduate.
+- The internal run directory layout, including `runs/`, `_latest`, task attempt
+  directories, and the `sprocket.db` schema. This does not include the
+  documented `inputs.json` and `outputs.json` formats or documented
+  `--index-on` behavior.
+- The root `sprocket` Rust library API.
+- APIs from separately versioned packages, such as the `wdl` and `wdl-*` Rust
+  crates and any separately released Python bindings. Their package versions,
+  rather than this executable policy, govern compatibility.
+- Undocumented interfaces and implementation details.
+- Human-readable output details excluded under
+  [Exit Status and Stream Conventions](#exit-status-and-stream-conventions).
+
+The `sprocket analyzer` command's documented invocation is stable, but LSP
+capabilities and protocol behavior are stable only when Sprocket documentation
+explicitly describes them.
+
+A pull request that moves a command or feature out of `dev` must list every
+command, option, file format, schema, and behavior that becomes stable. The
+release notes must announce that transition.
+
+The server must graduate from `sprocket dev server` before Sprocket 1.0 makes
+`/api/v1` stable. Sprocket 1.0 must not be released while `/api/v1` is available
+only through the experimental `dev` namespace.
+
+### Database Schema
+
+The `sprocket.db` schema is an internal implementation detail and is explicitly
+not backward compatible. Sprocket may add, remove, rename, or transform tables,
+columns, indexes, and stored values whenever its bundled migration can upgrade
+an existing database safely. Migrations must preserve the data and behavior
+needed by supported Sprocket commands, including user data those commands
+manage.
+
+Users must not query or modify the database directly. Use commands and APIs
+provided by Sprocket. If Sprocket does not expose a needed operation, request a
+supported command or API rather than depending on the schema.
+
+Sprocket supports forward migration by newer releases. A database migrated by a
+newer Sprocket release is not guaranteed to work with an older release.
+
+## Compatible and Breaking Changes
+
+Compatible changes preserve documented behavior for existing users. Examples
+include:
+
+- Adding an optional command-line option without changing existing defaults.
+- Accepting an input that an earlier release rejected.
+- Adding an optional `sprocket.toml` key.
+- Adding an optional field to an extensible JSON object.
+- Adding an HTTP endpoint without changing an existing endpoint.
+- Fixing behavior that contradicts the documentation.
+
+Consumers of extensible JSON objects must ignore fields they do not recognize.
+An enumeration is not extensible unless its documentation says so; adding a
+variant to a closed enumeration is a breaking change.
+
+Breaking changes require existing users, scripts, configurations, or clients
+to change. Examples include:
+
+- Removing or renaming a command, option, argument, configuration key, API
+  field, or JSON field.
+- Making an optional input or field required.
+- Changing a documented type, meaning, default, exit status, or output stream.
+- Rejecting an input that an earlier release accepted.
+- Changing an HTTP method, path, request, response, or documented status code.
+- Changing behavior that matches the documentation.
+
+When the documentation is silent but users could reasonably depend on the
+behavior, maintainers must treat the change as breaking and use the deprecation
+process. A breaking HTTP API design must use a new `/api/vN` prefix. Sprocket
+must continue serving the previous API version through its deprecation period.
+
+Security fixes may reject inputs or alter behavior when preserving the old
+behavior would leave users vulnerable. These changes still require the
+exception process below if they cannot follow the normal deprecation period.
+
+## Deprecation
+
+A stable interface must be deprecated before removal. Its notice must include:
+
+- The first Sprocket release containing the deprecation and that release's
+  publication date.
+- The replacement and migration instructions.
+- The earliest eligible removal release and date.
+- An entry in the changelog and release notes.
+- A notice in the relevant user documentation.
+- A runtime warning when practical.
+
+The change pull request must provide the replacement and migration
+instructions. If the release number and publication date are not yet known, it
+records the first deprecated release as "next release." During release
+preparation, maintainers replace that marker with the release number and date
+and calculate the earliest eligible removal release and date.
+
+Removal may occur only after **both** of these conditions are true:
+
+1. At least 90 days have passed since the release containing the first
+   deprecation notice.
+2. The release containing the removal is at least the second minor release
+   after the release containing the first notice.
+
+The release containing the first notice is release zero and does not count
+toward the two-release threshold. Patch releases do not count. For example, an
+interface first deprecated in `1.2.0` cannot be removed before `1.4.0`, and it
+must remain available longer if 90 days have not passed when `1.4.0` is
+published. Removal occurs in a minor or major release, never a patch release.
+
+## Exceptions
+
+An intentional exception to a stable 1.x guarantee requires a pull request
+that:
+
+- Identifies the affected contract.
+- Explains why no compatible approach is practical.
+- Describes the impact on users and automation.
+- Provides migration instructions.
+- Records its deprecation and release-note treatment.
+
+Urgent security, legal, or data-integrity needs may shorten or skip the normal
+notice period. They do not waive the written rationale, impact assessment,
+migration guidance, or release notes.
+
+An approved urgent exception may ship in a patch release. This is the only
+exception to the rule that patch releases contain compatible fixes and do not
+remove stable interfaces.
+
+Merging an exception does not silently redefine this policy. If the exception
+changes an ongoing guarantee, the same pull request must update this document.
+
+## Policy Approval and Schema Freeze
+
+Maintainers must approve this policy before declaring any public Sprocket 1.0
+schema frozen. Policy approval and schema freeze are separate checkpoints:
+approving this document defines the rules but does not itself freeze the
+`sprocket.toml`, module, API, or JSON schemas.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ Community contributions rock and we are psyched you're reading this document!
 - Bug reports go [here][issues]
 - Feature requests are welcome and go [here](https://github.com/stjude-rust-labs/sprocket/discussions/categories/feature-requests)
 - Lint rule proposals go [here](https://github.com/stjude-rust-labs/sprocket/discussions/categories/rule-proposals)
+- Compatibility guarantees are defined in [`COMPATIBILITY.md`](COMPATIBILITY.md)
 
 ## How can I start contributing?
 
@@ -74,6 +75,20 @@ our CI checks pass. Additional guidance for satisfying the CI checks can be
 
 Note that the maintainers reserve the right to close any submission without
 review for any reason.
+
+### Compatibility changes
+
+Before changing a public interface, read
+[`COMPATIBILITY.md`](COMPATIBILITY.md). Classify the change as compatible,
+deprecated, breaking, or experimental in the pull request. A deprecation must
+include its replacement and migration instructions. Use "next release" for
+release details that maintainers will assign during release preparation.
+Breaking changes to a stable interface must follow the exception process in
+the policy.
+
+Do not rely on a `!` or `BREAKING CHANGE` conventional commit marker to choose
+the `sprocket` executable's major version. Maintainers assign executable
+versions under the compatibility policy.
 
 ## FAQs
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,27 @@ Various CI features have been implemented to ease the release process, but some 
 Before cutting a release, review every entry under `## Unreleased` in each
 `CHANGELOG.md` and verify that every item links to its originating pull request.
 
+Review user-facing changes against [`COMPATIBILITY.md`](./COMPATIBILITY.md):
+
+- Confirm every stable-interface change is classified as compatible,
+  deprecated, or an approved exception.
+- Search this repository and the pending `sprocket.bio` `next` branch for each
+  deprecation's "next release" markers, including changelogs, documentation,
+  and runtime warnings. Replace them with this release number and date, then
+  record the earliest eligible removal release and date.
+- Confirm a removal has passed both the 90-day and two-minor-release minimums.
+- Confirm a feature graduating from `dev` lists the commands, formats, schemas,
+  and behavior that become stable.
+- Confirm a breaking HTTP API uses a new `/api/vN` prefix and retains the
+  previous version through its deprecation period.
+- Confirm database schema changes include a tested forward migration that
+  preserves data needed by supported commands.
+- Confirm an exception has the required rationale, impact assessment,
+  migration instructions, and release notes.
+- Confirm the version proposed for the `sprocket` package matches this policy.
+  Conventional commit markers and release automation do not choose the
+  executable's major version; edit the release pull request when needed.
+
 The following steps are handled automatically by the [release-plz](./.github/workflows/release-plz.yml) workflow.
 In the event it fails, they can be performed manually.
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,6 +8,7 @@ git_tag_name = "{{ package }}-v{{ version }}"
 [[package]]
 name = "sprocket"
 features_always_increment_minor = true
+semver_check = false
 git_release_enable = true
 git_release_name = "v{{ version }}"
 git_tag_name = "v{{ version }}"

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -11,7 +11,11 @@ use crate::config::Config;
 /// The [Taplo schema directive] for `sprocket.toml`.
 ///
 /// [Taplo schema directive]: https://taplo.tamasfe.dev/configuration/directives.html#the-schema-directive
-const SCHEMA_DIRECTIVE: &str = "#:schema https://raw.githubusercontent.com/stjude-rust-labs/sprocket/refs/heads/main/jsonschemas/sprocket.toml.json";
+const SCHEMA_DIRECTIVE: &str = concat!(
+    "#:schema https://raw.githubusercontent.com/stjude-rust-labs/sprocket/refs/tags/v",
+    env!("CARGO_PKG_VERSION"),
+    "/jsonschemas/sprocket.toml.json"
+);
 
 /// Arguments for the `config` subcommand.
 #[derive(Parser, Debug, Clone)]
@@ -86,4 +90,20 @@ pub fn config(args: Args, mut config: Config) -> CommandResult<()> {
             .map_err(CommandError::Single)?
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SCHEMA_DIRECTIVE;
+
+    #[test]
+    fn schema_directive_uses_release_tag() {
+        assert_eq!(
+            SCHEMA_DIRECTIVE,
+            format!(
+                "#:schema https://raw.githubusercontent.com/stjude-rust-labs/sprocket/refs/tags/v{}/jsonschemas/sprocket.toml.json",
+                env!("CARGO_PKG_VERSION")
+            )
+        );
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -298,6 +298,7 @@ fn normalize_string(input: &str, temp_dir: &Path) -> String {
         .replace(temp_dir.as_ref(), "_TEMP_DIR_")
         .replace("\r\n", "\n")
         .replace("\\r\\n", "\\n")
+        .replace(env!("CARGO_PKG_VERSION"), "_VERSION_")
         .replace("sprocket.exe", "sprocket");
 
     // Normalize Windows OS error messages to their Unix equivalents.

--- a/tests/cli/config/init/run/stdout
+++ b/tests/cli/config/init/run/stdout
@@ -1,4 +1,4 @@
-#:schema https://raw.githubusercontent.com/stjude-rust-labs/sprocket/refs/heads/main/jsonschemas/sprocket.toml.json
+#:schema https://raw.githubusercontent.com/stjude-rust-labs/sprocket/refs/tags/v_VERSION_/jsonschemas/sprocket.toml.json
 
 [format]
 indent = 4


### PR DESCRIPTION
Sprocket 1.0 needs one contract that defines which executable interfaces users can rely on and how maintainers may evolve them. Semantic Versioning alone cannot describe those guarantees because the executable uses version numbers to mark product milestones rather than compatibility boundaries.

This publishes the normative 1.x policy, connects it to contributor and release workflows, and pins generated `sprocket.toml` schema links to each release tag. The coordinated user-facing summary is in stjude-rust-labs/sprocket.bio#56 and should merge after or with this PR so its policy link resolves.

Closes #1071.

Before submitting this PR, please make sure:

For external contributors:

N/A—submitted by a maintainer.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [x] You have classified changes to stable interfaces under the [compatibility policy](https://github.com/stjude-rust-labs/sprocket/blob/main/COMPATIBILITY.md) (when appropriate).
- [x] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

N/A—this PR does not change lint rules.