### PR TITLE
fix(sprocket): disable `indicatif` layer for non-terminals

### DIFF
--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -43,9 +43,7 @@ use tracing::info;
 use tracing::instrument::WithSubscriber;
 use tracing::span;
 use tracing::subscriber::NoSubscriber;
-use tracing_indicatif::IndicatifWriter;
 use tracing_indicatif::span_ext::IndicatifSpanExt;
-use tracing_indicatif::writer::Stdout;
 use uuid::Uuid;
 use wdl::analysis::AnalysisResult;
 use wdl::ast::AstNode;
@@ -66,6 +64,7 @@ use wdl::engine::config::FailureMode;
 use wdl::engine::config::TaskResourceLimitBehavior;
 
 use crate::Config;
+use crate::Stdout;
 use crate::analysis::Analysis;
 use crate::analysis::Source;
 use crate::commands::CommandError;
@@ -306,7 +305,7 @@ impl TestIteration {
         self,
         clean: bool,
         quiet: bool,
-        mut indicatif_writer: IndicatifWriter<Stdout>,
+        mut stdout: Stdout,
     ) -> Result<IterationResult> {
         let id = format!(
             "{doc}::{target}::{test} (iteration #{num})",
@@ -441,13 +440,13 @@ impl TestIteration {
         if !quiet && self.cancellation.state() != CancellationContextState::Canceling {
             match &evaluation {
                 Ok(IterationResult::Success) => {
-                    writeln!(&mut indicatif_writer, "{id}: ✅")?;
+                    writeln!(&mut stdout, "{id}: ✅")?;
                 }
                 Ok(IterationResult::Fail(_)) => {
-                    writeln!(&mut indicatif_writer, "{id}: ❌")?;
+                    writeln!(&mut stdout, "{id}: ❌")?;
                 }
                 Err(_) => {
-                    writeln!(&mut indicatif_writer, "{id}: ☠️")?;
+                    writeln!(&mut stdout, "{id}: ☠️")?;
                 }
             }
         }
@@ -610,7 +609,7 @@ struct Runner {
     fixtures: Arc<EvaluationPath>,
     engine: Engine,
     status_bar: StatusBar,
-    indicatif_writer: IndicatifWriter<Stdout>,
+    stdout: Stdout,
     permits: usize,
     throttle: u64,
     cancellation: CancellationContext,
@@ -814,7 +813,7 @@ impl Runner {
             .expect("should have test results");
 
         let evaluation = test_iteration
-            .evaluate(clean, quiet, self.indicatif_writer.clone())
+            .evaluate(clean, quiet, self.stdout.clone())
             .await;
         test_results.push(evaluation);
 
@@ -987,7 +986,7 @@ pub async fn test(
     args: Args,
     mut config: Config,
     colorize: bool,
-    indicatif_writer: IndicatifWriter<Stdout>,
+    stdout: Stdout,
 ) -> CommandResult<()> {
     if matches!(args.command, Some(Subcommand::Schema)) {
         let schema = schemars::schema_for!(DocumentTests);
@@ -1155,7 +1154,7 @@ pub async fn test(
         } else {
             StatusBar::new(colorize)
         },
-        indicatif_writer,
+        stdout,
         permits: parallelism,
         throttle: config.test.throttle,
         cancellation: cancellation.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 
 use std::fs::File;
 use std::io::IsTerminal as _;
-use std::io::stderr;
+use std::io::Write;
 use std::path::PathBuf;
 
 use anyhow::Context as _;
@@ -33,10 +33,10 @@ use tracing::level_filters::LevelFilter;
 use tracing::trace;
 use tracing_indicatif::IndicatifLayer;
 use tracing_indicatif::IndicatifWriter;
-use tracing_indicatif::writer::Stdout;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::FmtSubscriber;
 use tracing_subscriber::fmt;
+use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::fmt::format::DefaultFields;
 use tracing_subscriber::fmt::format::Format;
 use tracing_subscriber::layer::Layered;
@@ -100,6 +100,7 @@ struct Cli {
 async fn real_main() -> CommandResult<()> {
     let cli = Cli::parse();
 
+    let is_terminal = std::io::stderr().is_terminal();
     let mut config = match &cli.command {
         Commands::Config(config_args) if config_args.is_init() => {
             // For `config init`, skip loading and use default
@@ -127,7 +128,7 @@ async fn real_main() -> CommandResult<()> {
                             &[e.to_diagnostic()],
                             Default::default(),
                             match cli.color {
-                                ColorMode::Auto => stderr().is_terminal(),
+                                ColorMode::Auto => is_terminal,
                                 ColorMode::Always => true,
                                 ColorMode::Never => false,
                             },
@@ -156,7 +157,7 @@ async fn real_main() -> CommandResult<()> {
     );
 
     let colorize = match (cli.color, config.common.color) {
-        (ColorMode::Auto, ColorMode::Auto) => stderr().is_terminal(),
+        (ColorMode::Auto, ColorMode::Auto) => is_terminal,
         (ColorMode::Auto, ColorMode::Always) => true,
         (ColorMode::Auto, ColorMode::Never) => false,
         (ColorMode::Always, _) => true,
@@ -165,7 +166,8 @@ async fn real_main() -> CommandResult<()> {
 
     colored::control::set_override(colorize);
     let (writer, file_handle, indicatif_writers) =
-        initialize_logging(cli.verbosity, colorize).context("failed to initialize logging")?;
+        initialize_logging(cli.verbosity, colorize, is_terminal)
+            .context("failed to initialize logging")?;
 
     match cli.command {
         Commands::Analyzer(args) => commands::analyzer::analyzer(args, config, writer).await,
@@ -207,7 +209,7 @@ async fn real_main() -> CommandResult<()> {
 }
 
 /// The type of the logging subscriber.
-pub type Subscriber = FmtSubscriber<DefaultFields, Format, LevelFilter, IndicatifWriter>;
+pub type Subscriber = FmtSubscriber<DefaultFields, Format, LevelFilter, Stderr>;
 
 /// Represents the type of the filter (i.e. controls logging output) layer.
 pub type FilterLayer = Layered<reload::Layer<EnvFilter, Subscriber>, Subscriber>;
@@ -224,17 +226,97 @@ pub type FilterReloadHandle = reload::Handle<EnvFilter, Subscriber>;
 /// run directory has been created.
 pub type FileReloadHandle = reload::Handle<
     Option<
-        fmt::Layer<Layered<IndicatifLayer<FilterLayer>, FilterLayer>, DefaultFields, Format, File>,
+        fmt::Layer<
+            Layered<Option<IndicatifLayer<FilterLayer>>, FilterLayer>,
+            DefaultFields,
+            Format,
+            File,
+        >,
     >,
-    Layered<IndicatifLayer<FilterLayer>, FilterLayer>,
+    Layered<Option<IndicatifLayer<FilterLayer>>, FilterLayer>,
 >;
 
-/// Writers for the `tracing-indicatif` layer.
-struct IndicatifWriters {
+/// Writer for stdout.
+#[derive(Clone)]
+#[allow(missing_debug_implementations)] // Can't, `IndicatifWriter` doesn't implement `Debug`.
+pub enum Stdout {
+    /// `tracing-indicatif` proxy writer.
+    IndicatifWriter(IndicatifWriter<tracing_indicatif::writer::Stdout>),
+    /// Direct `stdout` writer.
+    Stdout,
+}
+
+impl Write for Stdout {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Stdout::IndicatifWriter(writer) => writer.write(buf),
+            Stdout::Stdout => std::io::stdout().write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Stdout::IndicatifWriter(writer) => writer.flush(),
+            Stdout::Stdout => std::io::stdout().flush(),
+        }
+    }
+}
+
+impl<'a> MakeWriter<'a> for Stdout {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Writer for stderr.
+#[derive(Clone)]
+#[allow(missing_debug_implementations)] // Can't, `IndicatifWriter` doesn't implement `Debug`.
+pub enum Stderr {
+    /// `tracing-indicatif` proxy writer.
+    IndicatifWriter(IndicatifWriter),
+    /// Direct `stderr` writer.
+    Stderr,
+}
+
+impl<'a> MakeWriter<'a> for Stderr {
+    type Writer = Self;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+impl Write for Stderr {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Stderr::IndicatifWriter(writer) => writer.write(buf),
+            Stderr::Stderr => std::io::stderr().write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Stderr::IndicatifWriter(writer) => writer.flush(),
+            Stderr::Stderr => std::io::stderr().flush(),
+        }
+    }
+}
+
+/// Stdio writers.
+///
+/// This is used to dispatch between the `tracing-indicatif` writers and direct
+/// `std::io::{stdout, stderr}()`, depending on if the output is a terminal.
+///
+/// We can't just unconditionally use the `IndicatifWriter` due to a panic in debug mode, see <https://github.com/emersonford/tracing-indicatif/issues/24>.
+#[derive(Clone)]
+#[allow(missing_debug_implementations)] // Can't, `IndicatifWriter` doesn't implement `Debug`.
+pub struct Stdio {
     /// Writer for stdout.
-    stdout: IndicatifWriter<Stdout>,
+    pub stdout: Stdout,
     /// Writer for stderr.
-    stderr: IndicatifWriter,
+    pub stderr: Stderr,
 }
 
 /// Initializes logging given the verbosity level and whether or not to colorize
@@ -246,7 +328,8 @@ struct IndicatifWriters {
 fn initialize_logging(
     verbosity: Verbosity<WarnLevel>,
     colorize: bool,
-) -> Result<(FilterReloadHandle, FileReloadHandle, IndicatifWriters)> {
+    is_terminal: bool,
+) -> Result<(FilterReloadHandle, FileReloadHandle, Stdio)> {
     // Try to get a default environment filter via `RUST_LOG`
     let env_filter = match EnvFilter::try_from_default_env()
         .context("invalid `RUST_LOG` environment variable")
@@ -272,24 +355,40 @@ fn initialize_logging(
     // This layer should always come first in the subscriber
     let (filter_layer, filter_reload_handle) = reload::Layer::new(env_filter);
 
-    // Set up an indicatif layer so that progress bars don't interfere with
-    // logging output
-    let indicatif_layer = IndicatifLayer::new()
-        .with_span_child_prefix_indent("    ")
-        .with_span_child_prefix_symbol("↳ ");
-    let indicatif_writers = IndicatifWriters {
-        stdout: indicatif_layer.get_stdout_writer(),
-        stderr: indicatif_layer.get_stderr_writer(),
-    };
-
     // To start, the file layer is `None` and may be reloaded later
     let (file_layer, file_reload_handle) =
         reload::Layer::new(None::<File>.map(|f| fmt::layer().with_writer(f).with_ansi(false)));
 
+    let (indicatif_layer, stdio) = if is_terminal {
+        // Set up an indicatif layer so that progress bars don't interfere with
+        // logging output
+        let indicatif_layer = IndicatifLayer::new()
+            .with_span_child_prefix_indent("    ")
+            .with_span_child_prefix_symbol("↳ ");
+
+        let stdout = indicatif_layer.get_stdout_writer();
+        let stderr = indicatif_layer.get_stderr_writer();
+        (
+            Some(indicatif_layer),
+            Stdio {
+                stdout: Stdout::IndicatifWriter(stdout),
+                stderr: Stderr::IndicatifWriter(stderr),
+            },
+        )
+    } else {
+        (
+            None,
+            Stdio {
+                stdout: Stdout::Stdout,
+                stderr: Stderr::Stderr,
+            },
+        )
+    };
+
     // Build the subscriber and set it as the global default
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(LevelFilter::TRACE)
-        .with_writer(indicatif_writers.stderr.clone())
+        .with_writer(stdio.stderr.clone())
         .with_ansi(colorize)
         .with_ansi_sanitization(false)
         .finish()
@@ -300,7 +399,7 @@ fn initialize_logging(
     tracing::subscriber::set_global_default(subscriber)
         .context("failed to set tracing subscriber")?;
 
-    Ok((filter_reload_handle, file_reload_handle, indicatif_writers))
+    Ok((filter_reload_handle, file_reload_handle, stdio))
 }
 
 /// The Sprocket command line entrypoint.


### PR DESCRIPTION
This fully disables the `indicatif` layer when `stderr` isn't a terminal

closes #1007

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
