### PR TITLE
fix: apply module `exclude` patterns to content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Module `exclude` patterns now remove files from content validation, hashing,
+  signing, and imports. Excluded test harnesses can remain beside module files
+  and still run directly from a local checkout
+  ([#1187](https://github.com/stjude-rust-labs/sprocket/issues/1187)).
+
 * `sprocket run` and `sprocket dev test` now warn on a second Ctrl-C that
   terminating Sprocket leaves Docker containers running
   ([#1020](https://github.com/stjude-rust-labs/sprocket/issues/1020)).

--- a/crates/wdl-modules/CHANGELOG.md
+++ b/crates/wdl-modules/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Fixed
+
+* Manifest `exclude` patterns now consistently omit matching files from module
+  content validation, hashing, signing, and imports while retaining physical
+  tree safety and resource-limit checks ([#1187](https://github.com/stjude-rust-labs/sprocket/issues/1187)).
+
 ## 0.3.2 - 2026-08-26
 
 #### Added

--- a/crates/wdl-modules/Cargo.toml
+++ b/crates/wdl-modules/Cargo.toml
@@ -24,7 +24,6 @@ git-resolver = [
     "dep:dirs",
     "dep:futures",
     "dep:git2",
-    "dep:globset",
     "dep:tokio",
     "dep:toml-spanner",
     "dep:tracing",
@@ -40,7 +39,7 @@ dirs = { workspace = true, optional = true }
 ed25519-dalek = { workspace = true }
 futures = { workspace = true, optional = true }
 git2 = { workspace = true, optional = true, features = ["https", "ssh"] }
-globset = { workspace = true, optional = true }
+globset = { workspace = true }
 hex = { workspace = true }
 path-clean = { workspace = true }
 schemars = { workspace = true }

--- a/crates/wdl-modules/src/hash.rs
+++ b/crates/wdl-modules/src/hash.rs
@@ -1,4 +1,4 @@
-//! Content hashing per the WDL module spec.
+//! Content hashing per the WDL module spec, including manifest exclusions.
 
 use std::collections::BTreeSet;
 use std::fmt;
@@ -15,6 +15,8 @@ use sha2::Digest;
 use sha2::Sha256;
 use thiserror::Error;
 
+use crate::module_walk::ExcludePatternError;
+use crate::module_walk::ExclusionSet;
 use crate::module_walk::ModuleWalkError;
 use crate::relative_path::RelativePath;
 use crate::relative_path::RelativePathError;
@@ -23,6 +25,21 @@ use crate::tree::TreeError;
 /// An error during content hashing.
 #[derive(Debug, Error)]
 pub enum HashError {
+    /// The root module manifest could not be parsed while loading content
+    /// exclusions.
+    #[error("invalid module manifest at `{path}`")]
+    Manifest {
+        /// The root manifest path.
+        path: PathBuf,
+        /// The manifest parse error.
+        #[source]
+        source: crate::manifest::ManifestError,
+    },
+
+    /// A manifest `exclude` pattern is not a valid glob.
+    #[error(transparent)]
+    InvalidExclude(#[from] ExcludePatternError),
+
     /// A path supplied to [`Hasher::try_add`] failed relative-path
     /// validation.
     #[error(transparent)]
@@ -259,8 +276,6 @@ impl Hasher {
     }
 }
 
-/// Computes the content hash of a directory by walking it (excluding the
-/// spec-mandated exclusions `module.sig` and `module-lock.json`).
 /// Directory and file names that are not module content and should
 /// be excluded from hashing, limit checks, and content walks.
 pub(crate) const NON_MODULE_CONTENT: &[&str] = &[".git", ".sprocket"];
@@ -277,14 +292,25 @@ pub(crate) fn path_is_excluded_from_hash(path: &Path) -> bool {
         })
 }
 
-/// Walks `root` and computes the deterministic content hash of the
-/// module directory, skipping non-module content and spec-defined
-/// exclusions.
+/// Walks `root` and computes its deterministic module content hash.
+///
+/// Manifest `exclude` matches, `module.sig`, `module-lock.json`, and
+/// non-content metadata directories are omitted. The root `module.json` is
+/// always included.
 pub fn hash_directory(root: impl AsRef<Path>) -> Result<ContentHash, HashError> {
     let root = root.as_ref();
+    let exclusions = exclusions_from_root(root)?;
+    hash_directory_with_exclusions(root, &exclusions)
+}
+
+/// Computes a content hash with exclusions that have already been compiled.
+pub(crate) fn hash_directory_with_exclusions(
+    root: &Path,
+    exclusions: &ExclusionSet,
+) -> Result<ContentHash, HashError> {
     let mut hasher = Hasher::new(root.to_path_buf());
 
-    crate::module_walk::walk_module_tree(root, &mut |path: &Path, _size| {
+    crate::module_walk::walk_module_content_tree(root, exclusions, &mut |path: &Path, _size| {
         // SAFETY: the walker only yields paths under `root`.
         let rel_path = path.strip_prefix(root).unwrap();
         let rel = rel_path
@@ -305,6 +331,35 @@ pub fn hash_directory(root: impl AsRef<Path>) -> Result<ContentHash, HashError> 
     crate::tree::validate_tree(hasher.paths())?;
 
     hasher.finalize()
+}
+
+/// Loads and compiles exclusions from the root manifest when one is present.
+fn exclusions_from_root(root: &Path) -> Result<ExclusionSet, HashError> {
+    let path = root.join(crate::MANIFEST_FILENAME);
+    let metadata = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == io::ErrorKind::NotFound => {
+            return ExclusionSet::new(&[]).map_err(Into::into);
+        }
+        Err(source) => return Err(HashError::Io { path, source }),
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(HashError::Walk(ModuleWalkError::Symlink(
+            path.display().to_string(),
+        )));
+    }
+    if !metadata.is_file() {
+        return ExclusionSet::new(&[]).map_err(Into::into);
+    }
+    let bytes = std::fs::read(&path).map_err(|source| HashError::Io {
+        path: path.clone(),
+        source,
+    })?;
+    let manifest = crate::Manifest::parse(&bytes).map_err(|source| HashError::Manifest {
+        path: path.clone(),
+        source,
+    })?;
+    ExclusionSet::new(&manifest.exclude).map_err(Into::into)
 }
 
 #[cfg(test)]
@@ -455,6 +510,65 @@ mod tests {
         let d_with_state = hash_directory(dir.path()).unwrap();
 
         assert_eq!(d_clean, d_with_state);
+    }
+
+    #[test]
+    fn manifest_exclusions_keep_hash_stable_after_excluded_edits() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join(crate::MANIFEST_FILENAME),
+            br#"{"name":"example","license":"MIT","exclude":["test/**"]}"#,
+        )
+        .unwrap();
+        fs::create_dir(dir.path().join("test")).unwrap();
+        fs::write(dir.path().join("index.wdl"), b"version 1.3\n").unwrap();
+        fs::write(dir.path().join("test/harness.wdl"), b"first").unwrap();
+
+        let before = hash_directory(dir.path()).unwrap();
+        fs::write(dir.path().join("test/harness.wdl"), b"second").unwrap();
+        let after = hash_directory(dir.path()).unwrap();
+        assert_eq!(before, after);
+    }
+
+    #[test]
+    fn root_manifest_is_hashed_even_when_excluded_by_glob() {
+        let dir = tempdir().unwrap();
+        let manifest = dir.path().join(crate::MANIFEST_FILENAME);
+        fs::write(
+            &manifest,
+            br#"{"name":"example","license":"MIT","exclude":["*"]}"#,
+        )
+        .unwrap();
+        fs::write(dir.path().join("index.wdl"), b"version 1.3\n").unwrap();
+        let before = hash_directory(dir.path()).unwrap();
+
+        fs::write(
+            &manifest,
+            br#"{"name":"renamed","license":"MIT","exclude":["*"]}"#,
+        )
+        .unwrap();
+        let after = hash_directory(dir.path()).unwrap();
+        assert_ne!(before, after);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn excluded_paths_cannot_conceal_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join(crate::MANIFEST_FILENAME),
+            br#"{"name":"example","license":"MIT","exclude":["test/**"]}"#,
+        )
+        .unwrap();
+        fs::create_dir(dir.path().join("test")).unwrap();
+        symlink(dir.path(), dir.path().join("test/alias")).unwrap();
+
+        assert!(matches!(
+            hash_directory(dir.path()),
+            Err(HashError::Walk(ModuleWalkError::Symlink(_)))
+        ));
     }
 
     #[test]

--- a/crates/wdl-modules/src/lib.rs
+++ b/crates/wdl-modules/src/lib.rs
@@ -2,7 +2,8 @@
 //!
 //! `wdl-modules` provides the local, deterministic pieces of WDL module
 //! handling: `module.json` manifest parsing, `module-lock.json` lockfile
-//! parsing, symbolic import paths, deterministic content hashing, Ed25519
+//! parsing, symbolic import paths, manifest-driven content exclusions,
+//! deterministic content hashing, Ed25519
 //! `module.sig` signing and verification, SPDX license validation, and
 //! module file-tree checks.
 //!

--- a/crates/wdl-modules/src/manifest.rs
+++ b/crates/wdl-modules/src/manifest.rs
@@ -53,6 +53,16 @@ pub enum ManifestError {
         source: RelativePathError,
     },
 
+    /// An `exclude` entry is not a valid glob.
+    #[error("invalid `exclude` pattern `{pattern}`")]
+    InvalidExcludeGlob {
+        /// The offending pattern as written in the manifest.
+        pattern: String,
+        /// The underlying glob parser error.
+        #[source]
+        source: globset::Error,
+    },
+
     /// The `readme` field was set to the literal `true`. The schema only
     /// accepts a string, the literal `false`, or absence; `true` is
     /// rejected with a dedicated message because it is a common authoring
@@ -154,12 +164,12 @@ pub struct Manifest {
     pub entrypoint: Option<RelativePath>,
     /// The module's readme.
     pub readme: Readme,
-    /// Gitignore-style glob patterns identifying files within the module
-    /// that consumers may not reach via symbolic import. Each entry is a
-    /// validated [`RelativePath`]; absolute paths, `..` segments, and
-    /// other invalid forms are rejected at parse time. Has no effect on
-    /// content hashing, signing, validation, or quoted within-module
-    /// imports.
+    /// Gitignore-style glob patterns identifying files outside the module's
+    /// logical content. Excluded files cannot be reached through symbolic or
+    /// quoted module imports and do not contribute to content validation,
+    /// hashing, signing, or packaging. Each entry is a validated
+    /// [`RelativePath`]; absolute paths, `..` segments, and other invalid forms
+    /// are rejected at parse time. The root `module.json` is always included.
     pub exclude: Vec<RelativePath>,
     /// The upstream tools wrapped by the module.
     pub tools: Vec<Tool>,
@@ -226,8 +236,8 @@ struct ManifestFields {
     /// The `readme` field, accepting a string, `false`, or absence.
     #[serde(default, deserialize_with = "deserialize_readme")]
     readme: ReadmeFields,
-    /// Gitignore-style glob patterns identifying files outside the public
-    /// import surface.
+    /// Gitignore-style glob patterns identifying files outside logical module
+    /// content.
     #[serde(default)]
     exclude: Vec<String>,
     /// The upstream tools.
@@ -340,6 +350,12 @@ impl TryFrom<ManifestFields> for Manifest {
                     .map_err(|source| ManifestError::InvalidExclude { pattern, source })
             })
             .collect::<Result<Vec<_>, _>>()?;
+        crate::module_walk::ExclusionSet::new(&exclude).map_err(|error| {
+            ManifestError::InvalidExcludeGlob {
+                pattern: error.pattern,
+                source: error.source,
+            }
+        })?;
 
         for tool in &fields.tools {
             for id in &tool.ids {
@@ -629,6 +645,22 @@ mod tests {
             }
             other => panic!("expected `InvalidExclude` variant; got {other:?}"),
         }
+    }
+
+    #[test]
+    fn rejects_invalid_exclude_glob() {
+        let err = parse(
+            r#"{
+                "name": "spellbook",
+                "license": "MIT",
+                "exclude": ["["]
+            }"#,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            ManifestError::InvalidExcludeGlob { pattern, .. } if pattern == "["
+        ));
     }
 
     #[test]

--- a/crates/wdl-modules/src/module_walk.rs
+++ b/crates/wdl-modules/src/module_walk.rs
@@ -11,8 +11,77 @@ use std::path::Path;
 use std::path::PathBuf;
 
 use thiserror::Error;
+use unicode_normalization::UnicodeNormalization;
 
 use crate::hash::NON_MODULE_CONTENT;
+use crate::relative_path::RelativePath;
+
+/// A compiled set of manifest `exclude` patterns.
+///
+/// Patterns use gitignore-style glob semantics: `*` does not cross path
+/// separators, `**` does, and matching a directory also excludes its subtree.
+/// The root manifest is always module content, even when a pattern matches it.
+#[derive(Clone, Debug)]
+pub struct ExclusionSet {
+    /// The compiled glob matcher.
+    set: globset::GlobSet,
+}
+
+impl ExclusionSet {
+    /// Compiles manifest `exclude` patterns.
+    pub fn new(patterns: &[RelativePath]) -> Result<Self, ExcludePatternError> {
+        let mut builder = globset::GlobSetBuilder::new();
+        for pattern in patterns {
+            let source = pattern.as_str();
+            let normalized = source.nfc().collect::<String>();
+            let compile = |glob: &str| {
+                globset::GlobBuilder::new(glob)
+                    .literal_separator(true)
+                    .build()
+                    .map_err(|source_error| ExcludePatternError {
+                        pattern: source.to_string(),
+                        source: source_error,
+                    })
+            };
+            builder.add(compile(&normalized)?);
+            builder.add(compile(&format!(
+                "{}/**",
+                normalized.trim_end_matches('/')
+            ))?);
+        }
+
+        // `GlobSetBuilder::build` only consolidates globs already validated by
+        // `GlobBuilder::build` above.
+        Ok(Self {
+            set: builder
+                .build()
+                .expect("compiled globs should form a glob set"),
+        })
+    }
+
+    /// Returns whether `path` is excluded from logical module content.
+    pub fn is_excluded(&self, path: &Path) -> bool {
+        if path == Path::new(crate::MANIFEST_FILENAME) {
+            return false;
+        }
+        let Some(path) = path.to_str() else {
+            return false;
+        };
+        let normalized = path.replace('\\', "/").nfc().collect::<String>();
+        self.set.is_match(normalized)
+    }
+}
+
+/// An invalid manifest `exclude` glob.
+#[derive(Debug, Error)]
+#[error("invalid `exclude` pattern `{pattern}`")]
+pub struct ExcludePatternError {
+    /// The invalid pattern.
+    pub pattern: String,
+    /// The underlying glob parser error.
+    #[source]
+    pub source: globset::Error,
+}
 
 /// An error encountered while walking a module tree.
 #[derive(Debug, Error)]
@@ -57,6 +126,35 @@ pub fn walk_module_tree<E>(
 ) -> Result<TreeStats, WalkError<E>> {
     let mut stats = TreeStats::default();
     walk_recursive(root, visitor, &mut stats)?;
+    Ok(stats)
+}
+
+/// Walks logical module content, omitting files matched by `exclusions`.
+///
+/// The underlying physical tree is still traversed in full, so excluded paths
+/// cannot conceal symbolic links. Statistics count only visited module-content
+/// files; callers enforcing physical materialization limits should use
+/// [`walk_module_tree`] directly.
+pub fn walk_module_content_tree<E>(
+    root: &Path,
+    exclusions: &ExclusionSet,
+    visitor: &mut dyn FnMut(&Path, u64) -> Result<(), E>,
+) -> Result<TreeStats, WalkError<E>> {
+    let mut stats = TreeStats::default();
+    let mut visit_content = |path: &Path, size: u64| {
+        // SAFETY: `walk_module_tree` only yields paths beneath `root`.
+        let relative = path.strip_prefix(root).unwrap();
+        if exclusions.is_excluded(relative) {
+            return Ok(());
+        }
+        stats.files += 1;
+        stats.bytes = stats.bytes.saturating_add(size);
+        visitor(path, size)
+    };
+
+    // Discard the physical-tree statistics: this function reports logical
+    // module-content statistics accumulated by `visit_content`.
+    walk_module_tree(root, &mut visit_content)?;
     Ok(stats)
 }
 
@@ -123,16 +221,56 @@ fn walk_recursive<E>(
     Ok(())
 }
 
-#[cfg(all(test, unix))]
+#[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use std::convert::Infallible;
+    #[cfg(unix)]
     use std::os::unix::fs::symlink;
 
+    #[cfg(unix)]
     use tempfile::tempdir;
 
     use super::*;
 
+    fn rel(value: &str) -> RelativePath {
+        value.parse().unwrap()
+    }
+
     #[test]
+    fn exclusions_use_gitignore_style_globs_and_keep_manifest() {
+        let exclusions = ExclusionSet::new(&[
+            rel("internal"),
+            rel("scratch/*.wdl"),
+            rel("secret/**"),
+            rel("module.json"),
+        ])
+        .unwrap();
+
+        assert!(exclusions.is_excluded(Path::new("internal/private.wdl")));
+        assert!(exclusions.is_excluded(Path::new("internal/deep/nested.wdl")));
+        assert!(exclusions.is_excluded(Path::new("scratch/tmp.wdl")));
+        assert!(!exclusions.is_excluded(Path::new("scratch/sub/tmp.wdl")));
+        assert!(exclusions.is_excluded(Path::new("secret/a/b/c.wdl")));
+        assert!(!exclusions.is_excluded(Path::new("public.wdl")));
+        assert!(!exclusions.is_excluded(Path::new(crate::MANIFEST_FILENAME)));
+    }
+
+    #[test]
+    fn rejects_invalid_exclusion_glob() {
+        let error = ExclusionSet::new(&[rel("[")]).unwrap_err();
+        assert_eq!(error.pattern, "[");
+    }
+
+    #[test]
+    fn exclusions_match_after_unicode_normalization() {
+        let decomposed = "cafe\u{301}.wdl";
+        let exclusions = ExclusionSet::new(&[rel(decomposed)]).unwrap();
+        assert!(exclusions.is_excluded(Path::new("caf\u{e9}.wdl")));
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn rejects_symlink_in_excluded_directory() -> Result<(), Box<dyn std::error::Error>> {
         let root = tempdir()?;
         let outside = tempdir()?;

--- a/crates/wdl-modules/src/project/validation.rs
+++ b/crates/wdl-modules/src/project/validation.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use super::ModuleProject;
 use crate::hash::ContentHash;
 use crate::hash::HashError;
+use crate::module_walk::ExclusionSet;
 
 /// A manifest-referenced file required for a valid module project.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -78,16 +79,18 @@ impl ModuleProject {
     ///
     /// The returned digest can be reused for signature verification.
     pub fn validate(&self) -> Result<ContentHash, ProjectValidationError> {
-        validate_regular_file(
-            &self.root,
-            self.manifest().entrypoint_filename(),
-            ProjectFileKind::Entrypoint,
-        )?;
-        if let Some(readme) = self.manifest().readme_filename() {
+        let exclusions = ExclusionSet::new(&self.manifest().exclude).map_err(HashError::from)?;
+        let entrypoint = self.manifest().entrypoint_filename();
+        if !exclusions.is_excluded(entrypoint) {
+            validate_regular_file(&self.root, entrypoint, ProjectFileKind::Entrypoint)?;
+        }
+        if let Some(readme) = self.manifest().readme_filename()
+            && !exclusions.is_excluded(readme)
+        {
             validate_regular_file(&self.root, readme, ProjectFileKind::Readme)?;
         }
 
-        crate::hash::hash_directory(&self.root).map_err(Into::into)
+        crate::hash::hash_directory_with_exclusions(&self.root, &exclusions).map_err(Into::into)
     }
 }
 
@@ -321,6 +324,40 @@ mod tests {
             }
         ));
         assert!(error.to_string().contains(".sprocket/README.md"));
+        Ok(())
+    }
+
+    #[test]
+    fn allows_entrypoint_excluded_by_manifest_glob() -> Result<(), Box<dyn Error>> {
+        let (directory, project) = project(
+            r#"{
+                "name":"example",
+                "license":"MIT",
+                "exclude":["*.wdl"]
+            }"#,
+        )?;
+        std::fs::write(directory.path().join("index.wdl"), "version 1.3\n")?;
+        std::fs::write(directory.path().join("README.md"), "# Example\n")?;
+
+        project.validate()?;
+        Ok(())
+    }
+
+    #[test]
+    fn allows_readme_excluded_by_manifest_glob() -> Result<(), Box<dyn Error>> {
+        let (directory, project) = project(
+            r#"{
+                "name":"example",
+                "license":"MIT",
+                "exclude":["docs/**"],
+                "readme":"docs/README.md"
+            }"#,
+        )?;
+        std::fs::write(directory.path().join("index.wdl"), "version 1.3\n")?;
+        std::fs::create_dir(directory.path().join("docs"))?;
+        std::fs::write(directory.path().join("docs/README.md"), "# Example\n")?;
+
+        project.validate()?;
         Ok(())
     }
 

--- a/crates/wdl-modules/src/resolver/cache.rs
+++ b/crates/wdl-modules/src/resolver/cache.rs
@@ -5,10 +5,8 @@ use std::path::PathBuf;
 
 use sha2::Digest;
 use sha2::Sha256;
-use thiserror::Error;
 use url::Url;
 
-use crate::hash::ContentHash;
 use crate::lockfile::GitCommit;
 
 /// The cache layout key for a `(repository, commit)` pair.
@@ -37,8 +35,8 @@ enum PrefixKey {
         /// human-readable prefix.
         repo_with_suffix: String,
     },
-    /// `_opaque/<sha256(url)>` for URLs that don't fit the structured
-    /// shape (IP-only hosts, deeply nested groups, etc.).
+    /// `_opaque/<sha256(url)>` for URLs without a host or with fewer than
+    /// two path segments.
     GitOpaque {
         /// Lowercase hex SHA-256 digest of the canonical URL.
         digest_hex: String,
@@ -114,71 +112,8 @@ fn hash_url(url: &Url) -> String {
     hex::encode(bytes)
 }
 
-/// Removes the cache leaf at `path`. No-op if the leaf does not exist.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "will be called by the resolver once cache management is wired up"
-    )
-)]
-pub(crate) fn evict(path: &Path) -> std::io::Result<()> {
-    match std::fs::remove_dir_all(path) {
-        Ok(()) => Ok(()),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(e) => Err(e),
-    }
-}
-
-/// Re-hashes a cached module folder and compares against the expected
-/// content hash.
-#[cfg_attr(
-    not(test),
-    expect(
-        dead_code,
-        reason = "will be called by the resolver once cache management is wired up"
-    )
-)]
-pub(crate) fn verify_integrity(leaf: &Path, expected: &ContentHash) -> Result<(), IntegrityError> {
-    let observed =
-        crate::hash::hash_directory(leaf).map_err(|source| IntegrityError::Hash { source })?;
-    if observed != *expected {
-        return Err(IntegrityError::Mismatch {
-            expected: *expected,
-            observed,
-        });
-    }
-    Ok(())
-}
-
-/// An error produced by [`verify_integrity`].
-#[derive(Debug, Error)]
-pub(crate) enum IntegrityError {
-    /// The cached module's content hash does not match the expected
-    /// digest.
-    #[error("content hash mismatch: expected `{expected}`, observed `{observed}`")]
-    Mismatch {
-        /// The hash recorded in the lockfile.
-        expected: ContentHash,
-        /// The hash observed in the cache.
-        observed: ContentHash,
-    },
-
-    /// Re-hashing the cache leaf failed.
-    #[error(transparent)]
-    Hash {
-        /// The underlying hashing error.
-        #[from]
-        source: crate::hash::HashError,
-    },
-}
-
 #[cfg(test)]
 mod tests {
-    use std::fs;
-
-    use tempfile::tempdir;
-
     use super::*;
 
     fn commit() -> GitCommit {
@@ -242,45 +177,5 @@ mod tests {
             k_long.relative_path(),
             "nested repository URLs must produce distinct cache keys"
         );
-    }
-
-    #[test]
-    fn evict_removes_leaf() {
-        let dir = tempdir().unwrap();
-        let leaf = dir.path().join("leaf");
-        fs::create_dir_all(&leaf).unwrap();
-        fs::write(leaf.join("file"), b"x").unwrap();
-        evict(&leaf).unwrap();
-        assert!(!leaf.exists());
-    }
-
-    #[test]
-    fn evict_is_noop_when_missing() {
-        let dir = tempdir().unwrap();
-        evict(&dir.path().join("never-existed")).unwrap();
-    }
-
-    #[test]
-    fn verify_integrity_passes_on_match() {
-        let dir = tempdir().unwrap();
-        let leaf = dir.path().join("leaf");
-        fs::create_dir_all(&leaf).unwrap();
-        fs::write(leaf.join("a.wdl"), b"hello").unwrap();
-        let hash = crate::hash::hash_directory(&leaf).unwrap();
-        verify_integrity(&leaf, &hash).unwrap();
-    }
-
-    #[test]
-    fn verify_integrity_fails_on_mismatch() {
-        let dir = tempdir().unwrap();
-        let leaf = dir.path().join("leaf");
-        fs::create_dir_all(&leaf).unwrap();
-        fs::write(leaf.join("a.wdl"), b"hello").unwrap();
-        let bad: ContentHash =
-            "sha256:0000000000000000000000000000000000000000000000000000000000000000"
-                .parse()
-                .unwrap();
-        let err = verify_integrity(&leaf, &bad).unwrap_err();
-        assert!(matches!(err, IntegrityError::Mismatch { .. }));
     }
 }

--- a/crates/wdl-modules/src/resolver/error.rs
+++ b/crates/wdl-modules/src/resolver/error.rs
@@ -383,6 +383,21 @@ pub enum ResolverError {
         import: String,
     },
 
+    /// A quoted `import` in included module content targets an excluded path.
+    #[error(
+        "`{dep}` file `{file}` has a quoted import `{import}` that targets content excluded by \
+         the module manifest"
+    )]
+    QuotedImportExcluded {
+        /// The owning dependency.
+        dep: String,
+        /// The included `.wdl` file containing the offending import, relative
+        /// to the module root.
+        file: String,
+        /// The offending import target as written.
+        import: String,
+    },
+
     /// An I/O error.
     #[error("i/o error at `{path}`")]
     Io {

--- a/crates/wdl-modules/src/resolver/git.rs
+++ b/crates/wdl-modules/src/resolver/git.rs
@@ -320,7 +320,8 @@ impl GitResolver {
         };
 
         // Reject paths that match the manifest's exclude globs.
-        if exclude_set(&manifest.exclude)?.is_match(rel.as_path()) {
+        let exclusions = exclude_set(&manifest.exclude)?;
+        if exclusions.is_excluded(rel.as_path()) {
             return Err(ResolverError::MissingFile {
                 dep: name.manifest().to_string(),
                 path: rel.as_path().to_path_buf(),
@@ -342,6 +343,31 @@ impl GitResolver {
                 }
                 other => other,
             })?;
+
+        // Case-insensitive filesystems may resolve a differently-cased
+        // symbolic path to excluded content. Match the canonical target's
+        // actual on-disk spelling before returning it.
+        let canonical_root =
+            std::fs::canonicalize(root_path).map_err(|source| ResolverError::Io {
+                path: root_path.to_path_buf(),
+                source,
+            })?;
+        let actual = canonical
+            .strip_prefix(&canonical_root)
+            .map_err(|_| ResolverError::Io {
+                path: canonical.clone(),
+                source: std::io::Error::new(
+                    std::io::ErrorKind::NotFound,
+                    "path resolves outside module content",
+                ),
+            })?;
+        if crate::hash::path_is_excluded_from_hash(actual) || exclusions.is_excluded(actual) {
+            return Err(ResolverError::MissingFile {
+                dep: name.manifest().to_string(),
+                path: actual.to_path_buf(),
+                kind: MissingFileKind::Excluded,
+            });
+        }
 
         Ok(MaterializedFile {
             path: canonical,
@@ -1261,29 +1287,11 @@ pub(super) fn resolve_normalized_subpath(
 /// `literal_separator` is enabled so a single `*` does not cross `/`.
 pub(super) fn exclude_set(
     patterns: &[crate::relative_path::RelativePath],
-) -> Result<globset::GlobSet, ResolverError> {
-    if patterns.is_empty() {
-        return Ok(globset::GlobSet::empty());
-    }
-    let mut builder = globset::GlobSetBuilder::new();
-    for p in patterns {
-        let s: &str = p.as_ref();
-        let compile = |glob: &str| {
-            globset::GlobBuilder::new(glob)
-                .literal_separator(true)
-                .build()
-                .map_err(|source| ResolverError::InvalidExclude {
-                    pattern: s.to_string(),
-                    source,
-                })
-        };
-        builder.add(compile(s)?);
-        builder.add(compile(&format!("{}/**", s.trim_end_matches('/')))?);
-    }
-    // SAFETY: `GlobSetBuilder::build` only consolidates already-compiled
-    // globs; `GlobBuilder::build` above is the validating step, so by the
-    // time we reach this call there is nothing left for `build` to reject.
-    Ok(builder.build().unwrap())
+) -> Result<crate::module_walk::ExclusionSet, ResolverError> {
+    crate::module_walk::ExclusionSet::new(patterns).map_err(|error| ResolverError::InvalidExclude {
+        pattern: error.pattern,
+        source: error.source,
+    })
 }
 
 /// Returns true when a lockfile entry can satisfy the current Git

--- a/crates/wdl-modules/src/resolver/git/ops.rs
+++ b/crates/wdl-modules/src/resolver/git/ops.rs
@@ -1,7 +1,6 @@
 //! Wrapper over `git2` covering the operations the resolver needs.
-//! Handles credential delegation, partial clone via filtered fetch,
-//! and sparse checkout of selected module folders within the cloned
-//! tree.
+//! Handles credential delegation, Git fetches, and sparse checkout of
+//! selected module folders within the cloned tree.
 
 //! ## Cache layout
 //!
@@ -33,9 +32,9 @@
 //!         ...
 //! ```
 //!
-//! The structured layout is used when the Git URL has a parseable
-//! `<host>/<org>/<repo>` path. URLs that don't fit that shape
-//! (IP-only hosts, deeply nested groups, etc.) fall back to the
+//! The structured layout is used when the Git URL has a host and at least two
+//! path segments. Additional path segments remain part of the URL digest, which
+//! prevents nested repository URLs from colliding. Other URLs fall back to the
 //! `_opaque/` layout keyed by a SHA-256 digest of the URL.
 //!
 //! Both `.<commit>.lock` and `.<commit>.sparse.json` live next to the
@@ -54,43 +53,17 @@ mod remote;
 #[cfg(test)]
 mod test_support;
 
-// NOTE: This facade is consumed by resolver tests but unused in the library
-// build.
-#[allow(unused_imports)]
+#[cfg(test)]
 pub(crate) use cache_store::CACHE_MARKER_FILENAME;
 pub(crate) use cache_store::CacheLocation;
 pub(crate) use cache_store::initialize_cache_root;
-#[expect(unused_imports)]
-pub(crate) use cache_store::lock_cache_root_exclusive;
-#[expect(unused_imports)]
-pub(crate) use cache_store::lock_cache_root_shared;
-#[expect(unused_imports)]
-pub(crate) use cache_store::remove_cache_leaf;
 pub(crate) use cache_store::remove_cache_leaves;
 pub(crate) use cache_store::remove_cache_root;
-#[expect(unused_imports)]
-pub(crate) use checkout::GitTreeStats;
 pub(crate) use checkout::TreeLimits;
-#[expect(unused_imports)]
-pub(crate) use checkout::clone_with_sparse_checkout;
-#[expect(unused_imports)]
-pub(crate) use checkout::enforce_tree_limits;
 pub(crate) use checkout::ensure_materialized;
-#[expect(unused_imports)]
-pub(crate) use checkout::extend_sparse_checkout;
-#[expect(unused_imports)]
-pub(crate) use checkout::inspect_subtree_stats;
 pub(crate) use creds::CredentialMode;
 pub(crate) use creds::FetchPolicy;
-#[expect(unused_imports)]
-pub(crate) use creds::default_callbacks;
-#[expect(unused_imports)]
-pub(crate) use creds::default_fetch_options;
 pub(crate) use error::GitError;
-#[expect(unused_imports)]
-pub(crate) use remote::connect_remote;
-#[expect(unused_imports)]
-pub(crate) use remote::disconnect_remote;
 pub(crate) use remote::discover_default_branch;
 pub(crate) use remote::list_advertised_refs;
 pub(crate) use remote::resolve_commit_prefix;

--- a/crates/wdl-modules/src/resolver/git/tests/materialize.rs
+++ b/crates/wdl-modules/src/resolver/git/tests/materialize.rs
@@ -30,12 +30,12 @@ fn exclude_set_honors_gitignore_semantics() {
     let patterns = [rel("internal"), rel("scratch/*.wdl"), rel("secret/**")];
     let set = exclude_set(&patterns).unwrap();
 
-    assert!(set.is_match(Path::new("internal/private.wdl")));
-    assert!(set.is_match(Path::new("internal/deep/nested.wdl")));
-    assert!(set.is_match(Path::new("scratch/tmp.wdl")));
-    assert!(!set.is_match(Path::new("scratch/sub/tmp.wdl")));
-    assert!(set.is_match(Path::new("secret/a/b/c.wdl")));
-    assert!(!set.is_match(Path::new("public.wdl")));
+    assert!(set.is_excluded(Path::new("internal/private.wdl")));
+    assert!(set.is_excluded(Path::new("internal/deep/nested.wdl")));
+    assert!(set.is_excluded(Path::new("scratch/tmp.wdl")));
+    assert!(!set.is_excluded(Path::new("scratch/sub/tmp.wdl")));
+    assert!(set.is_excluded(Path::new("secret/a/b/c.wdl")));
+    assert!(!set.is_excluded(Path::new("public.wdl")));
 }
 
 #[test]
@@ -376,6 +376,49 @@ async fn materialize_blocks_excluded_glob() {
         panic!("expected `MissingFile`, got: {err}");
     };
     assert_eq!(kind, MissingFileKind::Excluded);
+}
+
+#[tokio::test]
+async fn materialize_matches_actual_entrypoint_case_on_case_insensitive_filesystems() {
+    let workdir = tempdir().unwrap();
+    let dep_dir = workdir.path().join("dep");
+    fs::create_dir_all(&dep_dir).unwrap();
+    fs::write(
+        dep_dir.join(crate::MANIFEST_FILENAME),
+        r#"{
+            "name":"dep",
+            "license":"MIT",
+            "readme":false,
+            "entrypoint":"INDEX.wdl",
+            "exclude":["index.wdl"]
+        }"#,
+    )
+    .unwrap();
+    fs::write(dep_dir.join("index.wdl"), b"version 1.3\n").unwrap();
+    if !dep_dir.join("INDEX.wdl").exists() {
+        return;
+    }
+
+    let consumer_dir = workdir.path().join("consumer");
+    let dep_src = format!("{{\"path\":\"{}\"}}", json_path(&dep_dir));
+    write_manifest(&consumer_dir, "consumer", "0.1.0", &[("dep", &dep_src)]);
+    let consumer =
+        Manifest::parse(&fs::read(consumer_dir.join(crate::MANIFEST_FILENAME)).unwrap()).unwrap();
+    let consumer = module(consumer, &consumer_dir);
+    let cache = tempdir().unwrap();
+    let (resolver, _) = resolve_and_lock(&cache, &consumer).await;
+
+    let error = resolver
+        .materialize(&consumer, &"dep".parse().unwrap())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        error,
+        ResolverError::MissingFile {
+            kind: MissingFileKind::Excluded,
+            ..
+        }
+    ));
 }
 
 #[tokio::test]

--- a/crates/wdl-modules/src/resolver/verify.rs
+++ b/crates/wdl-modules/src/resolver/verify.rs
@@ -141,50 +141,219 @@ pub(crate) fn verify_structure(
 ///
 /// A quoted import such as `import "../shared.wdl"` that escapes the
 /// module root makes the module invalid, even if the target exists.
-/// Imports that name an absolute URI (with a scheme) are not
-/// file-relative and are not subject to this check.
+/// Absolute non-file URIs are not file-relative and are not subject to this
+/// check. File URLs are decoded and checked like relative file imports.
 ///
-/// Each file is parsed with the WDL grammar and its actual import
-/// statements are inspected, so `import` appearing in a command block or
-/// after a definition cannot bypass the check. Files that fail to parse
-/// are skipped here; analysis reports their syntax errors separately.
+/// Every included `.wdl` file is parsed with the WDL grammar. Local imports are
+/// followed recursively regardless of file extension because WDL import URIs
+/// do not require one. Actual import statements are inspected, so `import`
+/// appearing in a command block or after a definition cannot bypass the check.
+/// Files that fail to parse yield no imports here; analysis reports their
+/// syntax errors separately.
 fn check_quoted_imports(name: &DependencyName, module_root: &Path) -> Result<(), ResolverError> {
+    use std::collections::HashSet;
+    use std::collections::VecDeque;
+
     // Symbolic links are already forbidden by the tree walk, so a
     // lexical comparison of cleaned paths is sufficient; the walk yields
-    // paths under `module_root`, so the root is used as-is.
-    let root = path_clean::clean(module_root);
-
-    walk_module_tree(module_root, &mut |path: &Path, _size| {
-        if path.extension().and_then(|e| e.to_str()) != Some("wdl") {
-            return Ok(());
+    // paths under `module_root`.
+    let root = if module_root.is_absolute() {
+        path_clean::clean(module_root)
+    } else {
+        path_clean::clean(
+            std::env::current_dir()
+                .map_err(|source| ResolverError::Io {
+                    path: module_root.to_path_buf(),
+                    source,
+                })?
+                .join(module_root),
+        )
+    };
+    let (manifest, exclusions) = exclusions_from_root(module_root)?;
+    let canonical_root = std::fs::canonicalize(&root).map_err(|source| ResolverError::Io {
+        path: root.clone(),
+        source,
+    })?;
+    let mut queue = VecDeque::new();
+    module_walk::walk_module_content_tree(module_root, &exclusions, &mut |path: &Path, _size| {
+        if path.extension().and_then(|extension| extension.to_str()) == Some("wdl") {
+            let relative = path.strip_prefix(module_root).unwrap_or(path);
+            queue.push_back(path_clean::clean(root.join(relative)));
         }
-        let contents = std::fs::read_to_string(path).map_err(|source| ResolverError::Io {
-            path: path.to_path_buf(),
+        Ok::<_, ResolverError>(())
+    })
+    .map_err(|error| match error {
+        module_walk::WalkError::Walk(error) => ResolverError::Walk(error),
+        module_walk::WalkError::Visitor(error) => error,
+    })?;
+    if let Some(manifest) = manifest {
+        let entrypoint = manifest.entrypoint_filename();
+        if !crate::hash::path_is_excluded_from_hash(entrypoint)
+            && !exclusions.is_excluded(entrypoint)
+        {
+            let path = path_clean::clean(root.join(entrypoint));
+            if std::fs::symlink_metadata(&path).is_ok_and(|metadata| metadata.is_file()) {
+                let canonical =
+                    std::fs::canonicalize(&path).map_err(|source| ResolverError::Io {
+                        path: path.clone(),
+                        source,
+                    })?;
+                if canonical.starts_with(&canonical_root) {
+                    let actual = canonical.strip_prefix(&canonical_root).unwrap();
+                    if !crate::hash::path_is_excluded_from_hash(actual)
+                        && !exclusions.is_excluded(actual)
+                    {
+                        queue.push_back(path);
+                    }
+                }
+            }
+        }
+    }
+
+    // Start with every included `.wdl` file to preserve whole-module
+    // validation, then follow local imports regardless of file extension.
+    // This catches import chains through extensionless documents without
+    // loading unrelated binary module assets into memory.
+    let mut visited = HashSet::new();
+    while let Some(path) = queue.pop_front() {
+        if !visited.insert(path.clone()) {
+            continue;
+        }
+        let contents = std::fs::read_to_string(&path).map_err(|source| ResolverError::Io {
+            path: path.clone(),
             source,
         })?;
-        let file_dir = path.parent().unwrap_or(&root);
+        let base = url::Url::from_file_path(&path).map_err(|()| ResolverError::Io {
+            path: path.clone(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "could not convert module path to a file URL",
+            ),
+        })?;
         for import in quoted_imports(&contents) {
-            // Absolute URIs (with a scheme) are not file-relative.
-            if url::Url::parse(&import).is_ok() {
+            let Ok(resolved_url) = base.join(&import) else {
+                // Analysis reports malformed import URIs separately.
+                continue;
+            };
+            // Absolute non-file URIs are not paths within module content.
+            if resolved_url.scheme() != "file" {
                 continue;
             }
-            let resolved = path_clean::clean(file_dir.join(&import));
+            let resolved = match resolved_url.to_file_path() {
+                Ok(path) => path_clean::clean(path),
+                Err(()) => {
+                    return Err(ResolverError::QuotedImportEscapesRoot {
+                        dep: name.manifest().to_string(),
+                        file: module_relative_path(&root, &path),
+                        import,
+                    });
+                }
+            };
             if !resolved.starts_with(&root) {
-                let rel = path
-                    .strip_prefix(&root)
-                    .unwrap_or(path)
-                    .to_string_lossy()
-                    .replace('\\', "/");
                 return Err(ResolverError::QuotedImportEscapesRoot {
                     dep: name.manifest().to_string(),
-                    file: rel,
+                    file: module_relative_path(&root, &path),
                     import,
                 });
             }
+            // SAFETY: containment was checked immediately above.
+            let target = resolved.strip_prefix(&root).unwrap();
+            if crate::hash::path_is_excluded_from_hash(target) || exclusions.is_excluded(target) {
+                return Err(ResolverError::QuotedImportExcluded {
+                    dep: name.manifest().to_string(),
+                    file: module_relative_path(&root, &path),
+                    import,
+                });
+            }
+            match std::fs::symlink_metadata(&resolved) {
+                Ok(metadata) if metadata.is_file() => {
+                    let canonical =
+                        std::fs::canonicalize(&resolved).map_err(|source| ResolverError::Io {
+                            path: resolved.clone(),
+                            source,
+                        })?;
+                    if !canonical.starts_with(&canonical_root) {
+                        return Err(ResolverError::QuotedImportEscapesRoot {
+                            dep: name.manifest().to_string(),
+                            file: module_relative_path(&root, &path),
+                            import,
+                        });
+                    }
+                    // Match again using the target's actual on-disk spelling.
+                    // Case-insensitive filesystems may resolve a differently
+                    // cased URI to an excluded file.
+                    let canonical_target = canonical.strip_prefix(&canonical_root).unwrap();
+                    if crate::hash::path_is_excluded_from_hash(canonical_target)
+                        || exclusions.is_excluded(canonical_target)
+                    {
+                        return Err(ResolverError::QuotedImportExcluded {
+                            dep: name.manifest().to_string(),
+                            file: module_relative_path(&root, &path),
+                            import,
+                        });
+                    }
+                    // Keep the lexical root spelling for subsequent URL joins;
+                    // `canonical_root` may use a platform alias such as
+                    // `/private/var` for a lexical `/var` root.
+                    queue.push_back(resolved);
+                }
+                Ok(_) => {}
+                Err(source) if source.kind() == std::io::ErrorKind::NotFound => {}
+                Err(source) => {
+                    return Err(ResolverError::Io {
+                        path: resolved,
+                        source,
+                    });
+                }
+            }
         }
-        Ok(())
-    })?;
+    }
     Ok(())
+}
+
+/// Returns a module-root-relative path using portable separators.
+fn module_relative_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .replace('\\', "/")
+}
+
+/// Loads the root manifest's compiled content exclusions, when present.
+fn exclusions_from_root(
+    root: &Path,
+) -> Result<(Option<crate::Manifest>, module_walk::ExclusionSet), ResolverError> {
+    let path = root.join(crate::MANIFEST_FILENAME);
+    let metadata = match std::fs::symlink_metadata(&path) {
+        Ok(metadata) => metadata,
+        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+            let exclusions = module_walk::ExclusionSet::new(&[]).map_err(|error| {
+                ResolverError::InvalidExclude {
+                    pattern: error.pattern,
+                    source: error.source,
+                }
+            })?;
+            return Ok((None, exclusions));
+        }
+        Err(source) => return Err(ResolverError::Io { path, source }),
+    };
+    if metadata.file_type().is_symlink() {
+        return Err(ResolverError::Walk(module_walk::ModuleWalkError::Symlink(
+            path.display().to_string(),
+        )));
+    }
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(source) => return Err(ResolverError::Io { path, source }),
+    };
+    let manifest = crate::Manifest::parse(&bytes)?;
+    let exclusions = module_walk::ExclusionSet::new(&manifest.exclude).map_err(|error| {
+        ResolverError::InvalidExclude {
+            pattern: error.pattern,
+            source: error.source,
+        }
+    })?;
+    Ok((Some(manifest), exclusions))
 }
 
 /// Extracts the target of each quoted (URI) `import` statement from WDL
@@ -359,6 +528,20 @@ mod tests {
         fs::write(dir.join("index.wdl"), content).unwrap();
     }
 
+    fn write_manifest(dir: &std::path::Path, exclusions: &[&str]) {
+        let body = serde_json::json!({
+            "name": "foo",
+            "license": "MIT",
+            "readme": false,
+            "exclude": exclusions,
+        });
+        fs::write(
+            dir.join(crate::MANIFEST_FILENAME),
+            serde_json::to_vec(&body).unwrap(),
+        )
+        .unwrap();
+    }
+
     fn write_signed_module(dir: &std::path::Path, content: &str, seed: u64) {
         write_module(dir, content);
         let checksum = crate::hash::hash_directory(dir).unwrap();
@@ -444,6 +627,165 @@ mod tests {
         .unwrap();
         let policy = ResolverPolicy::default();
         assert!(verify(&policy, &test_dep(), dir.path()).is_ok());
+    }
+
+    #[test]
+    fn verify_accepts_relative_module_root() {
+        let current = std::env::current_dir().unwrap();
+        let dir = tempfile::tempdir_in(&current).unwrap();
+        let relative = dir.path().strip_prefix(&current).unwrap();
+        write_manifest(dir.path(), &[]);
+        write_module(dir.path(), "version 1.3\nimport \"helper.wdl\"\n");
+        fs::write(dir.path().join("helper.wdl"), "version 1.3\n").unwrap();
+
+        let result = verify(&ResolverPolicy::default(), &test_dep(), relative);
+        assert!(
+            result.is_ok(),
+            "relative module root should verify: {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_ignores_escaping_import_in_excluded_file() {
+        let dir = tempdir().unwrap();
+        write_manifest(dir.path(), &["testrun.wdl"]);
+        write_module(dir.path(), "version 1.3\n");
+        fs::write(
+            dir.path().join("testrun.wdl"),
+            "version 1.3\nimport \"../shared.wdl\"\n",
+        )
+        .unwrap();
+
+        let result = verify(&ResolverPolicy::default(), &test_dep(), dir.path());
+        assert!(
+            result.is_ok(),
+            "excluded harness should be ignored: {result:?}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_included_import_targeting_excluded_content() {
+        let dir = tempdir().unwrap();
+        write_manifest(dir.path(), &["private/**"]);
+        write_module(dir.path(), "version 1.3\nimport \"private/helper.wdl\"\n");
+        fs::create_dir(dir.path().join("private")).unwrap();
+        fs::write(dir.path().join("private/helper.wdl"), "version 1.3\n").unwrap();
+
+        let error = verify(&ResolverPolicy::default(), &test_dep(), dir.path()).unwrap_err();
+        assert!(matches!(error, ResolverError::QuotedImportExcluded { .. }));
+    }
+
+    #[test]
+    fn verify_checks_imports_in_wdl_documents_without_wdl_extension() {
+        let dir = tempdir().unwrap();
+        write_manifest(dir.path(), &["private.wdl"]);
+        write_module(dir.path(), "version 1.3\nimport \"helper.txt\"\n");
+        fs::write(
+            dir.path().join("helper.txt"),
+            "version 1.3\nimport \"private.wdl\"\n",
+        )
+        .unwrap();
+        fs::write(dir.path().join("private.wdl"), "version 1.3\n").unwrap();
+
+        let error = verify(&ResolverPolicy::default(), &test_dep(), dir.path()).unwrap_err();
+        assert!(matches!(error, ResolverError::QuotedImportExcluded { .. }));
+    }
+
+    #[test]
+    fn verify_checks_custom_entrypoint_without_wdl_extension() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join(crate::MANIFEST_FILENAME),
+            br#"{
+                "name":"foo",
+                "license":"MIT",
+                "readme":false,
+                "entrypoint":"main.txt",
+                "exclude":["private.wdl"]
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("main.txt"),
+            "version 1.3\nimport \"private.wdl\"\n",
+        )
+        .unwrap();
+        fs::write(dir.path().join("private.wdl"), "version 1.3\n").unwrap();
+
+        let error = verify(&ResolverPolicy::default(), &test_dep(), dir.path()).unwrap_err();
+        assert!(matches!(error, ResolverError::QuotedImportExcluded { .. }));
+    }
+
+    #[test]
+    fn verify_rejects_import_of_unhashed_metadata() {
+        let dir = tempdir().unwrap();
+        write_manifest(dir.path(), &[]);
+        write_module(dir.path(), "version 1.3\nimport \"module-lock.json\"\n");
+        fs::write(dir.path().join(crate::LOCKFILE_FILENAME), "version 1.3\n").unwrap();
+
+        let error = verify(&ResolverPolicy::default(), &test_dep(), dir.path()).unwrap_err();
+        assert!(matches!(error, ResolverError::QuotedImportExcluded { .. }));
+    }
+
+    #[test]
+    fn verify_decodes_file_uri_before_checking_exclusions() {
+        let dir = tempdir().unwrap();
+        write_manifest(dir.path(), &["private files/**"]);
+        fs::create_dir(dir.path().join("private files")).unwrap();
+        let target = dir.path().join("private files/helper.wdl");
+        fs::write(&target, "version 1.3\n").unwrap();
+        let target = url::Url::from_file_path(&target).unwrap();
+        write_module(dir.path(), &format!("version 1.3\nimport \"{target}\"\n"));
+
+        let error = verify(&ResolverPolicy::default(), &test_dep(), dir.path()).unwrap_err();
+        assert!(matches!(error, ResolverError::QuotedImportExcluded { .. }));
+    }
+
+    #[test]
+    fn verify_decodes_relative_uri_before_checking_exclusions() {
+        let dir = tempdir().unwrap();
+        write_manifest(dir.path(), &["private.wdl"]);
+        write_module(
+            dir.path(),
+            "version 1.3\nimport \"private%2Ewdl#fragment\"\n",
+        );
+        fs::write(dir.path().join("private.wdl"), "version 1.3\n").unwrap();
+
+        let error = verify(&ResolverPolicy::default(), &test_dep(), dir.path()).unwrap_err();
+        assert!(matches!(error, ResolverError::QuotedImportExcluded { .. }));
+    }
+
+    #[test]
+    fn verify_matches_actual_path_case_on_case_insensitive_filesystems() {
+        let dir = tempdir().unwrap();
+        write_manifest(dir.path(), &["private.wdl"]);
+        fs::write(dir.path().join("private.wdl"), "version 1.3\n").unwrap();
+        if !dir.path().join("PRIVATE.wdl").exists() {
+            return;
+        }
+        write_module(dir.path(), "version 1.3\nimport \"PRIVATE.wdl\"\n");
+
+        let error = verify(&ResolverPolicy::default(), &test_dep(), dir.path()).unwrap_err();
+        assert!(matches!(error, ResolverError::QuotedImportExcluded { .. }));
+    }
+
+    #[test]
+    fn physical_limits_count_excluded_files() {
+        let dir = tempdir().unwrap();
+        write_manifest(dir.path(), &["testrun.wdl"]);
+        write_module(dir.path(), "version 1.3\n");
+        fs::write(dir.path().join("testrun.wdl"), "version 1.3\n").unwrap();
+        let policy = ResolverPolicy::try_from(&ModulesConfig {
+            max_materialized_files: Some(2),
+            ..ModulesConfig::default()
+        })
+        .unwrap();
+
+        let error = verify(&policy, &test_dep(), dir.path()).unwrap_err();
+        assert!(matches!(
+            error,
+            ResolverError::MaterializedTreeLimitExceeded { files: 3, .. }
+        ));
     }
 
     #[test]

--- a/src/commands/module/add.rs
+++ b/src/commands/module/add.rs
@@ -155,40 +155,22 @@ pub async fn add(args: Args, config: Config, output: CommandOutput) -> CommandRe
     document
         .insert_dependency(name.manifest(), &source)
         .map_err(anyhow::Error::from)?;
-    let relock = if args.no_lock {
-        None
-    } else {
-        Some(
-            RelockPlanner::new(&config, &project, &baseline)
-                .plan_and_enforce(
-                    std::sync::Arc::new(document.manifest().clone()),
-                    signer_change_mode(&config, args.trust_mode),
-                    output,
-                )
-                .await?,
+    let relock = RelockPlanner::new(&config, &project, &baseline)
+        .apply_manifest_edit(
+            &document,
+            args.no_lock,
+            signer_change_mode(&config, args.trust_mode),
+            output,
         )
-    };
-
-    project
-        .write_manifest(&document)
-        .map_err(anyhow::Error::from)?;
-    let written = match relock.as_ref() {
-        Some(outcome) => Some(write_lockfile(
-            &project,
-            &outcome.lockfile,
-            document.manifest(),
-            WriteIntent::Satisfy,
-        )?),
-        None => None,
-    };
+        .await?;
     tracing::debug!(
         dependency = name.manifest(),
         manifest = %project.manifest_path().display(),
         "wrote dependency to manifest"
     );
 
-    if let Some(outcome) = relock {
-        if written == Some(LockfileWrite::Kept) {
+    if let Some((outcome, written)) = relock {
+        if written == LockfileWrite::Kept {
             tracing::debug!("kept the module lockfile another process had already written");
             output.completed(ADD, format!("`{}`", name.manifest()));
             print_source_details(output, &source);

--- a/src/commands/module/lock.rs
+++ b/src/commands/module/lock.rs
@@ -12,6 +12,7 @@ use super::project::trace_project;
 use super::project::write_lockfile;
 use super::relock::RelockPlanner;
 use super::signer_policy::TrustModeArg;
+use super::signer_policy::enforce_lockfile_signer_policy;
 use super::signer_policy::signer_change_mode;
 use crate::commands::CommandResult;
 use crate::commands::output::Action;
@@ -77,11 +78,12 @@ pub async fn lock(args: Args, config: Config, output: CommandOutput) -> CommandR
         return Ok(());
     }
 
+    let baseline = lock.unwrap_or_default();
+    let plan = RelockPlanner::new(&config, &project, &baseline)
+        .plan(std::sync::Arc::new(project.manifest().clone()))
+        .await?;
+
     if args.dry_run {
-        let baseline = lock.clone().unwrap_or_default();
-        let plan = RelockPlanner::new(&config, &project, &baseline)
-            .plan(std::sync::Arc::new(project.manifest().clone()))
-            .await?;
         tracing::debug!("dry run completed without writing lockfile or trust store");
         let changes = relock_change_count(&plan.outcome.stats);
         output.planned(
@@ -106,14 +108,14 @@ pub async fn lock(args: Args, config: Config, output: CommandOutput) -> CommandR
         return Ok(());
     }
 
-    let baseline = lock.clone().unwrap_or_default();
-    let outcome = RelockPlanner::new(&config, &project, &baseline)
-        .plan_and_enforce(
-            std::sync::Arc::new(project.manifest().clone()),
-            signer_change_mode(&config, args.trust_mode),
-            output,
-        )
-        .await?;
+    enforce_lockfile_signer_policy(
+        &plan.existing,
+        &plan.outcome.lockfile,
+        &plan.identities,
+        signer_change_mode(&config, args.trust_mode),
+        output,
+    )?;
+    let outcome = plan.outcome;
     if write_lockfile(
         &project,
         &outcome.lockfile,

--- a/src/commands/module/project.rs
+++ b/src/commands/module/project.rs
@@ -7,6 +7,7 @@ use anyhow::Context as _;
 use clap::Args as ClapArgs;
 use wdl_modules::Lockfile;
 use wdl_modules::Manifest;
+use wdl_modules::dependency::DependencyName;
 use wdl_modules::project::LockedLockfile;
 use wdl_modules::project::ModuleProject;
 
@@ -70,6 +71,25 @@ pub(super) fn load_lockfile(project: &Project) -> anyhow::Result<Option<Lockfile
         }
     }
     Ok(lockfile)
+}
+
+/// Parses dependency names and verifies that each one is declared.
+pub(super) fn validate_dependency_names(
+    project: &Project,
+    names: &[String],
+) -> anyhow::Result<Vec<DependencyName>> {
+    names
+        .iter()
+        .map(|raw| {
+            let name: DependencyName = raw
+                .parse()
+                .with_context(|| format!("invalid dependency name `{raw}`"))?;
+            if !project.manifest().dependencies.contains_key(&name) {
+                anyhow::bail!("dependency `{raw}` not found in `module.json`");
+            }
+            Ok(name)
+        })
+        .collect()
 }
 
 /// The `--locked` flag shared by commands that read `module-lock.json`.

--- a/src/commands/module/relock.rs
+++ b/src/commands/module/relock.rs
@@ -6,12 +6,16 @@ use wdl_modules::Lockfile;
 use wdl_modules::Manifest;
 use wdl_modules::Resolver as _;
 use wdl_modules::module::Module;
+use wdl_modules::project::ManifestDocument;
 use wdl_modules::resolver::lock::RelockOutcome;
 use wdl_modules::resolver::lock::SignerIdentityMap;
 use wdl_modules::resolver::lock::partial_relock;
 use wdl_modules::resolver::lock::signer_identity_map;
 
+use super::project::LockfileWrite;
 use super::project::Project;
+use super::project::WriteIntent;
+use super::project::write_lockfile;
 use super::resolver::ResolverEnvironment;
 use super::signer_policy::SignerChangeMode;
 use super::signer_policy::enforce_lockfile_signer_policy;
@@ -94,6 +98,42 @@ impl<'a> RelockPlanner<'a> {
             output,
         )?;
         Ok(plan.outcome)
+    }
+
+    /// Applies an edited manifest and, unless locking was disabled, first
+    /// prepares and approves its relock and then writes the resulting lockfile.
+    ///
+    /// Planning happens before either file is written so a failed or refused
+    /// relock leaves the project files untouched.
+    pub(super) async fn apply_manifest_edit(
+        &self,
+        document: &ManifestDocument,
+        no_lock: bool,
+        mode: SignerChangeMode,
+        output: CommandOutput,
+    ) -> anyhow::Result<Option<(RelockOutcome, LockfileWrite)>> {
+        let outcome = if no_lock {
+            None
+        } else {
+            Some(
+                self.plan_and_enforce(Arc::new(document.manifest().clone()), mode, output)
+                    .await?,
+            )
+        };
+
+        self.project
+            .write_manifest(document)
+            .map_err(anyhow::Error::from)?;
+        let Some(outcome) = outcome else {
+            return Ok(None);
+        };
+        let written = write_lockfile(
+            self.project,
+            &outcome.lockfile,
+            document.manifest(),
+            WriteIntent::Satisfy,
+        )?;
+        Ok(Some((outcome, written)))
     }
 }
 

--- a/src/commands/module/remove.rs
+++ b/src/commands/module/remove.rs
@@ -4,11 +4,9 @@ use clap::Parser;
 
 use super::project::Locator;
 use super::project::LockfileWrite;
-use super::project::WriteIntent;
 use super::project::discover;
 use super::project::load_lockfile;
 use super::project::trace_project;
-use super::project::write_lockfile;
 use super::relock::RelockPlanner;
 use super::signer_policy::TrustModeArg;
 use super::signer_policy::signer_change_mode;
@@ -56,42 +54,22 @@ pub async fn remove(args: Args, config: Config, output: CommandOutput) -> Comman
         return Err(anyhow::anyhow!("dependency `{}` not found", args.name).into());
     }
 
-    // Relock against the pending manifest before touching any files so a
-    // refused or failed relock leaves the project untouched.
-    let relock = if args.no_lock {
-        None
-    } else {
-        Some(
-            RelockPlanner::new(&config, &project, &baseline)
-                .plan_and_enforce(
-                    std::sync::Arc::new(document.manifest().clone()),
-                    signer_change_mode(&config, args.trust_mode),
-                    output,
-                )
-                .await?,
+    let relock = RelockPlanner::new(&config, &project, &baseline)
+        .apply_manifest_edit(
+            &document,
+            args.no_lock,
+            signer_change_mode(&config, args.trust_mode),
+            output,
         )
-    };
-
-    project
-        .write_manifest(&document)
-        .map_err(anyhow::Error::from)?;
-    let written = match relock.as_ref() {
-        Some(outcome) => Some(write_lockfile(
-            &project,
-            &outcome.lockfile,
-            document.manifest(),
-            WriteIntent::Satisfy,
-        )?),
-        None => None,
-    };
+        .await?;
     tracing::debug!(
         dependency = args.name,
         manifest = %project.manifest_path().display(),
         "removed dependency from manifest"
     );
 
-    if let Some(outcome) = relock {
-        if written == Some(LockfileWrite::Kept) {
+    if let Some((outcome, written)) = relock {
+        if written == LockfileWrite::Kept {
             tracing::debug!("kept the module lockfile another process had already written");
             output.completed(REMOVE, format!("`{}`", args.name));
             output.current("module lockfile is up to date");

--- a/src/commands/module/update.rs
+++ b/src/commands/module/update.rs
@@ -2,11 +2,9 @@
 
 use std::collections::BTreeSet;
 
-use anyhow::Context as _;
 use clap::Parser;
 use wdl_modules::Lockfile;
 use wdl_modules::Resolver as _;
-use wdl_modules::dependency::DependencyName;
 use wdl_modules::module::Module;
 use wdl_modules::resolver::lock::RelockOutcome;
 use wdl_modules::resolver::lock::RelockStats;
@@ -21,6 +19,7 @@ use super::project::WriteIntent;
 use super::project::discover;
 use super::project::load_lockfile;
 use super::project::trace_project;
+use super::project::validate_dependency_names;
 use super::project::write_lockfile;
 use super::resolver::ResolverEnvironment;
 use super::signer_policy::TrustModeArg;
@@ -60,18 +59,15 @@ pub async fn update(args: Args, config: Config, output: CommandOutput) -> Comman
         "starting `sprocket dev module update`"
     );
     let project = discover(&args.locator)?;
+    trace_project("module update", &project);
+    let existing = load_lockfile(&project)?.unwrap_or_default();
+    let plan = plan_update(&args, &config, &project, &existing).await?;
     if args.dry_run {
-        trace_project("module update", &project);
-        let existing = load_lockfile(&project)?.unwrap_or_default();
-        let plan = plan_update(&args, &config, &project, &existing).await?;
         tracing::debug!("dry run completed without writing lockfile");
         print_update_outcome(output, &plan.outcome.stats, true);
         return Ok(());
     }
 
-    trace_project("module update", &project);
-    let existing = load_lockfile(&project)?.unwrap_or_default();
-    let plan = plan_update(&args, &config, &project, &existing).await?;
     enforce_lockfile_signer_policy(
         &plan.existing,
         &plan.outcome.lockfile,
@@ -115,17 +111,7 @@ async fn plan_update(
     if args.names.is_empty() {
         names.extend(project.manifest().dependencies.keys().cloned());
     } else {
-        for raw in &args.names {
-            let name: DependencyName = raw
-                .parse()
-                .with_context(|| format!("invalid dependency name `{raw}`"))?;
-            if !project.manifest().dependencies.contains_key(&name) {
-                return Err(anyhow::anyhow!(
-                    "dependency `{raw}` not found in `module.json`"
-                ));
-            }
-            names.insert(name);
-        }
+        names.extend(validate_dependency_names(project, &args.names)?);
     }
     tracing::debug!(
         selected = names.len(),

--- a/src/commands/module/upgrade.rs
+++ b/src/commands/module/upgrade.rs
@@ -25,6 +25,7 @@ use super::project::WriteIntent;
 use super::project::discover;
 use super::project::load_lockfile;
 use super::project::trace_project;
+use super::project::validate_dependency_names;
 use super::project::write_lockfile;
 use super::resolver::ResolverEnvironment;
 use super::signer_policy::TrustModeArg;
@@ -66,17 +67,14 @@ pub async fn upgrade(args: Args, config: Config, output: CommandOutput) -> Comma
         "starting `sprocket dev module upgrade`"
     );
     let project = discover(&args.locator)?;
+    trace_project("module upgrade", &project);
+    let existing = load_lockfile(&project)?.unwrap_or_default();
+    let plan = plan_upgrade(&args, &config, &project, &existing).await?;
     if args.dry_run {
-        trace_project("module upgrade", &project);
-        let existing = load_lockfile(&project)?.unwrap_or_default();
-        let plan = plan_upgrade(&args, &config, &project, &existing).await?;
         print_upgrade_plan(output, plan);
         return Ok(());
     }
 
-    trace_project("module upgrade", &project);
-    let existing = load_lockfile(&project)?.unwrap_or_default();
-    let plan = plan_upgrade(&args, &config, &project, &existing).await?;
     let UpgradePlan::Changes(changes) = plan else {
         print_upgrade_plan(output, plan);
         return Ok(());
@@ -152,17 +150,7 @@ async fn plan_upgrade(
     if args.names.is_empty() {
         selected.extend(project.manifest().dependencies.keys().cloned());
     } else {
-        for raw in &args.names {
-            let name: DependencyName = raw
-                .parse()
-                .with_context(|| format!("invalid dependency name `{raw}`"))?;
-            if !project.manifest().dependencies.contains_key(&name) {
-                return Err(anyhow::anyhow!(
-                    "dependency `{raw}` not found in `module.json`"
-                ));
-            }
-            selected.push(name);
-        }
+        selected = validate_dependency_names(project, &args.names)?;
     }
     tracing::debug!(
         selected = selected.len(),

--- a/tests/module/add_remove.rs
+++ b/tests/module/add_remove.rs
@@ -537,6 +537,52 @@ fn remove_leaves_manifest_untouched_when_relock_fails() {
 }
 
 #[test]
+fn remove_no_lock_skips_resolution_and_preserves_lockfile() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().join("consumer");
+    fs::create_dir_all(&root).unwrap();
+    fs::write(
+        root.join("module.json"),
+        r#"{
+  "name": "consumer",
+  "license": "MIT",
+  "dependencies": {
+    "broken": { "path": "../missing" },
+    "drop": { "path": "../also-missing" }
+  }
+}
+"#,
+    )
+    .unwrap();
+    let lockfile_before = br#"{"version":1,"dependencies":{}}"#;
+    fs::write(root.join("module-lock.json"), lockfile_before).unwrap();
+
+    let output = sprocket(&["dev", "module", "remove", "drop", "--no-lock"])
+        .current_dir(&root)
+        .output()
+        .expect("failed to run sprocket dev module remove");
+    assert!(
+        output.status.success(),
+        "command failed {status}: {stderr}",
+        status = output.status,
+        stderr = String::from_utf8_lossy(&output.stderr)
+    );
+
+    let manifest = Manifest::parse(&fs::read(root.join("module.json")).unwrap()).unwrap();
+    assert!(
+        manifest
+            .dependencies
+            .contains_key(&"broken".parse().unwrap())
+    );
+    assert!(!manifest.dependencies.contains_key(&"drop".parse().unwrap()));
+    assert_eq!(
+        fs::read(root.join("module-lock.json")).unwrap(),
+        lockfile_before,
+        "`--no-lock` must leave the existing lockfile byte-for-byte unchanged"
+    );
+}
+
+#[test]
 fn add_new_signer_matrix_respects_trust_mode() {
     let cases = [
         (CliTrustMode::Confirm, false, true),

--- a/tests/module/run.rs
+++ b/tests/module/run.rs
@@ -8,6 +8,114 @@ use wdl_modules::dependency::DependencyName;
 use crate::fixtures::*;
 
 #[test]
+fn run_ignores_excluded_dependency_harness_with_escaping_import() {
+    let fixture = GitFixture::without_version_tags();
+    let module_root = fixture.repo_dir.join("tasks");
+    fs::write(
+        module_root.join("module.json"),
+        r#"{
+  "name": "tasks",
+  "license": "MIT",
+  "entrypoint": "index.wdl",
+  "exclude": ["testrun.wdl"]
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        module_root.join("testrun.wdl"),
+        "version 1.3\nimport \"../outside.wdl\"\n",
+    )
+    .unwrap();
+    commit_without_tags(
+        &git2::Repository::open(&fixture.repo_dir).unwrap(),
+        "add excluded test harness",
+    );
+
+    let repo_url = fixture.repo_url();
+    let default_branch = fixture.default_branch();
+    let consumer = fixture.write_consumer(
+        "consumer-run-excluded-harness",
+        &format!(
+            r#"    "tasks": {{ "git": "{repo_url}", "branch": "{default_branch}", "path": "tasks" }}"#
+        ),
+    );
+    fs::write(
+        consumer.join("index.wdl"),
+        "version 1.4\nimport tasks\nworkflow wf {\n  output {\n    String ok = \"ok\"\n  }\n}\n",
+    )
+    .unwrap();
+    let cache_path = serde_json::to_string(&fixture.cache_path().to_string_lossy()).unwrap();
+    fs::write(
+        fixture.config_path(),
+        format!(
+            "[common.wdl.feature_flags]\nwdl_1_4 = true\n\n[modules]\ncache_path = \
+             {cache_path}\nallowed_schemes = [\"file\", \"https\", \"ssh\"]\ndenied_hosts = \
+             []\n\n[run.backends.default]\ntype = \"local\"\n"
+        ),
+    )
+    .unwrap();
+
+    let run = sprocket_with_config(fixture.config_path(), &["run", "."])
+        .current_dir(&consumer)
+        .output()
+        .expect("failed to run sprocket run");
+    assert!(
+        run.status.success(),
+        "command failed {status}: {stderr}",
+        status = run.status,
+        stderr = String::from_utf8_lossy(&run.stderr)
+    );
+}
+
+#[test]
+fn run_allows_excluded_local_harness_to_import_sibling() {
+    let fixture = ModuleFixture::with_local_dep();
+    let config = fixture.dir.path().join("sprocket.toml");
+    fs::write(&config, "[run.backends.default]\ntype = \"local\"\n").unwrap();
+    fs::write(
+        fixture.dep().join("index.wdl"),
+        "version 1.3\nstruct Marker { String value }\n",
+    )
+    .unwrap();
+    fs::write(
+        fixture.consumer().join("module.json"),
+        r#"{
+  "name": "consumer",
+  "license": "MIT",
+  "entrypoint": "index.wdl",
+  "exclude": ["testrun.wdl"]
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        fixture.consumer().join("testrun.wdl"),
+        r#"version 1.3
+import "../dep/index.wdl" as library
+
+workflow harness {
+  output {
+    String ok = "ok"
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let run = sprocket_with_config(&config, &["run", "testrun.wdl"])
+        .current_dir(fixture.consumer())
+        .output()
+        .expect("failed to run sprocket run");
+    assert!(
+        run.status.success(),
+        "command failed {status}: {stderr}",
+        status = run.status,
+        stderr = String::from_utf8_lossy(&run.stderr)
+    );
+}
+
+#[test]
 fn run_fails_when_locked_signer_key_is_removed_from_trust_store() {
     let (fixture, _public_key) = GitFixture::signed_without_version_tags();
     let home = isolated_home(fixture.dir.path(), "home-run-revoked");

--- a/tests/module/sign_verify.rs
+++ b/tests/module/sign_verify.rs
@@ -425,6 +425,52 @@ fn sign_writes_verifiable_signature() {
 }
 
 #[test]
+fn verify_signature_ignores_edits_to_excluded_files() {
+    let fixture = ModuleFixture::with_local_dep();
+    fs::write(
+        fixture.consumer().join("module.json"),
+        r#"{
+  "name": "consumer",
+  "license": "MIT",
+  "entrypoint": "index.wdl",
+  "exclude": ["testrun.wdl"]
+}
+"#,
+    )
+    .unwrap();
+    let harness = fixture.consumer().join("testrun.wdl");
+    fs::write(&harness, "version 1.3\nworkflow before {}\n").unwrap();
+    let key_path = fixture.dir.path().join("id_ed25519");
+    fs::write(&key_path, generate_openssh_ed25519_private_key()).unwrap();
+
+    let key_path_arg = key_path.to_string_lossy().into_owned();
+    let sign = sprocket(&["dev", "module", "sign", "--key", &key_path_arg])
+        .current_dir(fixture.consumer())
+        .output()
+        .expect("failed to run sprocket dev module sign");
+    assert!(
+        sign.status.success(),
+        "command failed {status}: {stderr}",
+        status = sign.status,
+        stderr = String::from_utf8_lossy(&sign.stderr)
+    );
+
+    fs::write(&harness, "version 1.3\nworkflow after {}\n").unwrap();
+
+    let verify = sprocket(&["dev", "module", "verify", "signature"])
+        .current_dir(fixture.consumer())
+        .output()
+        .expect("failed to run sprocket dev module verify signature");
+    assert!(
+        verify.status.success(),
+        "command failed {status}: {stderr}",
+        status = verify.status,
+        stderr = String::from_utf8_lossy(&verify.stderr)
+    );
+    assert!(String::from_utf8_lossy(&verify.stdout).contains("Verified module signature"));
+}
+
+#[test]
 fn sign_preserves_unstructured_public_key_comment() -> anyhow::Result<()> {
     let fixture = ModuleFixture::with_local_dep();
     let key_path = fixture.dir.path().join("id_ed25519");


### PR DESCRIPTION
Module test harnesses with imports outside the module root prevented dependency resolution, even when listed in `exclude`. I redefined `exclude` as module-content exclusion in [the module specification proposal](https://github.com/openwdl/wdl/pull/765) and applied the same policy to validation, hashing, signing, and imports in Sprocket. Excluded harnesses can still run directly from a local checkout.

Closes #1187.

Before submitting this PR, please make sure:

For external contributors:

N/A: this is an internal contribution.

- [ ] You have read the [contributing guide](https://github.com/stjude-rust-labs/sprocket/blob/main/CONTRIBUTING.md) in its entirety.
- [ ] You have not used AI on any parts of this pull request.
- [ ] You have added a few sentences describing the PR here.
- [ ] Your code builds clean without any errors or warnings.

For all contributors:

- [x] You have added tests (when appropriate).
- [x] You have added an entry in the CHANGELOG (when appropriate).
- [x] You have updated the README or other documentation to account for these changes (when appropriate).
- [ ] You have made a PR to the `next` branch in the [sprocket.bio repository](https://github.com/stjude-rust-labs/sprocket.bio) (when appropriate).

For PRs containing lint rule changes:

N/A.

- [ ] You have updated any and all effected entries within `RULES.md`.
- [ ] You have added a test case in `crates/wdl-lint/tests/lints` that covers every
      possible diagnostic emitted for the rule within the file where the rule
      is implemented.
