### PR TITLE
fix: preserve classes in homepage Markdown HTML

### DIFF
--- a/crates/wdl-doc/CHANGELOG.md
+++ b/crates/wdl-doc/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* CSS classes in authored Markdown HTML are preserved in generated documentation
+  pages ([#441](https://github.com/stjude-rust-labs/sprocket/issues/441)).
+
 ## 0.16.1 - 2026-08-26
 
 #### Fixed

--- a/crates/wdl-doc/src/docs_tree.rs
+++ b/crates/wdl-doc/src/docs_tree.rs
@@ -2009,7 +2009,11 @@ mod tests {
         let docs_dir = tempfile::tempdir().unwrap();
         let index_source = tempfile::tempdir().unwrap();
         let index_path = index_source.path().join("index.md");
-        fs::write(&index_path, "Custom homepage content marker").unwrap();
+        fs::write(
+            &index_path,
+            r#"<div class="wdl-tests-dark">Custom homepage content marker</div>"#,
+        )
+        .unwrap();
 
         let tree = DocsTreeBuilder::new(docs_dir.path())
             .maybe_workspace_metadata(None)
@@ -2029,6 +2033,7 @@ mod tests {
         let content = fs::read_to_string(docs_dir.path().join("index.html")).unwrap();
         assert!(!content.contains("main__homepage-header"));
         assert!(content.contains("Custom homepage content marker"));
+        assert!(content.contains("class=\"wdl-tests-dark\""));
         assert!(!content.contains("module-overview"));
     }
 

--- a/crates/wdl-doc/src/lib.rs
+++ b/crates/wdl-doc/src/lib.rs
@@ -350,11 +350,10 @@ impl<T: AsRef<str>> Render for Markdown<T> {
         options.insert(Options::ENABLE_DEFINITION_LIST);
         let parser = Parser::new_ext(self.0.as_ref(), options);
         pulldown_cmark::html::push_html(&mut unsafe_html, parser);
-        // Sanitize it with ammonia, preserving the `class` attribute on fenced
-        // code blocks so the theme's manual highlighter can detect the
-        // `language-*` hint that `pulldown-cmark` emits.
+        // Sanitize it with ammonia while preserving CSS classes authored in
+        // Markdown, including the `language-*` hint on fenced code blocks.
         let safe_html = ammonia::Builder::default()
-            .add_tag_attributes("code", ["class"])
+            .add_generic_attributes(["class"])
             .clean(&unsafe_html)
             .to_string();
 
@@ -768,6 +767,25 @@ mod tests {
             rendered.contains("class=\"language-json\""),
             "expected the fenced code block to keep its language class, got: {rendered}"
         );
+    }
+
+    #[test]
+    fn authored_html_retains_classes_without_disabling_sanitization() {
+        let rendered = Markdown(
+            r#"<div class="wdl-tests-dark" style="color: red" onclick="alert('unsafe')">
+                <span class="wdl-tests-light">Homepage content</span>
+                <script>alert('unsafe')</script>
+            </div>"#,
+        )
+        .render()
+        .into_string();
+
+        assert!(rendered.contains("class=\"wdl-tests-dark\""));
+        assert!(rendered.contains("class=\"wdl-tests-light\""));
+        assert!(!rendered.contains("style="));
+        assert!(!rendered.contains("onclick="));
+        assert!(!rendered.contains("<script"));
+        assert!(!rendered.contains("alert("));
     }
 
     #[test]


### PR DESCRIPTION
Authored HTML classes in homepage Markdown were removed during sanitation, which prevented users from applying custom light/dark-mode styling. This change keeps the existing Ammonia sanitizer but preserves generic `class` attributes, with unit and homepage rendering regressions covering both class retention and unsafe HTML filtering.

Fixes: #441

For external contributors: N/A - this is an internal contribution.

For all contributors:

- [x] Tests were added for the changed behavior.
- [x] An entry was added to the changelog.
- [ ] The README or other documentation needed no update for this focused fix.
- [ ] A PR was made to the `next` branch in the sprocket.bio repository; this is not applicable.

For PRs containing lint rule changes: N/A.