### PR TITLE
ci: collect coverage from doctests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,9 +84,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-shellcheck
       - name: Update Rust
-        run: |
-          rustup update stable && rustup default stable && rustup component add llvm-tools
-          rustup toolchain install nightly --component llvm-tools
+        # Nightly is required for `cargo llvm-cov --doc`
+        # (https://nexte.st/docs/integrations/test-coverage/#collecting-coverage-data-from-doctests).
+        run: rustup update nightly && rustup default nightly && rustup component add llvm-tools
 
       - name: Cache build artifacts
         uses: Swatinem/rust-cache@v2
@@ -120,7 +120,7 @@ jobs:
         run: |
           cargo llvm-cov clean --workspace
           cargo llvm-cov --no-report nextest --profile=ci --workspace --locked --all-targets --exclude fuzz --all-features --no-fail-fast
-          cargo +nightly llvm-cov --no-report --doc --workspace --locked --exclude fuzz --all-features
+          cargo llvm-cov --no-report --doc --workspace --locked --exclude fuzz --all-features
           cargo llvm-cov report --doctests --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov
@@ -177,9 +177,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-shellcheck
       - name: Update Rust
-        run: |
-          rustup update stable && rustup default stable && rustup component add llvm-tools
-          rustup toolchain install nightly --component llvm-tools
+        # Nightly is required for `cargo llvm-cov --doc`
+        # (https://nexte.st/docs/integrations/test-coverage/#collecting-coverage-data-from-doctests).
+        run: rustup update nightly && rustup default nightly && rustup component add llvm-tools
 
       - name: Install cargo-llvm-cov and cargo-nextest
         uses: taiki-e/install-action@v2
@@ -209,7 +209,7 @@ jobs:
           fi
           cargo llvm-cov clean --workspace
           cargo llvm-cov --no-report nextest --profile=ci --ignore-default-filter -E "not (kind(bench))" --locked -p wdl-engine -p sprocket --all-features --no-fail-fast
-          cargo +nightly llvm-cov --no-report --doc --locked -p wdl-engine -p sprocket --all-features
+          cargo llvm-cov --no-report --doc --locked -p wdl-engine -p sprocket --all-features
           cargo llvm-cov report --doctests --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,7 +84,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-shellcheck
       - name: Update Rust
-        run: rustup update stable && rustup default stable && rustup component add llvm-tools
+        run: |
+          rustup update stable && rustup default stable && rustup component add llvm-tools
+          rustup toolchain install nightly --component llvm-tools
 
       - name: Cache build artifacts
         uses: Swatinem/rust-cache@v2
@@ -107,12 +109,19 @@ jobs:
         if: runner.os == 'Linux'
         run: npx -y pagefind@1.5.0 --help
 
-      # TODO: nextest doesn't support doc tests yet (https://github.com/nextest-rs/nextest/issues/16)
+      # nextest doesn't support doc tests yet (https://github.com/nextest-rs/nextest/issues/16),
+      # so nextest coverage and doctest coverage are collected in separate `--no-report` passes
+      # and merged with `cargo llvm-cov report --doctests`.
+      # See: https://nexte.st/docs/integrations/test-coverage/#collecting-coverage-data-from-doctests
       - name: Run tests
         shell: bash
         env:
           RUST_LOG: info,thirtyfour::manager::driver=debug
-        run: cargo llvm-cov nextest --profile=ci --workspace --locked --all-targets --exclude fuzz --all-features --no-fail-fast --codecov --output-path codecov.json && cargo test --workspace --exclude fuzz --doc
+        run: |
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --no-report nextest --profile=ci --workspace --locked --all-targets --exclude fuzz --all-features --no-fail-fast
+          cargo +nightly llvm-cov --no-report --doc --workspace --locked --exclude fuzz --all-features
+          cargo llvm-cov report --doctests --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
@@ -168,7 +177,9 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-shellcheck
       - name: Update Rust
-        run: rustup update stable && rustup default stable && rustup component add llvm-tools
+        run: |
+          rustup update stable && rustup default stable && rustup component add llvm-tools
+          rustup toolchain install nightly --component llvm-tools
 
       - name: Install cargo-llvm-cov and cargo-nextest
         uses: taiki-e/install-action@v2
@@ -189,13 +200,17 @@ jobs:
           docker pull ghcr.io/multiqc/multiqc:v1.31
           docker pull ghcr.io/stjudecloud/util:3.0.1
           docker pull alpine:latest
+      # See the `test` job for why nextest and doctest coverage are collected separately.
       - name: Run tests
         shell: bash
         run: |
           if [[ "${{ runner.os }}" != "Linux" ]]; then
             export RUSTFLAGS="--cfg docker_tests_disabled ${RUSTFLAGS}"
           fi
-          cargo llvm-cov nextest --profile=ci --ignore-default-filter -E "not (kind(bench))" --locked -p wdl-engine -p sprocket --all-features --no-fail-fast --codecov --output-path codecov.json
+          cargo llvm-cov clean --workspace
+          cargo llvm-cov --no-report nextest --profile=ci --ignore-default-filter -E "not (kind(bench))" --locked -p wdl-engine -p sprocket --all-features --no-fail-fast
+          cargo +nightly llvm-cov --no-report --doc --locked -p wdl-engine -p sprocket --all-features
+          cargo llvm-cov report --doctests --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-shellcheck
       - name: Update Rust
-        run: rustup update nightly && rustup default nightly && rustup component add llvm-tools
+        run: rustup update stable && rustup default stable && rustup component add llvm-tools
 
       - name: Install cargo-llvm-cov and cargo-nextest
         uses: taiki-e/install-action@v2
@@ -196,17 +196,13 @@ jobs:
           docker pull ghcr.io/multiqc/multiqc:v1.31
           docker pull ghcr.io/stjudecloud/util:3.0.1
           docker pull alpine:latest
-      # See the `test` job for why nextest and doctest coverage are collected separately.
       - name: Run tests
         shell: bash
         run: |
           if [[ "${{ runner.os }}" != "Linux" ]]; then
             export RUSTFLAGS="--cfg docker_tests_disabled ${RUSTFLAGS}"
           fi
-          cargo llvm-cov clean --workspace
-          cargo llvm-cov --no-report nextest --profile=ci --ignore-default-filter -E "not (kind(bench))" --locked -p wdl-engine -p sprocket --all-features --no-fail-fast
-          cargo llvm-cov --no-report --doc --locked -p wdl-engine -p sprocket --all-features
-          cargo llvm-cov report -p wdl-engine -p sprocket --doctests --codecov --output-path codecov.json
+          cargo llvm-cov nextest --profile=ci --ignore-default-filter -E "not (kind(bench))" --locked -p wdl-engine -p sprocket --all-features --no-fail-fast --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,8 +84,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-shellcheck
       - name: Update Rust
-        # Nightly is required for `cargo llvm-cov --doc`
-        # (https://nexte.st/docs/integrations/test-coverage/#collecting-coverage-data-from-doctests).
         run: rustup update nightly && rustup default nightly && rustup component add llvm-tools
 
       - name: Cache build artifacts
@@ -177,8 +175,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/install-shellcheck
       - name: Update Rust
-        # Nightly is required for `cargo llvm-cov --doc`
-        # (https://nexte.st/docs/integrations/test-coverage/#collecting-coverage-data-from-doctests).
         run: rustup update nightly && rustup default nightly && rustup component add llvm-tools
 
       - name: Install cargo-llvm-cov and cargo-nextest
@@ -210,7 +206,7 @@ jobs:
           cargo llvm-cov clean --workspace
           cargo llvm-cov --no-report nextest --profile=ci --ignore-default-filter -E "not (kind(bench))" --locked -p wdl-engine -p sprocket --all-features --no-fail-fast
           cargo llvm-cov --no-report --doc --locked -p wdl-engine -p sprocket --all-features
-          cargo llvm-cov report --doctests --codecov --output-path codecov.json
+          cargo llvm-cov report -p wdl-engine -p sprocket --doctests --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,7 +99,7 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: |
-            cargo-llvm-cov@0.8
+            cargo-llvm-cov@0.9
             nextest@0.9
 
       # Pre-warm the npx cache so parallel tests don't race to install it.
@@ -181,7 +181,7 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: |
-            cargo-llvm-cov@0.8
+            cargo-llvm-cov@0.9
             nextest@0.9
 
       # See the `test` job

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -119,7 +119,7 @@ jobs:
           cargo llvm-cov clean --workspace
           cargo llvm-cov --no-report nextest --profile=ci --workspace --locked --all-targets --exclude fuzz --all-features --no-fail-fast
           cargo llvm-cov --no-report --doc --workspace --locked --exclude fuzz --all-features
-          cargo llvm-cov report --doctests --codecov --output-path codecov.json
+          cargo llvm-cov report --workspace --doctests --codecov --output-path codecov.json
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   terminating Sprocket leaves Docker containers running
   ([#1020](https://github.com/stjude-rust-labs/sprocket/issues/1020)).
 
+* CI now collects coverage from doctests in addition to `nextest`-run tests,
+  merging both into the Codecov report
+  ([#1176](https://github.com/stjude-rust-labs/sprocket/pull/1176)).
+
 ### Fixed
 
 * Input validation now identifies JSON and YAML input files that need an `@`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   terminating Sprocket leaves Docker containers running
   ([#1020](https://github.com/stjude-rust-labs/sprocket/issues/1020)).
 
-* CI now collects coverage from doctests in addition to `nextest`-run tests,
-  merging both into the Codecov report
-  ([#1176](https://github.com/stjude-rust-labs/sprocket/pull/1176)).
-
 ### Fixed
 
 * Input validation now identifies JSON and YAML input files that need an `@`


### PR DESCRIPTION
## Summary

We currently collect coverage for unit/integration tests via `cargo llvm-cov nextest`, but doctests are run separately and uninstrumented (`cargo test --workspace --doc` in `test`, and not run for coverage at all in `engine-test`), because `cargo-nextest` doesn't support doctests ([nextest-rs/nextest#16](https://github.com/nextest-rs/nextest/issues/16)).

This PR follows the approach documented in [nextest's test-coverage guide](https://nexte.st/docs/integrations/test-coverage/#collecting-coverage-data-from-doctests):
run nextest and doctests as two separate `cargo llvm-cov --no-report` passes, then merge them into a single report with `cargo llvm-cov report --doctests`.

Fixes #868 

## Expected coverage impact

Per the issue's own note, merging doctest coverage in is expected to produce a noticeable jump in the reported Codecov percentage. This is not a sign of newly added tests — it's previously-existing doctests being counted for the first time.

Before submitting this PR, please make sure:

For external contributors:

- [x] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [x] You have not used AI on any parts of this pull request.
- [x] You have added a few sentences describing the PR here.
- [x] Your code builds clean without any errors or warnings.

For all contributors:

- [ ] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [ ] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
