### PR TITLE
fix: pool `Analyzer` validators per instance

### DIFF
--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -10,12 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 * `Visitor` implementations must now implement `Send` so validators can be
-  reused across analysis worker threads.
+  reused across analysis worker threads
+  ([#1175](https://github.com/stjude-rust-labs/sprocket/pull/1175)).
 
 #### Fixed
 
 * `Analyzer` now reuses validators from a per-analyzer pool without sharing
-  validator configuration between analyzer instances.
+  validator configuration between analyzer instances
+  ([#1175](https://github.com/stjude-rust-labs/sprocket/pull/1175)).
 
 ## 0.25.0 - 2026-08-26
 

--- a/crates/wdl-analysis/CHANGELOG.md
+++ b/crates/wdl-analysis/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Changed
+
+* `Visitor` implementations must now implement `Send` so validators can be
+  reused across analysis worker threads.
+
+#### Fixed
+
+* `Analyzer` now reuses validators from a per-analyzer pool without sharing
+  validator configuration between analyzer instances.
+
 ## 0.25.0 - 2026-08-26
 
 #### Added

--- a/crates/wdl-analysis/src/analyzer.rs
+++ b/crates/wdl-analysis/src/analyzer.rs
@@ -469,8 +469,8 @@ where
     ///
     /// The provided progress callback will be invoked during analysis.
     ///
-    /// This validator function will be called once per worker thread to
-    /// initialize a thread-local validator.
+    /// The validator function constructs validators when none are available in
+    /// this analyzer's pool.
     ///
     /// The analyzer must be constructed from the context of a Tokio runtime.
     pub fn new_with_validator<Progress, Return, Validator>(
@@ -496,8 +496,8 @@ where
     ///
     /// The provided progress callback will be invoked during analysis.
     ///
-    /// This validator function will be called once per worker thread to
-    /// initialize a thread-local validator.
+    /// The validator function constructs validators when none are available in
+    /// this analyzer's pool.
     ///
     /// The analyzer must be constructed from the context of a Tokio runtime.
     pub fn new_with_validator_and_resolution<Progress, Return, Validator>(
@@ -534,7 +534,7 @@ where
         }
     }
 
-    /// Replace the current validator function.
+    /// Replaces the current validator function and starts a new validator pool.
     ///
     /// This will mark all documents for re-analysis.
     pub async fn swap_validator<Validator>(&self, validator: Validator) -> Result<()>
@@ -1294,12 +1294,31 @@ const _: () = {
 #[cfg(test)]
 mod test {
     use std::fs;
+    use std::path::Path;
     use std::path::PathBuf;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
 
     use tempfile::TempDir;
     use wdl_ast::Severity;
 
     use super::*;
+
+    /// Writes a valid task document to the given path.
+    fn write_task(path: &Path, name: &str) {
+        fs::write(
+            path,
+            format!(
+                r#"version 1.1
+
+task {name} {{
+    command <<<>>>
+}}
+"#
+            ),
+        )
+        .expect("failed to create test file");
+    }
 
     #[tokio::test]
     #[test_log::test]
@@ -1369,6 +1388,137 @@ workflow test {
             results[0].document.diagnostics().next().unwrap().message(),
             "conflicting workflow name `test`"
         );
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn it_reuses_validators_across_analysis_requests() {
+        let dir = TempDir::new().expect("failed to create temporary directory");
+        let first = dir.path().join("first.wdl");
+        let second = dir.path().join("second.wdl");
+        write_task(&first, "same_name");
+        fs::write(
+            &second,
+            r#"version 1.1
+
+task same_name {
+}
+"#,
+        )
+        .expect("failed to create second test file");
+
+        let constructions = Arc::new(AtomicUsize::new(0));
+        let factory_constructions = constructions.clone();
+        let analyzer = Analyzer::new_with_validator(
+            Config::default(),
+            |(), _, _, _| async {},
+            move || {
+                factory_constructions.fetch_add(1, Ordering::SeqCst);
+                crate::Validator::default()
+            },
+        );
+
+        analyzer
+            .add_document(path_to_uri(&first).expect("should convert to URI"))
+            .await
+            .expect("should add first document");
+        let results = analyzer.analyze(()).await.expect("analysis should succeed");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].document().diagnostics().next().is_none());
+
+        analyzer
+            .add_document(path_to_uri(&second).expect("should convert to URI"))
+            .await
+            .expect("should add second document");
+        let results = analyzer.analyze(()).await.expect("analysis should succeed");
+        assert_eq!(results.len(), 2);
+        let second = results
+            .iter()
+            .find(|result| result.document().uri().to_file_path().unwrap() == second)
+            .expect("should find second document");
+        assert_eq!(
+            second
+                .document()
+                .diagnostics()
+                .map(|diagnostic| diagnostic.message())
+                .collect::<Vec<_>>(),
+            ["task `same_name` is missing a command section"]
+        );
+        assert_eq!(constructions.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn validator_pool_is_bounded_by_rayon_workers() {
+        let dir = TempDir::new().expect("failed to create temporary directory");
+        let worker_count = rayon::current_num_threads();
+        let document_count = worker_count + 1;
+        for index in 0..document_count {
+            write_task(
+                &dir.path().join(format!("{index}.wdl")),
+                &format!("task_{index}"),
+            );
+        }
+
+        let constructions = Arc::new(AtomicUsize::new(0));
+        let factory_constructions = constructions.clone();
+        let analyzer = Analyzer::new_with_validator(
+            Config::default(),
+            |(), _, _, _| async {},
+            move || {
+                factory_constructions.fetch_add(1, Ordering::SeqCst);
+                crate::Validator::default()
+            },
+        );
+        analyzer
+            .add_directory(dir.path())
+            .await
+            .expect("should add documents");
+
+        let results = analyzer.analyze(()).await.expect("analysis should succeed");
+        assert_eq!(results.len(), document_count);
+        let constructions = constructions.load(Ordering::SeqCst);
+        assert!(constructions <= worker_count);
+        assert!(constructions < document_count);
+    }
+
+    #[tokio::test]
+    #[test_log::test]
+    async fn swapping_validator_discards_the_existing_pool() {
+        let dir = TempDir::new().expect("failed to create temporary directory");
+        let path = dir.path().join("source.wdl");
+        write_task(&path, "test");
+
+        let original_constructions = Arc::new(AtomicUsize::new(0));
+        let factory_constructions = original_constructions.clone();
+        let analyzer = Analyzer::new_with_validator(
+            Config::default(),
+            |(), _, _, _| async {},
+            move || {
+                factory_constructions.fetch_add(1, Ordering::SeqCst);
+                crate::Validator::default()
+            },
+        );
+        analyzer
+            .add_document(path_to_uri(&path).expect("should convert to URI"))
+            .await
+            .expect("should add document");
+        analyzer.analyze(()).await.expect("analysis should succeed");
+        assert_eq!(original_constructions.load(Ordering::SeqCst), 1);
+
+        let replacement_constructions = Arc::new(AtomicUsize::new(0));
+        let factory_constructions = replacement_constructions.clone();
+        analyzer
+            .swap_validator(move || {
+                factory_constructions.fetch_add(1, Ordering::SeqCst);
+                crate::Validator::default()
+            })
+            .await
+            .expect("validator should be replaced");
+        analyzer.analyze(()).await.expect("analysis should succeed");
+
+        assert_eq!(original_constructions.load(Ordering::SeqCst), 1);
+        assert_eq!(replacement_constructions.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/wdl-analysis/src/queue.rs
+++ b/crates/wdl-analysis/src/queue.rs
@@ -33,6 +33,7 @@ use lsp_types::SemanticTokensResult;
 use lsp_types::SignatureHelp;
 use lsp_types::SymbolInformation;
 use lsp_types::WorkspaceEdit;
+use parking_lot::Mutex;
 use parking_lot::RwLock;
 use petgraph::Direction;
 use petgraph::graph::NodeIndex;
@@ -70,6 +71,71 @@ use crate::rayon::RayonHandle;
 
 /// A validator constructor function.
 pub(crate) type ValidatorFn = Arc<dyn Fn() -> crate::Validator + Send + Sync + 'static>;
+
+/// A pool of validators that belong to one analyzer configuration.
+struct ValidatorPool {
+    /// The constructor to use when no validator is available.
+    factory: ValidatorFn,
+    /// Validators that are ready to be reused.
+    available: Mutex<Vec<crate::Validator>>,
+}
+
+impl ValidatorPool {
+    /// Creates an empty validator pool.
+    fn new(factory: ValidatorFn) -> Self {
+        Self {
+            factory,
+            available: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Checks out a validator from this pool.
+    fn checkout(self: &Arc<Self>) -> ValidatorGuard {
+        let validator = { self.available.lock().pop() }.unwrap_or_else(|| (self.factory)());
+
+        ValidatorGuard {
+            pool: self.clone(),
+            validator: Some(validator),
+            reusable: false,
+        }
+    }
+}
+
+/// A checked-out validator that returns to its originating pool after success.
+struct ValidatorGuard {
+    /// The pool generation that owns the validator.
+    pool: Arc<ValidatorPool>,
+    /// The checked-out validator.
+    validator: Option<crate::Validator>,
+    /// Whether validation completed without panicking.
+    reusable: bool,
+}
+
+impl ValidatorGuard {
+    /// Gets the checked-out validator.
+    fn get_mut(&mut self) -> &mut crate::Validator {
+        self.validator
+            .as_mut()
+            .expect("checked-out validator should be present")
+    }
+
+    /// Marks the validator for return to its pool.
+    fn recycle(mut self) {
+        self.reusable = true;
+    }
+}
+
+impl Drop for ValidatorGuard {
+    fn drop(&mut self) {
+        if self.reusable {
+            self.pool.available.lock().push(
+                self.validator
+                    .take()
+                    .expect("reusable validator should be present"),
+            );
+        }
+    }
+}
 
 /// The minimum number of milliseconds between analysis progress reports.
 const MINIMUM_PROGRESS_MILLIS: u128 = 50;
@@ -471,8 +537,8 @@ pub struct AnalysisQueue<Progress, Context, Return> {
     module_root_cache: parking_lot::Mutex<HashMap<PathBuf, bool>>,
     /// The progress callback to use.
     progress: Arc<Progress>,
-    /// The validator callback to use.
-    validator: Arc<RwLock<ValidatorFn>>,
+    /// The active validator pool.
+    validators: RwLock<Arc<ValidatorPool>>,
     /// A marker for the `Context` and `Return` types.
     marker: PhantomData<(Context, Return)>,
 }
@@ -508,7 +574,7 @@ where
             progress: Arc::new(progress),
             marker: PhantomData,
             client: Default::default(),
-            validator: Arc::new(RwLock::new(validator)),
+            validators: RwLock::new(Arc::new(ValidatorPool::new(validator))),
         }
     }
 
@@ -1299,7 +1365,7 @@ where
 
             let tasks = {
                 let graph = self.graph.read();
-                let validator = self.validator.read().clone();
+                let validators = self.validators.read().clone();
 
                 let handles = FuturesUnordered::new();
                 for index in set.iter().copied() {
@@ -1313,10 +1379,18 @@ where
 
                     let graph = self.graph.clone();
                     let config = self.config.clone();
-                    let validator = validator.clone();
+                    let validators = validators.clone();
                     handles.push(RayonHandle::spawn(move || {
                         let result = panic::catch_unwind(AssertUnwindSafe(|| {
-                            Self::analyze_node(&config, graph.clone(), index, &mut (validator)())
+                            let mut validator = validators.checkout();
+                            let result = Self::analyze_node(
+                                &config,
+                                graph.clone(),
+                                index,
+                                validator.get_mut(),
+                            );
+                            validator.recycle();
+                            result
                         }));
 
                         let mut graph = graph.write();
@@ -1927,7 +2001,7 @@ where
 
     /// Replace the current validator function.
     fn swap_validator(&self, validator: ValidatorFn) {
-        *self.validator.write() = validator;
+        *self.validators.write() = Arc::new(ValidatorPool::new(validator));
 
         // Invalidate the *entire* graph
         self.graph.write().reanalyze_all();
@@ -1942,5 +2016,72 @@ pub(crate) fn format_panic_payload(payload: &Box<dyn std::any::Any + Send>) -> S
         s.clone()
     } else {
         "unknown panic payload".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+
+    /// Creates a validator factory that tracks its invocation count.
+    fn counting_factory(constructions: Arc<AtomicUsize>) -> ValidatorFn {
+        Arc::new(move || {
+            constructions.fetch_add(1, Ordering::SeqCst);
+            crate::Validator::default()
+        })
+    }
+
+    #[test]
+    fn successful_checkout_returns_validator_to_originating_pool() {
+        let constructions = Arc::new(AtomicUsize::new(0));
+        let pool = Arc::new(ValidatorPool::new(counting_factory(constructions.clone())));
+
+        pool.checkout().recycle();
+        pool.checkout().recycle();
+
+        assert_eq!(constructions.load(Ordering::SeqCst), 1);
+        assert_eq!(pool.available.lock().len(), 1);
+    }
+
+    #[test]
+    fn panicked_checkout_discards_validator() {
+        let constructions = Arc::new(AtomicUsize::new(0));
+        let pool = Arc::new(ValidatorPool::new(counting_factory(constructions.clone())));
+
+        let result = panic::catch_unwind(AssertUnwindSafe({
+            let pool = pool.clone();
+            move || {
+                let _validator = pool.checkout();
+                panic!("validation failed");
+            }
+        }));
+        assert!(result.is_err());
+
+        pool.checkout().recycle();
+        assert_eq!(constructions.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn checkout_returns_only_to_originating_pool_generation() {
+        let original_constructions = Arc::new(AtomicUsize::new(0));
+        let original = Arc::new(ValidatorPool::new(counting_factory(
+            original_constructions.clone(),
+        )));
+        let validator = original.checkout();
+
+        let replacement_constructions = Arc::new(AtomicUsize::new(0));
+        let replacement = Arc::new(ValidatorPool::new(counting_factory(
+            replacement_constructions.clone(),
+        )));
+        validator.recycle();
+
+        assert_eq!(original.available.lock().len(), 1);
+        assert!(replacement.available.lock().is_empty());
+        replacement.checkout().recycle();
+        assert_eq!(original_constructions.load(Ordering::SeqCst), 1);
+        assert_eq!(replacement_constructions.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/wdl-analysis/src/validation.rs
+++ b/crates/wdl-analysis/src/validation.rs
@@ -187,6 +187,12 @@ pub struct Validator {
     exceptions: exceptions::Exceptions,
 }
 
+/// Asserts that validators can move between analysis workers.
+const _: () = {
+    const fn assert_send<T: Send>() {}
+    assert_send::<Validator>();
+};
+
 impl Validator {
     /// Creates a validator with an empty visitors set.
     pub fn empty() -> Self {

--- a/crates/wdl-analysis/src/validation/counts.rs
+++ b/crates/wdl-analysis/src/validation/counts.rs
@@ -10,7 +10,6 @@ use wdl_ast::Ident;
 use wdl_ast::Span;
 use wdl_ast::SupportedVersion;
 use wdl_ast::SyntaxNode;
-use wdl_ast::TokenText;
 use wdl_ast::v1::CommandKeyword;
 use wdl_ast::v1::CommandSection;
 use wdl_ast::v1::HintsKeyword;
@@ -235,7 +234,7 @@ fn empty_struct(name: Ident) -> Diagnostic {
 #[derive(Default, Debug)]
 pub struct CountingVisitor {
     /// Keeps track of what task names we've seen.
-    tasks_seen: HashSet<TokenText>,
+    tasks_seen: HashSet<String>,
     /// Whether or not we should ignore the task or workflow.
     ignore_current: bool,
     /// Whether or not the document has at least one workflow.
@@ -337,7 +336,7 @@ impl Visitor for CountingVisitor {
             return;
         }
 
-        self.ignore_current = !self.tasks_seen.insert(task.name().hashable());
+        self.ignore_current = !self.tasks_seen.insert(task.name().text().to_string());
     }
 
     fn struct_definition(

--- a/crates/wdl-analysis/src/validation/keys.rs
+++ b/crates/wdl-analysis/src/validation/keys.rs
@@ -1,13 +1,12 @@
 //! Validation of unique keys in an AST.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 use std::fmt;
 
 use wdl_ast::AstToken;
 use wdl_ast::Diagnostic;
 use wdl_ast::Ident;
 use wdl_ast::Span;
-use wdl_ast::TokenText;
 use wdl_ast::v1::CallStatement;
 use wdl_ast::v1::Expr;
 use wdl_ast::v1::LiteralExpr;
@@ -104,7 +103,7 @@ fn conflicting_key(context: Context, name: &Ident, first: Span) -> Diagnostic {
 
 /// Checks the given set of keys for duplicates
 fn check_duplicate_keys(
-    keys: &mut HashSet<TokenText>,
+    keys: &mut HashMap<String, Span>,
     aliases: &[(&str, &str)],
     names: impl Iterator<Item = Ident>,
     context: Context,
@@ -113,7 +112,7 @@ fn check_duplicate_keys(
     keys.clear();
     for name in names {
         if let Some(first) = keys.get(name.text()) {
-            diagnostics.add(duplicate_key(context, &name, first.span()));
+            diagnostics.add(duplicate_key(context, &name, *first));
             continue;
         }
 
@@ -127,12 +126,12 @@ fn check_duplicate_keys(
             };
 
             if let Some(first) = keys.get(*alias) {
-                diagnostics.add(conflicting_key(context, &name, first.span()));
+                diagnostics.add(conflicting_key(context, &name, *first));
                 break;
             }
         }
 
-        keys.insert(name.hashable());
+        keys.insert(name.text().to_string(), name.span());
     }
 }
 
@@ -147,7 +146,7 @@ fn check_duplicate_keys(
 /// * object literals
 /// * struct literals
 #[derive(Default, Debug)]
-pub struct UniqueKeysVisitor(HashSet<TokenText>);
+pub struct UniqueKeysVisitor(HashMap<String, Span>);
 
 impl Visitor for UniqueKeysVisitor {
     fn reset(&mut self) {
@@ -300,7 +299,7 @@ impl Visitor for UniqueKeysVisitor {
 
         // As metadata objects are nested inside of metadata sections and
         // objects, use a different set to check the keys
-        let mut keys = HashSet::new();
+        let mut keys = HashMap::new();
         check_duplicate_keys(
             &mut keys,
             &[],

--- a/crates/wdl-analysis/src/visitor.rs
+++ b/crates/wdl-analysis/src/visitor.rs
@@ -89,8 +89,10 @@ pub type RuleMap = HashMap<String, Option<&'static [SyntaxKind]>>;
 /// Each encountered node will receive a corresponding method call
 /// that receives both a [VisitReason::Enter] call and a
 /// matching [VisitReason::Exit] call.
+///
+/// Visitors must be transferable between analysis worker threads.
 #[allow(unused_variables)]
-pub trait Visitor {
+pub trait Visitor: Send {
     /// Get all lint rules known to this `Visitor`.
     ///
     /// Note that [`Validator`]s will expect this value to be static.

--- a/crates/wdl-lint/CHANGELOG.md
+++ b/crates/wdl-lint/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 * `Rule` implementations must now implement `Send` through the
-  `wdl_analysis::Visitor` trait.
+  `wdl_analysis::Visitor` trait
+  ([#1175](https://github.com/stjude-rust-labs/sprocket/pull/1175)).
 
 ## 0.27.0 - 2026-08-26
 

--- a/crates/wdl-lint/CHANGELOG.md
+++ b/crates/wdl-lint/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Changed
+
+* `Rule` implementations must now implement `Send` through the
+  `wdl_analysis::Visitor` trait.
+
 ## 0.27.0 - 2026-08-26
 
 #### Added
@@ -378,4 +383,3 @@ _A patch bump was required because an error was made during the release of `wdl`
 * Ported the `NoCurlyCommands` rule to `wdl-lint` ([#69](https://github.com/stjude-rust-labs/wdl/pull/69)).
 * Added the `wdl-lint` as the crate implementing linting rules for the future
   ([#68](https://github.com/stjude-rust-labs/wdl/pull/68)).
-


### PR DESCRIPTION
`Analyzer` had stopped reusing validators because process-wide thread-local reuse locked in the first validation configuration seen by each worker. This change moved reuse into a generation-aware pool owned by each analyzer, isolates old generations during canceled work, and discards validators whose visitors panic.

Closes #556.

Before submitting this PR, please make sure:

For external contributors: N/A - this is an internal contribution.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (not applicable).

For PRs containing lint rule changes: N/A.
