### PR TITLE
refactor: simplify WDL module command and resolver internals

### DIFF
--- a/crates/wdl-modules/src/resolver/cache.rs
+++ b/crates/wdl-modules/src/resolver/cache.rs
@@ -5,10 +5,8 @@ use std::path::PathBuf;
 
 use sha2::Digest;
 use sha2::Sha256;
-use thiserror::Error;
 use url::Url;
 
-use crate::hash::ContentHash;
 use crate::lockfile::GitCommit;
 
 /// The cache layout key for a `(repository, commit)` pair.
@@ -37,8 +35,8 @@ enum PrefixKey {
         /// human-readable prefix.
         repo_with_suffix: String,
     },
-    /// `_opaque/<sha256(url)>` for URLs that don't fit the structured
-    /// shape (IP-only hosts, deeply nested groups, etc.).
+    /// `_opaque/<sha256(url)>` for URLs without a host or with fewer than
+    /// two path segments.
     GitOpaque {
         /// Lowercase hex SHA-256 digest of the canonical URL.
         digest_hex: String,
@@ -114,71 +112,8 @@ fn hash_url(url: &Url) -> String {
     hex::encode(bytes)
 }
 
-/// Removes the cache leaf at `path`. No-op if the leaf does not exist.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "will be called by the resolver once cache management is wired up"
-    )
-)]
-pub(crate) fn evict(path: &Path) -> std::io::Result<()> {
-    match std::fs::remove_dir_all(path) {
-        Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(e),
-    }
-}
-
-/// Re-hashes a cached module folder and compares against the expected
-/// content hash.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "will be called by the resolver once cache management is wired up"
-    )
-)]
-pub(crate) fn verify_integrity(leaf: &Path, expected: &ContentHash) -> Result<(), IntegrityError> {
-    let observed =
-        crate::hash::hash_directory(leaf).map_err(|source| IntegrityError::Hash { source })?;
-    if observed != *expected {
-        return Err(IntegrityError::Mismatch {
-            expected: *expected,
-            observed,
-        });
-    }
-    Ok(())
-}
-
-/// An error produced by [`verify_integrity`].
-#[derive(Debug, Error)]
-pub(crate) enum IntegrityError {
-    /// The cached module's content hash does not match the expected
-    /// digest.
-    #[error("content hash mismatch: expected `{expected}`, observed `{observed}`")]
-    Mismatch {
-        /// The hash recorded in the lockfile.
-        expected: ContentHash,
-        /// The hash observed in the cache.
-        observed: ContentHash,
-    },
-
-    /// Re-hashing the cache leaf failed.
-    #[error(transparent)]
-    Hash {
-        /// The underlying hashing error.
-        #[from]
-        source: crate::hash::HashError,
-    },
-}
-
 #[cfg(test)]
 mod tests {
-    use std::fs;
-
-    use tempfile::tempdir;
-
     use super::*;
 
     fn commit() -> GitCommit {
@@ -242,45 +177,5 @@ mod tests {
             k_long.relative_path(),
             "nested repository URLs must produce distinct cache keys"
         );
-    }
-
-    #[test]
-    fn evict_removes_leaf() {
-        let dir = tempdir().unwrap();
-        let leaf = dir.path().join("leaf");
-        fs::create_dir_all(&leaf).unwrap();
-        fs::write(leaf.join("file"), b"x").unwrap();
-        evict(&leaf).unwrap();
-        assert!(!leaf.exists());
-    }
-
-    #[test]
-    fn evict_is_noop_when_missing() {
-        let dir = tempdir().unwrap();
-        evict(&dir.path().join("never-existed")).unwrap();
-    }
-
-    #[test]
-    fn verify_integrity_passes_on_match() {
-        let dir = tempdir().unwrap();
-        let leaf = dir.path().join("leaf");
-        fs::create_dir_all(&leaf).unwrap();
-        fs::write(leaf.join("a.wdl"), b"hello").unwrap();
-        let hash = crate::hash::hash_directory(&leaf).unwrap();
-        verify_integrity(&leaf, &hash).unwrap();
-    }
-
-    #[test]
-    fn verify_integrity_fails_on_mismatch() {
-        let dir = tempdir().unwrap();
-        let leaf = dir.path().join("leaf");
-        fs::create_dir_all(&leaf).unwrap();
-        fs::write(leaf.join("a.wdl"), b"hello").unwrap();
-        let bad: ContentHash =
-            "sha256:0000000000000000000000000000000000000000000000000000000000000000"
-                .parse()
-                .unwrap();
-        let err = verify_integrity(&leaf, &bad).unwrap_err();
-        assert!(matches!(err, IntegrityError::Mismatch { .. }));
     }
 }

--- a/crates/wdl-modules/src/resolver/git/ops.rs
+++ b/crates/wdl-modules/src/resolver/git/ops.rs
@@ -1,7 +1,6 @@
 //! Wrapper over `git2` covering the operations the resolver needs.
-//! Handles credential delegation, partial clone via filtered fetch,
-//! and sparse checkout of selected module folders within the cloned
-//! tree.
+//! Handles credential delegation, Git fetches, and sparse checkout of
+//! selected module folders within the cloned tree.
 
 //! ## Cache layout
 //!
@@ -33,9 +32,9 @@
 //!         ...
 //! ```
 //!
-//! The structured layout is used when the Git URL has a parseable
-//! `<host>/<org>/<repo>` path. URLs that don't fit that shape
-//! (IP-only hosts, deeply nested groups, etc.) fall back to the
+//! The structured layout is used when the Git URL has a host and at least two
+//! path segments. Additional path segments remain part of the URL digest, which
+//! prevents nested repository URLs from colliding. Other URLs fall back to the
 //! `_opaque/` layout keyed by a SHA-256 digest of the URL.
 //!
 //! Both `.<commit>.lock` and `.<commit>.sparse.json` live next to the
@@ -54,43 +53,17 @@ mod remote;
 #[cfg(test)]
 mod test_support;
 
-// NOTE: This facade is consumed by resolver tests but unused in the library
-// build.
-#[allow(unused_imports)]
+#[cfg(test)]
 pub(crate) use cache_store::CACHE_MARKER_FILENAME;
 pub(crate) use cache_store::CacheLocation;
 pub(crate) use cache_store::initialize_cache_root;
-#[expect(unused_imports)]
-pub(crate) use cache_store::lock_cache_root_exclusive;
-#[expect(unused_imports)]
-pub(crate) use cache_store::lock_cache_root_shared;
-#[expect(unused_imports)]
-pub(crate) use cache_store::remove_cache_leaf;
 pub(crate) use cache_store::remove_cache_leaves;
 pub(crate) use cache_store::remove_cache_root;
-#[expect(unused_imports)]
-pub(crate) use checkout::GitTreeStats;
 pub(crate) use checkout::TreeLimits;
-#[expect(unused_imports)]
-pub(crate) use checkout::clone_with_sparse_checkout;
-#[expect(unused_imports)]
-pub(crate) use checkout::enforce_tree_limits;
 pub(crate) use checkout::ensure_materialized;
-#[expect(unused_imports)]
-pub(crate) use checkout::extend_sparse_checkout;
-#[expect(unused_imports)]
-pub(crate) use checkout::inspect_subtree_stats;
 pub(crate) use creds::CredentialMode;
 pub(crate) use creds::FetchPolicy;
-#[expect(unused_imports)]
-pub(crate) use creds::default_callbacks;
-#[expect(unused_imports)]
-pub(crate) use creds::default_fetch_options;
 pub(crate) use error::GitError;
-#[expect(unused_imports)]
-pub(crate) use remote::connect_remote;
-#[expect(unused_imports)]
-pub(crate) use remote::disconnect_remote;
 pub(crate) use remote::discover_default_branch;
 pub(crate) use remote::list_advertised_refs;
 pub(crate) use remote::resolve_commit_prefix;

--- a/src/commands/module/add.rs
+++ b/src/commands/module/add.rs
@@ -155,40 +155,22 @@ pub async fn add(args: Args, config: Config, output: CommandOutput) -> CommandRe
     document
         .insert_dependency(name.manifest(), &source)
         .map_err(anyhow::Error::from)?;
-    let relock = if args.no_lock {
-        None
-    } else {
-        Some(
-            RelockPlanner::new(&config, &project, &baseline)
-                .plan_and_enforce(
-                    std::sync::Arc::new(document.manifest().clone()),
-                    signer_change_mode(&config, args.trust_mode),
-                    output,
-                )
-                .await?,
+    let relock = RelockPlanner::new(&config, &project, &baseline)
+        .apply_manifest_edit(
+            &document,
+            args.no_lock,
+            signer_change_mode(&config, args.trust_mode),
+            output,
         )
-    };
-
-    project
-        .write_manifest(&document)
-        .map_err(anyhow::Error::from)?;
-    let written = match relock.as_ref() {
-        Some(outcome) => Some(write_lockfile(
-            &project,
-            &outcome.lockfile,
-            document.manifest(),
-            WriteIntent::Satisfy,
-        )?),
-        None => None,
-    };
+        .await?;
     tracing::debug!(
         dependency = name.manifest(),
         manifest = %project.manifest_path().display(),
         "wrote dependency to manifest"
     );
 
-    if let Some(outcome) = relock {
-        if written == Some(LockfileWrite::Kept) {
+    if let Some((outcome, written)) = relock {
+        if written == LockfileWrite::Kept {
             tracing::debug!("kept the module lockfile another process had already written");
             output.completed(ADD, format!("`{}`", name.manifest()));
             print_source_details(output, &source);

--- a/src/commands/module/lock.rs
+++ b/src/commands/module/lock.rs
@@ -12,6 +12,7 @@ use super::project::trace_project;
 use super::project::write_lockfile;
 use super::relock::RelockPlanner;
 use super::signer_policy::TrustModeArg;
+use super::signer_policy::enforce_lockfile_signer_policy;
 use super::signer_policy::signer_change_mode;
 use crate::commands::CommandResult;
 use crate::commands::output::Action;
@@ -77,11 +78,12 @@ pub async fn lock(args: Args, config: Config, output: CommandOutput) -> CommandR
         return Ok(());
     }
 
+    let baseline = lock.unwrap_or_default();
+    let plan = RelockPlanner::new(&config, &project, &baseline)
+        .plan(std::sync::Arc::new(project.manifest().clone()))
+        .await?;
+
     if args.dry_run {
-        let baseline = lock.clone().unwrap_or_default();
-        let plan = RelockPlanner::new(&config, &project, &baseline)
-            .plan(std::sync::Arc::new(project.manifest().clone()))
-            .await?;
         tracing::debug!("dry run completed without writing lockfile or trust store");
         let changes = relock_change_count(&plan.outcome.stats);
         output.planned(
@@ -106,14 +108,14 @@ pub async fn lock(args: Args, config: Config, output: CommandOutput) -> CommandR
         return Ok(());
     }
 
-    let baseline = lock.clone().unwrap_or_default();
-    let outcome = RelockPlanner::new(&config, &project, &baseline)
-        .plan_and_enforce(
-            std::sync::Arc::new(project.manifest().clone()),
-            signer_change_mode(&config, args.trust_mode),
-            output,
-        )
-        .await?;
+    enforce_lockfile_signer_policy(
+        &plan.existing,
+        &plan.outcome.lockfile,
+        &plan.identities,
+        signer_change_mode(&config, args.trust_mode),
+        output,
+    )?;
+    let outcome = plan.outcome;
     if write_lockfile(
         &project,
         &outcome.lockfile,

--- a/src/commands/module/project.rs
+++ b/src/commands/module/project.rs
@@ -7,6 +7,7 @@ use anyhow::Context as _;
 use clap::Args as ClapArgs;
 use wdl_modules::Lockfile;
 use wdl_modules::Manifest;
+use wdl_modules::dependency::DependencyName;
 use wdl_modules::project::LockedLockfile;
 use wdl_modules::project::ModuleProject;
 
@@ -70,6 +71,25 @@ pub(super) fn load_lockfile(project: &Project) -> anyhow::Result<Option<Lockfile
         }
     }
     Ok(lockfile)
+}
+
+/// Parses dependency names and verifies that each one is declared.
+pub(super) fn validate_dependency_names(
+    project: &Project,
+    names: &[String],
+) -> anyhow::Result<Vec<DependencyName>> {
+    names
+        .iter()
+        .map(|raw| {
+            let name: DependencyName = raw
+                .parse()
+                .with_context(|| format!("invalid dependency name `{raw}`"))?;
+            if !project.manifest().dependencies.contains_key(&name) {
+                anyhow::bail!("dependency `{raw}` not found in `module.json`");
+            }
+            Ok(name)
+        })
+        .collect()
 }
 
 /// The `--locked` flag shared by commands that read `module-lock.json`.

--- a/src/commands/module/relock.rs
+++ b/src/commands/module/relock.rs
@@ -6,12 +6,16 @@ use wdl_modules::Lockfile;
 use wdl_modules::Manifest;
 use wdl_modules::Resolver as _;
 use wdl_modules::module::Module;
+use wdl_modules::project::ManifestDocument;
 use wdl_modules::resolver::lock::RelockOutcome;
 use wdl_modules::resolver::lock::SignerIdentityMap;
 use wdl_modules::resolver::lock::partial_relock;
 use wdl_modules::resolver::lock::signer_identity_map;
 
+use super::project::LockfileWrite;
 use super::project::Project;
+use super::project::WriteIntent;
+use super::project::write_lockfile;
 use super::resolver::ResolverEnvironment;
 use super::signer_policy::SignerChangeMode;
 use super::signer_policy::enforce_lockfile_signer_policy;
@@ -94,6 +98,42 @@ impl<'a> RelockPlanner<'a> {
             output,
         )?;
         Ok(plan.outcome)
+    }
+
+    /// Applies an edited manifest and, unless locking was disabled, first
+    /// prepares and approves its relock and then writes the resulting lockfile.
+    ///
+    /// Planning happens before either file is written so a failed or refused
+    /// relock leaves the project files untouched.
+    pub(super) async fn apply_manifest_edit(
+        &self,
+        document: &ManifestDocument,
+        no_lock: bool,
+        mode: SignerChangeMode,
+        output: CommandOutput,
+    ) -> anyhow::Result<Option<(RelockOutcome, LockfileWrite)>> {
+        let outcome = if no_lock {
+            None
+        } else {
+            Some(
+                self.plan_and_enforce(Arc::new(document.manifest().clone()), mode, output)
+                    .await?,
+            )
+        };
+
+        self.project
+            .write_manifest(document)
+            .map_err(anyhow::Error::from)?;
+        let Some(outcome) = outcome else {
+            return Ok(None);
+        };
+        let written = write_lockfile(
+            self.project,
+            &outcome.lockfile,
+            document.manifest(),
+            WriteIntent::Satisfy,
+        )?;
+        Ok(Some((outcome, written)))
     }
 }
 

--- a/src/commands/module/remove.rs
+++ b/src/commands/module/remove.rs
@@ -4,11 +4,9 @@ use clap::Parser;
 
 use super::project::Locator;
 use super::project::LockfileWrite;
-use super::project::WriteIntent;
 use super::project::discover;
 use super::project::load_lockfile;
 use super::project::trace_project;
-use super::project::write_lockfile;
 use super::relock::RelockPlanner;
 use super::signer_policy::TrustModeArg;
 use super::signer_policy::signer_change_mode;
@@ -56,42 +54,22 @@ pub async fn remove(args: Args, config: Config, output: CommandOutput) -> Comman
         return Err(anyhow::anyhow!("dependency `{}` not found", args.name).into());
     }
 
-    // Relock against the pending manifest before touching any files so a
-    // refused or failed relock leaves the project untouched.
-    let relock = if args.no_lock {
-        None
-    } else {
-        Some(
-            RelockPlanner::new(&config, &project, &baseline)
-                .plan_and_enforce(
-                    std::sync::Arc::new(document.manifest().clone()),
-                    signer_change_mode(&config, args.trust_mode),
-                    output,
-                )
-                .await?,
+    let relock = RelockPlanner::new(&config, &project, &baseline)
+        .apply_manifest_edit(
+            &document,
+            args.no_lock,
+            signer_change_mode(&config, args.trust_mode),
+            output,
         )
-    };
-
-    project
-        .write_manifest(&document)
-        .map_err(anyhow::Error::from)?;
-    let written = match relock.as_ref() {
-        Some(outcome) => Some(write_lockfile(
-            &project,
-            &outcome.lockfile,
-            document.manifest(),
-            WriteIntent::Satisfy,
-        )?),
-        None => None,
-    };
+        .await?;
     tracing::debug!(
         dependency = args.name,
         manifest = %project.manifest_path().display(),
         "removed dependency from manifest"
     );
 
-    if let Some(outcome) = relock {
-        if written == Some(LockfileWrite::Kept) {
+    if let Some((outcome, written)) = relock {
+        if written == LockfileWrite::Kept {
             tracing::debug!("kept the module lockfile another process had already written");
             output.completed(REMOVE, format!("`{}`", args.name));
             output.current("module lockfile is up to date");

--- a/src/commands/module/update.rs
+++ b/src/commands/module/update.rs
@@ -2,11 +2,9 @@
 
 use std::collections::BTreeSet;
 
-use anyhow::Context as _;
 use clap::Parser;
 use wdl_modules::Lockfile;
 use wdl_modules::Resolver as _;
-use wdl_modules::dependency::DependencyName;
 use wdl_modules::module::Module;
 use wdl_modules::resolver::lock::RelockOutcome;
 use wdl_modules::resolver::lock::RelockStats;
@@ -21,6 +19,7 @@ use super::project::WriteIntent;
 use super::project::discover;
 use super::project::load_lockfile;
 use super::project::trace_project;
+use super::project::validate_dependency_names;
 use super::project::write_lockfile;
 use super::resolver::ResolverEnvironment;
 use super::signer_policy::TrustModeArg;
@@ -60,18 +59,15 @@ pub async fn update(args: Args, config: Config, output: CommandOutput) -> Comman
         "starting `sprocket dev module update`"
     );
     let project = discover(&args.locator)?;
+    trace_project("module update", &project);
+    let existing = load_lockfile(&project)?.unwrap_or_default();
+    let plan = plan_update(&args, &config, &project, &existing).await?;
     if args.dry_run {
-        trace_project("module update", &project);
-        let existing = load_lockfile(&project)?.unwrap_or_default();
-        let plan = plan_update(&args, &config, &project, &existing).await?;
         tracing::debug!("dry run completed without writing lockfile");
         print_update_outcome(output, &plan.outcome.stats, true);
         return Ok(());
     }
 
-    trace_project("module update", &project);
-    let existing = load_lockfile(&project)?.unwrap_or_default();
-    let plan = plan_update(&args, &config, &project, &existing).await?;
     enforce_lockfile_signer_policy(
         &plan.existing,
         &plan.outcome.lockfile,
@@ -115,17 +111,7 @@ async fn plan_update(
     if args.names.is_empty() {
         names.extend(project.manifest().dependencies.keys().cloned());
     } else {
-        for raw in &args.names {
-            let name: DependencyName = raw
-                .parse()
-                .with_context(|| format!("invalid dependency name `{raw}`"))?;
-            if !project.manifest().dependencies.contains_key(&name) {
-                return Err(anyhow::anyhow!(
-                    "dependency `{raw}` not found in `module.json`"
-                ));
-            }
-            names.insert(name);
-        }
+        names.extend(validate_dependency_names(project, &args.names)?);
     }
     tracing::debug!(
         selected = names.len(),

--- a/src/commands/module/upgrade.rs
+++ b/src/commands/module/upgrade.rs
@@ -25,6 +25,7 @@ use super::project::WriteIntent;
 use super::project::discover;
 use super::project::load_lockfile;
 use super::project::trace_project;
+use super::project::validate_dependency_names;
 use super::project::write_lockfile;
 use super::resolver::ResolverEnvironment;
 use super::signer_policy::TrustModeArg;
@@ -66,17 +67,14 @@ pub async fn upgrade(args: Args, config: Config, output: CommandOutput) -> Comma
         "starting `sprocket dev module upgrade`"
     );
     let project = discover(&args.locator)?;
+    trace_project("module upgrade", &project);
+    let existing = load_lockfile(&project)?.unwrap_or_default();
+    let plan = plan_upgrade(&args, &config, &project, &existing).await?;
     if args.dry_run {
-        trace_project("module upgrade", &project);
-        let existing = load_lockfile(&project)?.unwrap_or_default();
-        let plan = plan_upgrade(&args, &config, &project, &existing).await?;
         print_upgrade_plan(output, plan);
         return Ok(());
     }
 
-    trace_project("module upgrade", &project);
-    let existing = load_lockfile(&project)?.unwrap_or_default();
-    let plan = plan_upgrade(&args, &config, &project, &existing).await?;
     let UpgradePlan::Changes(changes) = plan else {
         print_upgrade_plan(output, plan);
         return Ok(());
@@ -152,17 +150,7 @@ async fn plan_upgrade(
     if args.names.is_empty() {
         selected.extend(project.manifest().dependencies.keys().cloned());
     } else {
-        for raw in &args.names {
-            let name: DependencyName = raw
-                .parse()
-                .with_context(|| format!("invalid dependency name `{raw}`"))?;
-            if !project.manifest().dependencies.contains_key(&name) {
-                return Err(anyhow::anyhow!(
-                    "dependency `{raw}` not found in `module.json`"
-                ));
-            }
-            selected.push(name);
-        }
+        selected = validate_dependency_names(project, &args.names)?;
     }
     tracing::debug!(
         selected = selected.len(),

--- a/tests/module/add_remove.rs
+++ b/tests/module/add_remove.rs
@@ -537,6 +537,52 @@ fn remove_leaves_manifest_untouched_when_relock_fails() {
 }
 
 #[test]
+fn remove_no_lock_skips_resolution_and_preserves_lockfile() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("consumer");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join("module.json"),
+        r#"{
+  "name": "consumer",
+  "license": "MIT",
+  "dependencies": {
+    "broken": { "path": "../missing" },
+    "drop": { "path": "../also-missing" }
+  }
+}
+"#,
+    )
+    .unwrap();
+    let lockfile_before = br#"{"version":1,"dependencies":{}}"#;
+    fs::write(root.join("module-lock.json"), lockfile_before).unwrap();
+
+    let output = sprocket(&["dev", "module", "remove", "drop", "--no-lock"])
+        .current_dir(&root)
+        .output()
+        .expect("failed to run sprocket dev module remove");
+    assert!(
+        output.status.success(),
+        "command failed {status}: {stderr}",
+        status = output.status,
+        stderr = String::from_utf8_lossy(&output.stderr)
+    );
+
+    let manifest = Manifest::parse(&fs::read(root.join("module.json")).unwrap()).unwrap();
+    assert!(
+        manifest
+            .dependencies
+            .contains_key(&"broken".parse().unwrap())
+    );
+    assert!(!manifest.dependencies.contains_key(&"drop".parse().unwrap()));
+    assert_eq!(
+        fs::read(root.join("module-lock.json")).unwrap(),
+        lockfile_before,
+        "`--no-lock` must leave the existing lockfile byte-for-byte unchanged"
+    );
+}
+
+#[test]
 fn add_new_signer_matrix_respects_trust_mode() {
     let cases = [
         (CliTrustMode::Confirm, false, true),


### PR DESCRIPTION
The module implementation retained unused cache helpers and Git re-exports, while the CLI commands repeated planning and persistence logic. Removed the obsolete resolver code, corrected cache documentation, and shared dependency validation and the add/remove relock-and-write sequence. Lock, update, and upgrade now prepare one plan before branching for dry runs, preserving signer checks, write ordering, and command output.

Added a regression test confirming that `remove --no-lock` skips resolution of a broken remaining dependency and preserves the existing lockfile byte-for-byte. Local validation passed 357 module library tests, four doctests, and 167 module command tests, plus workspace Clippy with warnings denied, nightly formatting, and spelling checks.

Workspace documentation also built with `cargo --locked doc --workspace --no-deps`; it reported three existing link warnings in unchanged files. This is an internal refactor; a changelog entry, website update, and lint-rule changes are N/A.

Before submitting this PR, please make sure:

For external contributors:

N/A — internal contribution.

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [ ] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
