### PR TITLE
fix: format malformed `input` hint values

### DIFF
--- a/crates/wdl-format/CHANGELOG.md
+++ b/crates/wdl-format/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* Formatting no longer panics when an `input` hints item has a value that is not a `hints` literal.
+
 ## 0.20.2 - 2026-08-26
 
 #### Added

--- a/crates/wdl-format/CHANGELOG.md
+++ b/crates/wdl-format/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
-* Formatting no longer panics when an `input` hints item has a value that is not a `hints` literal.
+* Formatting no longer panics when an `input` hints item has a value that is not a `hints` literal ([#1174](https://github.com/stjude-rust-labs/sprocket/pull/1174)).
 
 ## 0.20.2 - 2026-08-26
 

--- a/crates/wdl-format/src/v1.rs
+++ b/crates/wdl-format/src/v1.rs
@@ -325,9 +325,8 @@ pub fn format_literal_input_item(
         }
     }
 
-    let hints_node = children.next().expect("literal input item hints node");
-    assert_eq!(hints_node.element().kind(), SyntaxKind::LiteralHintsNode);
-    (&hints_node).write(stream, config);
+    let value = children.next().expect("literal input item value");
+    (&value).write(stream, config);
 }
 
 /// Formats a [`LiteralInput`](wdl_ast::v1::LiteralInput).

--- a/crates/wdl-format/tests/format/issue-1173/source.formatted.wdl
+++ b/crates/wdl-format/tests/format/issue-1173/source.formatted.wdl
@@ -1,0 +1,9 @@
+version 1.3
+
+task repro {
+    hints {
+        inputs: input {
+            foo: bar,
+        }
+    }
+}

--- a/crates/wdl-format/tests/format/issue-1173/source.wdl
+++ b/crates/wdl-format/tests/format/issue-1173/source.wdl
@@ -1,0 +1,9 @@
+version 1.3
+
+task repro {
+    hints {
+        inputs: input {
+            foo: bar
+        }
+    }
+}


### PR DESCRIPTION
Formatting malformed task input hints could panic when the parser represented a value as an expression rather than a `hints` literal. I changed the formatter to write the parsed value generically while preserving semantic diagnostics, and added regression coverage.

Closes #1173.

Before submitting this PR, please make sure:

For external contributors:

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every possible diagnostic emitted for the rule within the file where the rule is implemented.